### PR TITLE
Fix bug in `has_construct` by using `std::declval`

### DIFF
--- a/include/boost/unordered/detail/implementation.hpp
+++ b/include/boost/unordered/detail/implementation.hpp
@@ -1145,7 +1145,7 @@ namespace boost {
       template <typename T, typename ValueType, typename... Args>
       BOOST_UNORDERED_HAS_FUNCTION(construct, U,
         (boost::unordered::detail::make<ValueType*>(),
-          boost::unordered::detail::make<Args const>()...),
+          std::declval<Args>()...),
         2);
 
 #else


### PR DESCRIPTION
`boost::unordered::detail::make<Args const>()` has the fatal flaw that this creates a `Args const&` which can invoke implicitly deleted copy constructors such as when `Args` is `std::tuple<int&&>` as is the case of some of the `rvalue(k)`-style tests.