### PR TITLE
Fix C++17 deprecation warning from std::allocator::is_always_equal

### DIFF
--- a/include/boost/unordered/detail/implementation.hpp
+++ b/include/boost/unordered/detail/implementation.hpp
@@ -13,6 +13,7 @@
 #endif
 
 #include <boost/assert.hpp>
+#include <boost/core/allocator_access.hpp>
 #include <boost/core/no_exceptions_support.hpp>
 #include <boost/core/pointer_traits.hpp>
 #include <boost/detail/select_type.hpp>
@@ -1472,8 +1473,8 @@ namespace boost {
         // it where possible.
         typedef BOOST_UNORDERED_DEFAULT_TYPE(std::allocator_traits<Alloc>,
           is_always_equal,
-          BOOST_UNORDERED_DEFAULT_TYPE(Alloc, is_always_equal,
-            typename boost::is_empty<Alloc>::type)) is_always_equal;
+          BOOST_UNORDERED_DEFAULT_TYPE(boost::allocator_is_always_equal<Alloc>, is_always_equal,
+              typename boost::is_empty<Alloc>::type)) is_always_equal;
       };
 
       template <typename Alloc, typename T> struct rebind_wrap

--- a/include/boost/unordered/detail/implementation.hpp
+++ b/include/boost/unordered/detail/implementation.hpp
@@ -1473,7 +1473,8 @@ namespace boost {
         // it where possible.
         typedef BOOST_UNORDERED_DEFAULT_TYPE(std::allocator_traits<Alloc>,
           is_always_equal,
-          BOOST_UNORDERED_DEFAULT_TYPE(boost::allocator_is_always_equal<Alloc>, is_always_equal,
+          BOOST_UNORDERED_DEFAULT_TYPE(typename boost::allocator_is_always_equal<
+            Alloc>::type, is_always_equal,
               typename boost::is_empty<Alloc>::type)) is_always_equal;
       };
 


### PR DESCRIPTION
When compiling with support for C++17 the following deprecation warning is encountered
```
C:\usr\local\include\boost-1_77\boost/unordered/detail/implementation.hpp(1452,7): warning C4996: 'std::allocator<std::pair<const std::basic_string<char,std::char_traits<char>,std::allocator<char>>,std::basic_string<char,std::char_traits<char>,std::allocator<char>>>>::is_always_equal': warning STL4010: Various members of std::allocator are deprecated in C++17. Use std::allocator_traits instead of accessing these members directly. You can define _SILENCE_CXX17_OLD_ALLOCATOR_MEMBERS_DEPRECATION_WARNING or _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS to acknowledge that you have received this warning.
```

Following the lead suggested here
https://groups.google.com/g/boost-developers-archive/c/3MOWuQgEEy4/m/boIwsJsdBAAJ
and using `boost::allocator_is_always_equal` from
`<boost/core/allocator_access.hpp>` does fix the source of the deprecation warning.
