### PR TITLE
Fix integer overflow UB in test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
             cxxstd: "03,11,14,17,2a"
             os: ubuntu-20.04
             install: g++-11
+            sanitizers: true
           - toolset: clang
             compiler: clang++-3.9
             cxxstd: "03,11,14"
@@ -96,9 +97,11 @@ jobs:
             compiler: clang++-12
             cxxstd: "03,11,14,17,2a"
             os: ubuntu-20.04
+            sanitizers: true
           - toolset: clang
             cxxstd: "03,11,14,17"
             os: macos-10.15
+            sanitizers: true
 
     runs-on: ${{matrix.os}}
 
@@ -139,7 +142,11 @@ jobs:
       - name: Run tests
         run: |
           cd ../boost-root
-          ./b2 -j3 libs/$LIBRARY/test toolset=${{matrix.toolset}} cxxstd=${{matrix.cxxstd}} variant=debug,release
+          ./b2 -j3 libs/$LIBRARY/test \
+                   toolset=${{matrix.toolset}} \
+                   cxxstd=${{matrix.cxxstd}} \
+                   variant=debug,release \
+                   ${{(matrix.sanitizers && 'address-sanitizer=norecover undefined-sanitizer=norecover') || ''}}
 
   windows:
     strategy:

--- a/test/objects/exception.hpp
+++ b/test/objects/exception.hpp
@@ -194,18 +194,19 @@ namespace test {
 
       std::size_t hash_impl(object const& x) const
       {
-        int result;
+        unsigned result;
         switch (tag_) {
         case 1:
-          result = x.tag1_;
+          result = static_cast<unsigned>(x.tag1_);
           break;
         case 2:
-          result = x.tag2_;
+          result = static_cast<unsigned>(x.tag2_);
           break;
         default:
-          result = x.tag1_ + x.tag2_;
+          result =
+            static_cast<unsigned>(x.tag1_) + static_cast<unsigned>(x.tag2_);
         }
-        return static_cast<std::size_t>(result);
+        return result;
       }
 
       friend bool operator==(hash const& x1, hash const& x2)

--- a/test/objects/test.hpp
+++ b/test/objects/test.hpp
@@ -195,34 +195,36 @@ namespace test {
 
     std::size_t operator()(object const& x) const
     {
-      int result;
+      unsigned result;
       switch (type_) {
       case 1:
-        result = x.tag1_;
+        result = static_cast<unsigned>(x.tag1_);
         break;
       case 2:
-        result = x.tag2_;
+        result = static_cast<unsigned>(x.tag2_);
         break;
       default:
-        result = x.tag1_ + x.tag2_;
+        result =
+          static_cast<unsigned>(x.tag1_) + static_cast<unsigned>(x.tag2_);
       }
-      return static_cast<std::size_t>(result);
+      return result;
     }
 
     std::size_t operator()(movable const& x) const
     {
-      int result;
+      unsigned result;
       switch (type_) {
       case 1:
-        result = x.tag1_;
+        result = static_cast<unsigned>(x.tag1_);
         break;
       case 2:
-        result = x.tag2_;
+        result = static_cast<unsigned>(x.tag2_);
         break;
       default:
-        result = x.tag1_ + x.tag2_;
+        result =
+          static_cast<unsigned>(x.tag1_) + static_cast<unsigned>(x.tag2_);
       }
-      return static_cast<std::size_t>(result);
+      return result;
     }
 
     std::size_t operator()(int x) const


### PR DESCRIPTION
Enable the CI to run with `address-sanitizer=norecover undefined-sanitizer=norecover`.