### PR TITLE
fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,6 @@ matrix:
             CXXSTD=03
 
 before_install:
-    - sudo apt-get install python3
-    - if [ -n $enable_coverage ]; then pip install --user cpp-coveralls; fi
-    - if [ -n $enable_coverage ]; then pip install --user cpp-coveralls; fi
 
 before_script:
     - export BOOST_VERSION=1.67.0
@@ -81,7 +78,6 @@ before_script:
     - ./b2 install --prefix=$HOME/opt
 
 after_success:
-    if [ -n $enable_coverage ]; then coveralls -r ${TRAVIS_BUILD_DIR} -b ${TRAVIS_BUILD_DIR}/test --gcov-options '\-lp' --include include/boost/unordered/ ; fi
 
 script:
     - cd ${TRAVIS_BUILD_DIR}/test

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
             user_config="using clang : : clang++ -fsanitize=address ;"
             CXXSTD=11,17
         # sanitized=address not available for 32-bit clang on travis
-        # prune source-location since log-output got to big and led to error
+        # prune source-location since log-output got too big and led to error
       - compiler: clang
         env: |
             label="clang 32 bit";

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ matrix:
         env: |
             label="gcc C++03/11";
             user_config="using gcc : : g++-4.8 --coverage -fsanitize=address ;"
-            enable_coverage=1
             CXXSTD=03,11
       - compiler: gcc
         env: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,14 +32,17 @@ matrix:
             label="clang C++11/17";
             user_config="using clang : : clang++ -fsanitize=address ;"
             CXXSTD=11,17
-        # sanitized=address not available for 32-bit clang on travis.
+        # sanitized=address not available for 32-bit clang on travis
+        # prune source-location since log-output got to big and led to error
       - compiler: clang
         env: |
             label="clang 32 bit";
-            user_config="using clang : : clang++ -m32 ;"
+            user_config="using clang : : clang++ -m32 -fno-show-column -fno-show-source-location ;"
             CXXSTD=03
 
 before_install:
+    - sudo apt-get install python3
+    - if [ -n $enable_coverage ]; then pip install --user cpp-coveralls; fi
     - if [ -n $enable_coverage ]; then pip install --user cpp-coveralls; fi
 
 before_script:


### PR DESCRIPTION
pruned source-location from 32-bit C++03 build
32-bit C++03 build produces a lot of warnings which led to a too big log output and the test failed
added python 3