### PR TITLE
Initialize data_ in value_base default constructor

### DIFF
--- a/include/boost/unordered/detail/table.hpp
+++ b/include/boost/unordered/detail/table.hpp
@@ -59,6 +59,10 @@ namespace boost { namespace unordered { namespace detail {
             sizeof(value_type),
             boost::alignment_of<value_type>::value>::type data_;
 
+        value_base() :
+            data_()
+        {}
+
         void* address() {
             return this;
         }


### PR DESCRIPTION
This means data_ should get initialized in the default constructor for boost::unordered::detail::unique_node (and any other inheritors), as this constructor will be called there.

This uninitialized data member was reported by Coverity (CID 49445), which unfortunately does not seem to have any convenient way to publicly, globally address issues.
