### PR TITLE
Remove template patameters from friend declarations in interator.

### DIFF
--- a/include/boost/unordered/detail/buckets.hpp
+++ b/include/boost/unordered/detail/buckets.hpp
@@ -192,11 +192,11 @@ namespace boost { namespace unordered { namespace iterator_detail {
             typename Node::value_type&>
     {
 #if !defined(BOOST_NO_MEMBER_TEMPLATE_FRIENDS)
-        template <typename, typename>
+        template <typename>
         friend struct boost::unordered::iterator_detail::c_iterator;
         template <typename, typename>
         friend struct boost::unordered::iterator_detail::l_iterator;
-        template <typename, typename, typename>
+        template <typename, typename>
         friend struct boost::unordered::iterator_detail::cl_iterator;
         template <typename>
         friend struct boost::unordered::detail::table;


### PR DESCRIPTION
This PR fixes Unordered broken in commit https://github.com/boostorg/unordered/commit/b4795f414d69581a0fedf268108582a3010a9507
