### PR TITLE
Implement heterogeneous `equal_range()` for `unordered_map`

### DIFF
--- a/include/boost/unordered/unordered_map.hpp
+++ b/include/boost/unordered/unordered_map.hpp
@@ -799,6 +799,34 @@ namespace boost {
       std::pair<const_iterator, const_iterator> equal_range(
         const key_type&) const;
 
+      template <class Key>
+      typename boost::enable_if_c<detail::is_transparent<Key, H>::value &&
+                                    detail::is_transparent<Key, P>::value,
+        std::pair<iterator, iterator> >::type
+      equal_range(const Key& key)
+      {
+        node_pointer p = table_.find_node_impl(
+          table::policy::apply_hash(this->hash_function(), key), key,
+          this->key_eq());
+
+        return std::make_pair(
+          iterator(p), iterator(p ? table::next_node(p) : p));
+      }
+
+      template <class Key>
+      typename boost::enable_if_c<detail::is_transparent<Key, H>::value &&
+                                    detail::is_transparent<Key, P>::value,
+        std::pair<const_iterator, const_iterator> >::type
+      equal_range(const Key& key) const
+      {
+        node_pointer p = table_.find_node_impl(
+          table::policy::apply_hash(this->hash_function(), key), key,
+          this->key_eq());
+
+        return std::make_pair(
+          const_iterator(p), const_iterator(p ? table::next_node(p) : p));
+      }
+
       mapped_type& operator[](const key_type&);
       mapped_type& operator[](BOOST_RV_REF(key_type));
       mapped_type& at(const key_type&);

--- a/test/unordered/transparent_tests.cpp
+++ b/test/unordered/transparent_tests.cpp
@@ -279,8 +279,10 @@ template <class UnorderedMap> void test_transparent_equal_range()
   UnorderedMap unordered_map;
 
   unordered_map[key(0)] = 1337;
+  unordered_map[key(1)] = 1338;
+  unordered_map[key(2)] = 1339;
 
-  int const expected_key_count = 2;
+  int const expected_key_count = 6;
 
   BOOST_TEST(key::count_ == expected_key_count);
 
@@ -301,8 +303,10 @@ template <class UnorderedMap> void test_transparent_equal_range()
 
     BOOST_TEST(begin != end);
     BOOST_TEST(begin != map.end());
+    BOOST_TEST(std::distance(begin, end) == 1);
 
     value_type const& val = *begin;
+    BOOST_TEST(val.first.x_ == 0);
     BOOST_TEST(val.second == 1337);
 
     iters = map.equal_range(1337);
@@ -312,6 +316,7 @@ template <class UnorderedMap> void test_transparent_equal_range()
 
     BOOST_TEST(begin == end);
     BOOST_TEST(begin == map.end());
+    BOOST_TEST(std::distance(begin, end) == 0);
 
     BOOST_TEST(key::count_ == expected_key_count);
   }
@@ -329,8 +334,10 @@ template <class UnorderedMap> void test_transparent_equal_range()
 
     BOOST_TEST(begin != end);
     BOOST_TEST(begin != map.end());
+    BOOST_TEST(std::distance(begin, end) == 1);
 
     value_type const& val = *begin;
+    BOOST_TEST(val.first.x_ == 0);
     BOOST_TEST(val.second == 1337);
 
     iters = map.equal_range(1337);
@@ -340,6 +347,7 @@ template <class UnorderedMap> void test_transparent_equal_range()
 
     BOOST_TEST(begin == end);
     BOOST_TEST(begin == map.end());
+    BOOST_TEST(std::distance(begin, end) == 0);
 
     BOOST_TEST(key::count_ == expected_key_count);
   }
@@ -352,8 +360,10 @@ template <class UnorderedMap> void test_non_transparent_equal_range()
   UnorderedMap unordered_map;
 
   unordered_map[key(0)] = 1337;
+  unordered_map[key(1)] = 1338;
+  unordered_map[key(2)] = 1339;
 
-  int key_count = 2;
+  int key_count = 6;
 
   BOOST_TEST(key::count_ == key_count);
 
@@ -374,8 +384,10 @@ template <class UnorderedMap> void test_non_transparent_equal_range()
 
     BOOST_TEST(begin != end);
     BOOST_TEST(begin != map.end());
+    BOOST_TEST(std::distance(begin, end) == 1);
 
     value_type const& val = *begin;
+    BOOST_TEST(val.first.x_ == 0);
     BOOST_TEST(val.second == 1337);
 
     iters = map.equal_range(1337);
@@ -385,6 +397,7 @@ template <class UnorderedMap> void test_non_transparent_equal_range()
 
     BOOST_TEST(begin == end);
     BOOST_TEST(begin == map.end());
+    BOOST_TEST(std::distance(begin, end) == 0);
 
     BOOST_TEST(key::count_ == 2 + key_count);
     key_count += 2;
