### PR TITLE
Fix API docs to show the correct return type for emplace/insert

### DIFF
--- a/doc/unordered/unordered_map.adoc
+++ b/doc/unordered/unordered_map.adoc
@@ -131,7 +131,7 @@ public:
   iterator insert(const_iterator hint, node_type&& nh);
 
   template <class P>
-  std::pair<iterator, bool>
+  iterator
   insert(const_iterator hint, P&& value);
 
   template<typename InputIterator>
@@ -883,13 +883,13 @@ std::pair<iterator, bool>
 insert(const_iterator hint, P&& value);
 ```
 
-Inserts an element into the container by performing `emplace(std::forward<P>(value))`.
+Inserts an element into the container by performing `emplace_hint(hint, std::forward<P>(value))`.
 
 Only participates in overload resolution if `std::is_constructible<value_type, P&&>::value` is `true`.
 
 `hint` is a suggestion to where the element should be inserted.
 
-Returns:: The bool component of the return type is true if an insert took place. If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
+Returns:: If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
 
 Notes:: The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated.
 

--- a/doc/unordered/unordered_multimap.adoc
+++ b/doc/unordered/unordered_multimap.adoc
@@ -107,17 +107,17 @@ public:
 
   // modifiers
   template<typename... Args>
-  std::pair<iterator, bool>
+  iterator
   emplace(Args&&... args);
 
   template<typename... Args>
   iterator
   emplace_hint(const_iterator hint, Args&&... args);
 
-  std::pair<iterator, bool>
+  iterator
   insert(value_type const& obj);
 
-  std::pair<iterator, bool>
+  iterator
   insert(value_type&& obj);
 
   template <class P>
@@ -715,7 +715,7 @@ Returns:: A `const_iterator` which refers to the past-the-end value for the cont
 ==== emplace
 ```c++
 template<typename... Args>
-std::pair<iterator, bool>
+iterator
 emplace(Args&&... args);
 ```
 
@@ -761,7 +761,7 @@ Since existing `std::pair` implementations don't support `std::piecewise_constru
 
 ==== Copy Insert
 ```c++
-std::pair<iterator, bool>
+iterator
 insert(value_type const& obj);
 ```
 
@@ -779,7 +779,7 @@ Notes:: Can invalidate iterators, but only if the insert causes the load factor 
 
 ==== Move Insert
 ```c++
-std::pair<iterator, bool>
+iterator
 insert(value_type&& obj);
 ```
 
@@ -871,10 +871,10 @@ Notes:: The standard is fairly vague on the meaning of the hint. But the only pr
 ```c++
 template <class P>
 iterator
-insert(P&& value);
+insert(const_iterator hint, P&& value);
 ```
 
-Inserts an element into the container by performing `emplace(std::forward<P>(value))`.
+Inserts an element into the container by performing `emplace_hint(hint, std::forward<P>(value))`.
 
 Only participates in overload resolution if `std::is_constructible<value_type, P&&>::value` is `true`.
 

--- a/doc/unordered/unordered_multiset.adoc
+++ b/doc/unordered/unordered_multiset.adoc
@@ -105,20 +105,20 @@ public:
 
   // modifiers
   template<typename... Args>
-  std::pair<iterator, bool>
+  iterator
   emplace(Args&&... args);
 
   template<typename... Args>
   iterator
   emplace_hint(const_iterator hint, Args&&... args);
 
-  std::pair<iterator, bool>
+  iterator
   insert(value_type const& obj);
 
-  std::pair<iterator, bool>
+  iterator
   insert(value_type&& obj);
 
-  insert_return_type insert(node_type&& nh);
+  iterator insert(node_type&& nh);
 
   iterator insert(const_iterator hint, value_type const& obj);
   iterator insert(const_iterator hint, value_type&& obj);
@@ -703,7 +703,7 @@ Returns:: A `const_iterator` which refers to the past-the-end value for the cont
 ==== emplace
 ```c++
 template<typename... Args>
-std::pair<iterator, bool>
+iterator
 emplace(Args&&... args);
 ```
 
@@ -749,7 +749,7 @@ Since existing `std::pair` implementations don't support `std::piecewise_constru
 
 ==== Copy Insert
 ```c++
-std::pair<iterator, bool>
+iterator
 insert(value_type const& obj);
 ```
 
@@ -767,7 +767,7 @@ Notes:: Can invalidate iterators, but only if the insert causes the load factor 
 
 ==== Move Insert
 ```c++
-std::pair<iterator, bool>
+iterator
 insert(value_type&& obj);
 ```
 
@@ -785,7 +785,7 @@ Notes:: Can invalidate iterators, but only if the insert causes the load factor 
 
 ==== Insert with `node_handle`
 ```c++
-insert_return_type
+iterator
 insert(node_type&& nh);
 ```
 


### PR DESCRIPTION
Some of the reference synopses and text were the result of bad-copy paste. This PR aims to fix the inconsistencies.