### PR TITLE
Inheriting std::iterator is deprecated in c++17.

### DIFF
--- a/include/boost/unordered/detail/implementation.hpp
+++ b/include/boost/unordered/detail/implementation.hpp
@@ -2099,9 +2099,6 @@ namespace boost {
 
       template <typename Node>
       struct l_iterator
-        : public std::iterator<std::forward_iterator_tag,
-            typename Node::value_type, std::ptrdiff_t,
-            typename Node::value_type*, typename Node::value_type&>
       {
 #if !defined(BOOST_NO_MEMBER_TEMPLATE_FRIENDS)
         template <typename Node2>
@@ -2116,6 +2113,10 @@ namespace boost {
 
       public:
         typedef typename Node::value_type value_type;
+        typedef value_type* pointer;
+        typedef value_type& reference;
+        typedef std::ptrdiff_t difference_type;
+        typedef std::forward_iterator_tag iterator_category;
 
         l_iterator() BOOST_NOEXCEPT : ptr_() {}
 
@@ -2158,9 +2159,6 @@ namespace boost {
 
       template <typename Node>
       struct cl_iterator
-        : public std::iterator<std::forward_iterator_tag,
-            typename Node::value_type, std::ptrdiff_t,
-            typename Node::value_type const*, typename Node::value_type const&>
       {
         friend struct boost::unordered::iterator_detail::l_iterator<Node>;
 
@@ -2172,6 +2170,10 @@ namespace boost {
 
       public:
         typedef typename Node::value_type value_type;
+        typedef value_type const* pointer;
+        typedef value_type const& reference;
+        typedef std::ptrdiff_t difference_type;
+        typedef std::forward_iterator_tag iterator_category;
 
         cl_iterator() BOOST_NOEXCEPT : ptr_() {}
 
@@ -2224,9 +2226,6 @@ namespace boost {
 
       template <typename Node>
       struct iterator
-        : public std::iterator<std::forward_iterator_tag,
-            typename Node::value_type, std::ptrdiff_t,
-            typename Node::value_type*, typename Node::value_type&>
       {
 #if !defined(BOOST_NO_MEMBER_TEMPLATE_FRIENDS)
         template <typename>
@@ -2240,6 +2239,10 @@ namespace boost {
 
       public:
         typedef typename Node::value_type value_type;
+        typedef value_type* pointer;
+        typedef value_type& reference;
+        typedef std::ptrdiff_t difference_type;
+        typedef std::forward_iterator_tag iterator_category;
 
         iterator() BOOST_NOEXCEPT : node_() {}
 
@@ -2278,9 +2281,6 @@ namespace boost {
 
       template <typename Node>
       struct c_iterator
-        : public std::iterator<std::forward_iterator_tag,
-            typename Node::value_type, std::ptrdiff_t,
-            typename Node::value_type const*, typename Node::value_type const&>
       {
         friend struct boost::unordered::iterator_detail::iterator<Node>;
 
@@ -2295,6 +2295,10 @@ namespace boost {
 
       public:
         typedef typename Node::value_type value_type;
+        typedef value_type const* pointer;
+        typedef value_type const& reference;
+        typedef std::ptrdiff_t difference_type;
+        typedef std::forward_iterator_tag iterator_category;
 
         c_iterator() BOOST_NOEXCEPT : node_() {}
 

--- a/test/helpers/input_iterator.hpp
+++ b/test/helpers/input_iterator.hpp
@@ -26,14 +26,14 @@ namespace test {
 
   template <class Iterator>
   struct input_iterator_adaptor
-    : public std::iterator<std::input_iterator_tag,
-        BOOST_DEDUCED_TYPENAME std::iterator_traits<Iterator>::value_type,
-        std::ptrdiff_t,
-        BOOST_DEDUCED_TYPENAME std::iterator_traits<Iterator>::pointer,
-        proxy<Iterator> >
   {
     typedef BOOST_DEDUCED_TYPENAME std::iterator_traits<Iterator>::value_type
       value_type;
+    typedef BOOST_DEDUCED_TYPENAME std::iterator_traits<Iterator>::pointer
+      pointer;
+    typedef proxy<Iterator> reference;
+    typedef std::ptrdiff_t difference_type;
+    typedef std::input_iterator_tag iterator_category;
 
     input_iterator_adaptor() : base_() {}
     explicit input_iterator_adaptor(Iterator& it) : base_(&it) {}
@@ -67,17 +67,16 @@ namespace test {
 
   template <class Iterator>
   struct copy_iterator_adaptor
-    : public std::iterator<BOOST_DEDUCED_TYPENAME
-                             std::iterator_traits<Iterator>::iterator_category,
-        BOOST_DEDUCED_TYPENAME std::iterator_traits<Iterator>::value_type,
-        BOOST_DEDUCED_TYPENAME std::iterator_traits<Iterator>::difference_type,
-        BOOST_DEDUCED_TYPENAME std::iterator_traits<Iterator>::pointer,
-        proxy<Iterator> >
   {
     typedef BOOST_DEDUCED_TYPENAME std::iterator_traits<Iterator>::value_type
       value_type;
     typedef BOOST_DEDUCED_TYPENAME
       std::iterator_traits<Iterator>::difference_type difference_type;
+    typedef BOOST_DEDUCED_TYPENAME
+      std::iterator_traits<Iterator>::iterator_category iterator_category;
+    typedef BOOST_DEDUCED_TYPENAME std::iterator_traits<Iterator>::pointer
+      pointer;
+    typedef proxy<Iterator> reference;
 
     copy_iterator_adaptor() : base_() {}
     explicit copy_iterator_adaptor(Iterator const& it) : base_(it) {}

--- a/test/helpers/list.hpp
+++ b/test/helpers/list.hpp
@@ -83,7 +83,6 @@ namespace test {
 
     template <typename T>
     class list_iterator
-      : public std::iterator<std::forward_iterator_tag, T, int, T*, T&>
     {
       friend class list_const_iterator<T>;
       friend class test::list<T>;
@@ -93,6 +92,12 @@ namespace test {
       node* ptr_;
 
     public:
+      typedef T value_type;
+      typedef T* pointer;
+      typedef T& reference;
+      typedef int difference_type;
+      typedef std::forward_iterator_tag iterator_category;
+
       list_iterator() : ptr_(0) {}
       explicit list_iterator(node* x) : ptr_(x) {}
 
@@ -114,8 +119,7 @@ namespace test {
     };
 
     template <typename T>
-    class list_const_iterator : public std::iterator<std::forward_iterator_tag,
-                                  T, int, T const*, T const&>
+    class list_const_iterator
     {
       friend class list_iterator<T>;
       friend class test::list<T>;
@@ -126,6 +130,12 @@ namespace test {
       node* ptr_;
 
     public:
+      typedef T value_type;
+      typedef T const* pointer;
+      typedef T const& reference;
+      typedef int difference_type;
+      typedef std::forward_iterator_tag iterator_category;
+
       list_const_iterator() : ptr_(0) {}
       list_const_iterator(list_iterator<T> const& x) : ptr_(x.ptr_) {}
 


### PR DESCRIPTION
Therefore get rid of all of that and replace inheritance by lifting std::iterator's members into the derived class.

Signed-off-by: Daniela Engert <dani@ngrt.de>