@@ -403,8 +416,10 @@ template <class UnorderedMap> void test_non_transparent_equal_range()
 
     BOOST_TEST(begin != end);
     BOOST_TEST(begin != map.end());
+    BOOST_TEST(std::distance(begin, end) == 1);
 
     value_type const& val = *begin;
+    BOOST_TEST(val.first.x_ == 0);
     BOOST_TEST(val.second == 1337);
 
     iters = map.equal_range(1337);
@@ -414,6 +429,7 @@ template <class UnorderedMap> void test_non_transparent_equal_range()
 
     BOOST_TEST(begin == end);
     BOOST_TEST(begin == map.end());
+    BOOST_TEST(std::distance(begin, end) == 0);
 
     BOOST_TEST(key::count_ == 2 + key_count);
   }

--- a/test/unordered/transparent_tests.cpp
+++ b/test/unordered/transparent_tests.cpp
@@ -278,6 +278,46 @@ template <class UnorderedMap> void test_transparent_equal_range()
 
   UnorderedMap unordered_map;
 
+  // empty tests
+  //
+  // explicitly test `equal_range()` vs `equal_range() const`
+  //
+  {
+    typedef typename UnorderedMap::iterator iterator;
+    typedef std::pair<iterator, iterator> iterator_pair;
+
+    UnorderedMap& map = unordered_map;
+    BOOST_TEST(map.empty());
+
+    iterator_pair iters = map.equal_range(0);
+
+    iterator begin = iters.first;
+    iterator end = iters.second;
+
+    BOOST_TEST(begin == end);
+    BOOST_TEST(begin == map.end());
+    BOOST_TEST(std::distance(begin, end) == 0);
+  }
+
+  {
+    typedef typename UnorderedMap::const_iterator iterator;
+    typedef std::pair<iterator, iterator> iterator_pair;
+
+    UnorderedMap const& map = unordered_map;
+    BOOST_TEST(map.empty());
+
+    iterator_pair iters = map.equal_range(0);
+
+    iterator begin = iters.first;
+    iterator end = iters.second;
+
+    BOOST_TEST(begin == end);
+    BOOST_TEST(begin == map.end());
+    BOOST_TEST(std::distance(begin, end) == 0);
+  }
+
+  BOOST_TEST(key::count_ == 0);
+
   unordered_map[key(0)] = 1337;
   unordered_map[key(1)] = 1338;
   unordered_map[key(2)] = 1339;
@@ -359,11 +399,51 @@ template <class UnorderedMap> void test_non_transparent_equal_range()
 
   UnorderedMap unordered_map;
 
+  // empty tests
+  //
+  // explicitly test `equal_range()` vs `equal_range() const`
+  //
+  {
+    typedef typename UnorderedMap::iterator iterator;
+    typedef std::pair<iterator, iterator> iterator_pair;
+
+    UnorderedMap& map = unordered_map;
+    BOOST_TEST(map.empty());
+
+    iterator_pair iters = map.equal_range(0);
+
+    iterator begin = iters.first;
+    iterator end = iters.second;
+
+    BOOST_TEST(begin == end);
+    BOOST_TEST(begin == map.end());
+    BOOST_TEST(std::distance(begin, end) == 0);
+  }
+
+  {
+    typedef typename UnorderedMap::const_iterator iterator;
+    typedef std::pair<iterator, iterator> iterator_pair;
+
+    UnorderedMap const& map = unordered_map;
+    BOOST_TEST(map.empty());
+
+    iterator_pair iters = map.equal_range(0);
+
+    iterator begin = iters.first;
+    iterator end = iters.second;
+
+    BOOST_TEST(begin == end);
+    BOOST_TEST(begin == map.end());
+    BOOST_TEST(std::distance(begin, end) == 0);
+  }
+
+  BOOST_TEST(key::count_ == 2);
+
   unordered_map[key(0)] = 1337;
   unordered_map[key(1)] = 1338;
   unordered_map[key(2)] = 1339;
 
-  int key_count = 6;
+  int key_count = 8;
 
   BOOST_TEST(key::count_ == key_count);
 

--- a/test/unordered/transparent_tests.cpp
+++ b/test/unordered/transparent_tests.cpp
@@ -272,6 +272,153 @@ template <class UnorderedMap> void test_non_transparent_find()
   }
 }
 
