### PR TITLE
Changes for Embarcadero C++ clang-based compilers, targeting Boost 1.74. Change __BORLANDC__ to BOOST_BORLANDC and __CODEGEARC__ to BOOST_CODE…

### DIFF
--- a/include/boost/unordered/unordered_map.hpp
+++ b/include/boost/unordered/unordered_map.hpp
@@ -822,7 +822,7 @@ namespace boost {
       void rehash(size_type);
       void reserve(size_type);
 
-#if !BOOST_WORKAROUND(__BORLANDC__, < 0x0582)
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, < 0x0582)
       friend bool operator==
         <K, T, H, P, A>(unordered_map const&, unordered_map const&);
       friend bool operator!=
@@ -1426,7 +1426,7 @@ namespace boost {
       void rehash(size_type);
       void reserve(size_type);
 
-#if !BOOST_WORKAROUND(__BORLANDC__, < 0x0582)
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, < 0x0582)
       friend bool operator==
         <K, T, H, P, A>(unordered_multimap const&, unordered_multimap const&);
       friend bool operator!=
@@ -1941,7 +1941,7 @@ namespace boost {
     inline bool operator==(unordered_map<K, T, H, P, A> const& m1,
       unordered_map<K, T, H, P, A> const& m2)
     {
-#if BOOST_WORKAROUND(__CODEGEARC__, BOOST_TESTED_AT(0x0613))
+#if BOOST_WORKAROUND(BOOST_CODEGEARC, BOOST_TESTED_AT(0x0613))
       struct dummy
       {
         unordered_map<K, T, H, P, A> x;
@@ -1954,7 +1954,7 @@ namespace boost {
     inline bool operator!=(unordered_map<K, T, H, P, A> const& m1,
       unordered_map<K, T, H, P, A> const& m2)
     {
-#if BOOST_WORKAROUND(__CODEGEARC__, BOOST_TESTED_AT(0x0613))
+#if BOOST_WORKAROUND(BOOST_CODEGEARC, BOOST_TESTED_AT(0x0613))
       struct dummy
       {
         unordered_map<K, T, H, P, A> x;
@@ -1968,7 +1968,7 @@ namespace boost {
       unordered_map<K, T, H, P, A>& m1, unordered_map<K, T, H, P, A>& m2)
       BOOST_NOEXCEPT_IF(BOOST_NOEXCEPT_EXPR(m1.swap(m2)))
     {
-#if BOOST_WORKAROUND(__CODEGEARC__, BOOST_TESTED_AT(0x0613))
+#if BOOST_WORKAROUND(BOOST_CODEGEARC, BOOST_TESTED_AT(0x0613))
       struct dummy
       {
         unordered_map<K, T, H, P, A> x;
@@ -2386,7 +2386,7 @@ namespace boost {
     inline bool operator==(unordered_multimap<K, T, H, P, A> const& m1,
       unordered_multimap<K, T, H, P, A> const& m2)
     {
-#if BOOST_WORKAROUND(__CODEGEARC__, BOOST_TESTED_AT(0x0613))
+#if BOOST_WORKAROUND(BOOST_CODEGEARC, BOOST_TESTED_AT(0x0613))
       struct dummy
       {
         unordered_multimap<K, T, H, P, A> x;
@@ -2399,7 +2399,7 @@ namespace boost {
     inline bool operator!=(unordered_multimap<K, T, H, P, A> const& m1,
       unordered_multimap<K, T, H, P, A> const& m2)
     {
-#if BOOST_WORKAROUND(__CODEGEARC__, BOOST_TESTED_AT(0x0613))
+#if BOOST_WORKAROUND(BOOST_CODEGEARC, BOOST_TESTED_AT(0x0613))
       struct dummy
       {
         unordered_multimap<K, T, H, P, A> x;
@@ -2413,7 +2413,7 @@ namespace boost {
       unordered_multimap<K, T, H, P, A>& m2)
       BOOST_NOEXCEPT_IF(BOOST_NOEXCEPT_EXPR(m1.swap(m2)))
     {
-#if BOOST_WORKAROUND(__CODEGEARC__, BOOST_TESTED_AT(0x0613))
+#if BOOST_WORKAROUND(BOOST_CODEGEARC, BOOST_TESTED_AT(0x0613))
       struct dummy
       {
         unordered_multimap<K, T, H, P, A> x;

--- a/include/boost/unordered/unordered_set.hpp
+++ b/include/boost/unordered/unordered_set.hpp
@@ -536,7 +536,7 @@ namespace boost {
       void rehash(size_type);
       void reserve(size_type);
 
-#if !BOOST_WORKAROUND(__BORLANDC__, < 0x0582)
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, < 0x0582)
       friend bool operator==
         <T, H, P, A>(unordered_set const&, unordered_set const&);
       friend bool operator!=
@@ -1083,7 +1083,7 @@ namespace boost {
       void rehash(size_type);
       void reserve(size_type);
 
-#if !BOOST_WORKAROUND(__BORLANDC__, < 0x0582)
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, < 0x0582)
       friend bool operator==
         <T, H, P, A>(unordered_multiset const&, unordered_multiset const&);
       friend bool operator!=
@@ -1497,7 +1497,7 @@ namespace boost {
     inline bool operator==(
       unordered_set<T, H, P, A> const& m1, unordered_set<T, H, P, A> const& m2)
     {
-#if BOOST_WORKAROUND(__CODEGEARC__, BOOST_TESTED_AT(0x0613))
+#if BOOST_WORKAROUND(BOOST_CODEGEARC, BOOST_TESTED_AT(0x0613))
       struct dummy
       {
         unordered_set<T, H, P, A> x;
@@ -1510,7 +1510,7 @@ namespace boost {
     inline bool operator!=(
       unordered_set<T, H, P, A> const& m1, unordered_set<T, H, P, A> const& m2)
     {
-#if BOOST_WORKAROUND(__CODEGEARC__, BOOST_TESTED_AT(0x0613))
+#if BOOST_WORKAROUND(BOOST_CODEGEARC, BOOST_TESTED_AT(0x0613))
       struct dummy
       {
         unordered_set<T, H, P, A> x;
@@ -1524,7 +1524,7 @@ namespace boost {
       unordered_set<T, H, P, A>& m1, unordered_set<T, H, P, A>& m2)
       BOOST_NOEXCEPT_IF(BOOST_NOEXCEPT_EXPR(m1.swap(m2)))
     {
-#if BOOST_WORKAROUND(__CODEGEARC__, BOOST_TESTED_AT(0x0613))
+#if BOOST_WORKAROUND(BOOST_CODEGEARC, BOOST_TESTED_AT(0x0613))
       struct dummy
       {
         unordered_set<T, H, P, A> x;
@@ -1900,7 +1900,7 @@ namespace boost {
     inline bool operator==(unordered_multiset<T, H, P, A> const& m1,
       unordered_multiset<T, H, P, A> const& m2)
     {
-#if BOOST_WORKAROUND(__CODEGEARC__, BOOST_TESTED_AT(0x0613))
+#if BOOST_WORKAROUND(BOOST_CODEGEARC, BOOST_TESTED_AT(0x0613))
       struct dummy
       {
         unordered_multiset<T, H, P, A> x;
@@ -1913,7 +1913,7 @@ namespace boost {
     inline bool operator!=(unordered_multiset<T, H, P, A> const& m1,
       unordered_multiset<T, H, P, A> const& m2)
     {
-#if BOOST_WORKAROUND(__CODEGEARC__, BOOST_TESTED_AT(0x0613))
+#if BOOST_WORKAROUND(BOOST_CODEGEARC, BOOST_TESTED_AT(0x0613))
       struct dummy
       {
         unordered_multiset<T, H, P, A> x;
@@ -1927,7 +1927,7 @@ namespace boost {
       unordered_multiset<T, H, P, A>& m1, unordered_multiset<T, H, P, A>& m2)
       BOOST_NOEXCEPT_IF(BOOST_NOEXCEPT_EXPR(m1.swap(m2)))
     {
-#if BOOST_WORKAROUND(__CODEGEARC__, BOOST_TESTED_AT(0x0613))
+#if BOOST_WORKAROUND(BOOST_CODEGEARC, BOOST_TESTED_AT(0x0613))
       struct dummy
       {
         unordered_multiset<T, H, P, A> x;

--- a/test/unordered/link_test_2.cpp
+++ b/test/unordered/link_test_2.cpp
@@ -13,7 +13,7 @@
 void foo(boost::unordered_set<int>& x1, boost::unordered_map<int, int>& x2,
   boost::unordered_multiset<int>& x3, boost::unordered_multimap<int, int>& x4)
 {
-#if BOOST_WORKAROUND(__CODEGEARC__, BOOST_TESTED_AT(0x0613))
+#if BOOST_WORKAROUND(BOOST_CODEGEARC, BOOST_TESTED_AT(0x0613))
   struct dummy
   {
     boost::unordered_set<int> x1;


### PR DESCRIPTION
…GEARC, which are3defined in Boost config for the Embarcadero non-clang-based compilers.