### PR TITLE
Bounds-check after arithmetic is complete

### DIFF
--- a/include/boost/unordered/detail/table.hpp
+++ b/include/boost/unordered/detail/table.hpp
@@ -343,7 +343,7 @@ namespace boost { namespace unordered { namespace detail {
             return policy::new_bucket_count(
                 boost::unordered::detail::double_to_size(floor(
                     static_cast<double>(size) /
-                    static_cast<double>(mlf_))) + 1);
+                    static_cast<double>(mlf_)) + 1));
         }
 
         ////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
double_to_size can return std::numeric_limits<size_t>max(), so we cannot add 1 to the return value of double_to_size. That addition should be done while still working with a double, as can be seen being done on line 850 of this file.
This was uncovered by Coverity, and addresses Coverity issues CID13443 and CID12664