+template <class UnorderedMap> void test_transparent_equal_range()
+{
+  count_reset();
+
+  UnorderedMap unordered_map;
+
+  unordered_map[key(0)] = 1337;
+
+  int const expected_key_count = 2;
+
+  BOOST_TEST(key::count_ == expected_key_count);
+
+  typedef typename UnorderedMap::value_type value_type;
+
+  // explicitly test `equal_range()` vs `equal_range() const`
+  //
+  {
+    typedef typename UnorderedMap::iterator iterator;
+    typedef std::pair<iterator, iterator> iterator_pair;
+
+    UnorderedMap& map = unordered_map;
+
+    iterator_pair iters = map.equal_range(0);
+
+    iterator begin = iters.first;
+    iterator end = iters.second;
+
+    BOOST_TEST(begin != end);
+    BOOST_TEST(begin != map.end());
+
+    value_type const& val = *begin;
+    BOOST_TEST(val.second == 1337);
+
+    iters = map.equal_range(1337);
+
+    begin = iters.first;
+    end = iters.second;
+
+    BOOST_TEST(begin == end);
+    BOOST_TEST(begin == map.end());
+
+    BOOST_TEST(key::count_ == expected_key_count);
+  }
+
+  {
+    typedef typename UnorderedMap::const_iterator iterator;
+    typedef std::pair<iterator, iterator> iterator_pair;
+
+    UnorderedMap const& map = unordered_map;
+
+    iterator_pair iters = map.equal_range(0);
+
+    iterator begin = iters.first;
+    iterator end = iters.second;
+
+    BOOST_TEST(begin != end);
+    BOOST_TEST(begin != map.end());
+
+    value_type const& val = *begin;
+    BOOST_TEST(val.second == 1337);
+
+    iters = map.equal_range(1337);
+
+    begin = iters.first;
+    end = iters.second;
+
+    BOOST_TEST(begin == end);
+    BOOST_TEST(begin == map.end());
+
+    BOOST_TEST(key::count_ == expected_key_count);
+  }
+}
+
+template <class UnorderedMap> void test_non_transparent_equal_range()
+{
+  count_reset();
+
+  UnorderedMap unordered_map;
+
+  unordered_map[key(0)] = 1337;
+
+  int key_count = 2;
+
+  BOOST_TEST(key::count_ == key_count);
+
+  typedef typename UnorderedMap::value_type value_type;
+
+  // explicitly test `equal_range()` vs `equal_range() const`
+  //
+  {
+    typedef typename UnorderedMap::iterator iterator;
+    typedef std::pair<iterator, iterator> iterator_pair;
+
+    UnorderedMap& map = unordered_map;
+
+    iterator_pair iters = map.equal_range(0);
+
+    iterator begin = iters.first;
+    iterator end = iters.second;
+
+    BOOST_TEST(begin != end);
+    BOOST_TEST(begin != map.end());
+
+    value_type const& val = *begin;
+    BOOST_TEST(val.second == 1337);
+
+    iters = map.equal_range(1337);
+
+    begin = iters.first;
+    end = iters.second;
+
+    BOOST_TEST(begin == end);
+    BOOST_TEST(begin == map.end());
+
+    BOOST_TEST(key::count_ == 2 + key_count);
+    key_count += 2;
+  }
+
+  {
+    typedef typename UnorderedMap::const_iterator iterator;
+    typedef std::pair<iterator, iterator> iterator_pair;
+
+    UnorderedMap const& map = unordered_map;
+
+    iterator_pair iters = map.equal_range(0);
+
+    iterator begin = iters.first;
+    iterator end = iters.second;
+
+    BOOST_TEST(begin != end);
+    BOOST_TEST(begin != map.end());
+
+    value_type const& val = *begin;
+    BOOST_TEST(val.second == 1337);
+
+    iters = map.equal_range(1337);
+
+    begin = iters.first;
+    end = iters.second;
+
+    BOOST_TEST(begin == end);
+    BOOST_TEST(begin == map.end());
+
+    BOOST_TEST(key::count_ == 2 + key_count);
+  }
+}
+
 UNORDERED_AUTO_TEST (unordered_map_transparent_count) {
   {
     typedef boost::unordered_map<key, int, transparent_hasher,
@@ -280,6 +427,7 @@ UNORDERED_AUTO_TEST (unordered_map_transparent_count) {
 
     test_transparent_count<unordered_map>();
     test_transparent_find<unordered_map>();
+    test_transparent_equal_range<unordered_map>();
   }
 
   {
@@ -289,6 +437,7 @@ UNORDERED_AUTO_TEST (unordered_map_transparent_count) {
 
     test_non_transparent_count<unordered_map>();
     test_non_transparent_find<unordered_map>();
+    test_non_transparent_equal_range<unordered_map>();
   }
 
   {
@@ -299,6 +448,7 @@ UNORDERED_AUTO_TEST (unordered_map_transparent_count) {
 
     test_non_transparent_count<unordered_map>();
     test_non_transparent_find<unordered_map>();
+    test_non_transparent_equal_range<unordered_map>();
   }
 
   {
@@ -309,6 +459,7 @@ UNORDERED_AUTO_TEST (unordered_map_transparent_count) {
 
     test_non_transparent_count<unordered_map>();
     test_non_transparent_find<unordered_map>();
+    test_non_transparent_equal_range<unordered_map>();
   }
 }
 


### PR DESCRIPTION
Closes #49 