### PR TITLE
Clean Up Reference

### DIFF
--- a/doc/unordered/unordered_map.adoc
+++ b/doc/unordered/unordered_map.adoc
@@ -7,276 +7,197 @@
 
 === Synopsis
 
-[source,c++,subs=+quotes]
+[listing,subs="+macros,+quotes"]
 -----
 // #include <boost/unordered_map.hpp>
 
-template<
-  typename Key,
-  typename Mapped,
-  typename Hash = boost::hash<Key>,
-  typename Pred = std::equal_to<Key>,
-  typename Alloc = std::allocator<std::pair<Key const, Mapped>> >
-class unordered_map {
-public:
-  // types
-  typedef Key                                    key_type;
-  typedef std::pair<Key const, Mapped>           value_type;
-  typedef Mapped                                 mapped_type;
-  typedef Hash                                   hasher;
-  typedef Pred                                   key_equal;
-  typedef Alloc                                  allocator_type;
-  typedef typename allocator_type::pointer       pointer;
-  typedef typename allocator_type::const_pointer const_pointer;
-  typedef value_type&                            reference;
-  typedef value_type const&                      const_reference;
-  typedef _implementation-defined_                 size_type;
-  typedef _implementation-defined_                 difference_type;
-  typedef _implementation-defined_                 iterator;
-  typedef _implementation-defined_                 const_iterator;
-  typedef _implementation-defined_                 local_iterator;
-  typedef _implementation-defined_                 const_local_iterator;
-  typedef _implementation-defined_                 node_type;
-  typedef _implementation-defined_                 insert_return_type;
+namespace boost {
+  template<class Key,
+           class T,
+           class Hash = boost::hash<Key>,
+           class Pred = std::equal_to<Key>,
+           class Allocator = std::allocator<std::pair<const Key, T>>>
+  class unordered_map {
+  public:
+    // types
+    using key_type             = Key;
+    using mapped_type          = T;
+    using value_type           = std::pair<const Key, T>;
+    using hasher               = Hash;
+    using key_equal            = Pred;
+    using allocator_type       = Allocator;
+    using pointer              = typename boost::allocator_traits<Allocator>::pointer;
+    using const_pointer        = typename boost::allocator_traits<Allocator>::const_pointer;
+    using reference            = value_type&;
+    using const_reference      = const value_type&;
+    using size_type            = _implementation-defined_;
+    using difference_type      = _implementation-defined_;
 
-  // construct/copy/destruct
-  unordered_map();
+    using iterator             = _implementation-defined_;
+    using const_iterator       = _implementation-defined_;
+    using local_iterator       = _implementation-defined_;
+    using const_local_iterator = _implementation-defined_;
+    using node_type            = _implementation-defined_;
+    using insert_return_type   = _implementation-defined_;
 
-  explicit unordered_map(size_type n,
-                         hasher const& hf = hasher(),
-                         key_equal const& eq = key_equal(),
-                         allocator_type const& a  = allocator_type());
+    // construct/copy/destroy
+    xref:#unordered_map_default_constructor[unordered_map]();
+    explicit xref:#unordered_map_bucket_count_constructor[unordered_map](size_type n,
+                           const hasher& hf = hasher(),
+                           const key_equal& eql = key_equal(),
+                           const allocator_type& a = allocator_type());
+    template<class InputIterator>
+      xref:#unordered_map_iterator_range_constructor[unordered_map](InputIterator f, InputIterator l,
+                    size_type n = _implementation-defined_,
+                    const hasher& hf = hasher(),
+                    const key_equal& eql = key_equal(),
+                    const allocator_type& a = allocator_type());
+    xref:#unordered_map_copy_constructor[unordered_map](const unordered_map& other);
+    xref:#unordered_map_move_constructor[unordered_map](unordered_map&& other);
+    explicit xref:#unordered_map_allocator_constructor[unordered_map](const Allocator& a);
+    xref:#unordered_map_copy_constructor_with_allocator[unordered_map](const unordered_map& other, const Allocator& a);
+    xref:#unordered_map_move_constructor_with_allocator[unordered_map](unordered_map&& other, const Allocator& a);
+    xref:#unordered_map_initializer_list_constructor[unordered_map](initializer_list<value_type> il,
+                  size_type n = _implementation-defined_
+                  const hasher& hf = hasher(),
+                  const key_equal& eql = key_equal(),
+                  const allocator_type& a = allocator_type());
+    xref:#unordered_map_bucket_count_constructor_with_allocator[unordered_map](size_type n, const allocator_type& a);
+    xref:#unordered_map_bucket_count_constructor_with_hasher_and_allocator[unordered_map](size_type n, const hasher& hf, const allocator_type& a);
+    template<class InputIterator>
+      xref:#unordered_map_iterator_range_constructor_with_bucket_count_and_allocator[unordered_map](InputIterator f, InputIterator l, size_type n, const allocator_type& a);
+    template<class InputIterator>
+      xref:#unordered_map_iterator_range_constructor_with_bucket_count_and_hasher[unordered_map](InputIterator f, InputIterator l, size_type n, const hasher& hf,
+                    const allocator_type& a);
+    xref:#unordered_map_destructor[~unordered_map]();
+    unordered_map& xref:#unordered_map_copy_assignment[operator++=++](const unordered_map& other);
+    unordered_map& xref:#unordered_map_move_assignment[operator++=++](unordered_map&& other)
+      noexcept(boost::allocator_traits<Allocator>::is_always_equal::value &&
+               boost::is_nothrow_move_assignable_v<Hash> &&
+               boost::is_nothrow_move_assignable_v<Pred>);
+    unordered_map& xref:#unordered_map_initializer_list_assignment[operator++=++](initializer_list<value_type>);
+    allocator_type xref:#unordered_map_get_allocator[get_allocator]() const noexcept;
 
-  unordered_map(unordered_map const& other);
-  unordered_map(unordered_map&& other);
+    // iterators
+    iterator       xref:#unordered_map_begin[begin]() noexcept;
+    const_iterator xref:#unordered_map_begin[begin]() const noexcept;
+    iterator       xref:#unordered_map_end[end]() noexcept;
+    const_iterator xref:#unordered_map_end[end]() const noexcept;
+    const_iterator xref:#unordered_map_cbegin[cbegin]() const noexcept;
+    const_iterator xref:#unordered_map_cend[cend]() const noexcept;
 
-  explicit unordered_map(Allocator const& a);
-  unordered_map(unordered_map const& other, Allocator const& a);
-  unordered_map(unordered_map&& other, Allocator const& a);
+    // capacity
+    bool xref:#unordered_map_empty[empty]() const noexcept;
+    size_type xref:#unordered_map_size[size]() const noexcept;
+    size_type xref:#unordered_map_max_size[max_size]() const noexcept;
 
-  unordered_map(size_type n, allocator_type const& a);
-  unordered_map(size_type n, hasher const& hf, allocator_type const& a);
+    // modifiers
+    template<class... Args> std::pair<iterator, bool> xref:#unordered_map_emplace[emplace](Args&&... args);
+    template<class... Args> iterator xref:#unordered_map_emplace_hint[emplace_hint](const_iterator position, Args&&... args);
+    std::pair<iterator, bool> xref:#unordered_map_copy_insert[insert](const value_type& obj);
+    std::pair<iterator, bool> xref:#unordered_map_move_insert[insert](value_type&& obj);
+    template<class P> std::pair<iterator, bool> xref:#unordered_map_emplace_insert[insert](P&& obj);
+    iterator       xref:#unordered_map_copy_insert_with_hint[insert](const_iterator hint, const value_type& obj);
+    iterator       xref:#unordered_map_move_insert_with_hint[insert](const_iterator hint, value_type&& obj);
+    template<class P> iterator xref:#unordered_map_emplace_insert_with_hint[insert](const_iterator hint, P&& obj);
+    template<class InputIterator> void xref:#unordered_map_insert_iterator_range[insert](InputIterator first, InputIterator last);
+    void xref:#unordered_map_insert_initializer_list[insert](initializer_list<value_type>);
 
-  unordered_map(initializer_list<value_type> il,
-                size_type n = _implementation-defined_,
-                hasher const& hf = hasher(),
-                key_equal const& eq = key_equal(),
-                allocator_type const& a = allocator_type());
+    node_type xref:#unordered_map_extract_by_iterator[extract](const_iterator position);
+    node_type xref:#unordered_map_extract_by_key[extract](const key_type& k);
+    template<class K> node_type xref:#unordered_map_transparent_extract_by_key[extract](K&& k);
+    insert_return_type xref:#unordered_map_insert_with_node_handle[insert](node_type&& nh);
+    iterator           xref:#unordered_map_insert_with_hint_and_node_handle[insert](const_iterator hint, node_type&& nh);
 
-  template<typename InputIterator>
-  unordered_map(InputIterator f,
-                InputIterator l,
-                size_type n = _implementation-defined_,
-                hasher const& hf = hasher(),
-                key_equal const& eq = key_equal(),
-                allocator_type const& a  = allocator_type());
+    iterator  xref:#unordered_map_erase_by_position[erase](iterator position);
+    iterator  xref:#unordered_map_erase_by_position[erase](const_iterator position);
+    size_type xref:#unordered_map_erase_by_key[erase](const key_type& k);
+    template<class K> size_type xref:#unordered_map_transparent_erase_by_key[erase](K&& k);
+    iterator  xref:#unordered_map_erase_range[erase](const_iterator first, const_iterator last);
+    void      xref:#unordered_map_quick_erase[quick_erase](const_iterator position);
+    void      xref:#unordered_map_erase_return_void[erase_return_void](const_iterator position);
+    void      xref:#unordered_map_swap[swap](unordered_map& other)
+      noexcept(boost::allocator_traits<Allocator>::is_always_equal::value &&
+               boost::is_nothrow_swappable_v<Hash> &&
+               boost::is_nothrow_swappable_v<Pred>);
+    void      xref:#unordered_map_clear[clear]() noexcept;
 
-  template<typename InputIterator>
-  unordered_map(InputIterator f,
-                InputIterator l,
-                size_type n,
-                allocator_type const& a);
+    template<class H2, class P2>
+      void xref:#unordered_map_merge[merge](unordered_map<Key, T, H2, P2, Allocator>& source);
+    template<class H2, class P2>
+      void xref:#unordered_map_merge_rvalue_reference[merge](unordered_map<Key, T, H2, P2, Allocator>&& source);
 
-  template<typename InputIterator>
-  unordered_map(InputIterator f,
-                InputIterator l,
-                size_type n,
-                hasher const& hf,
-                allocator_type const& a);
+    // observers
+    hasher xref:#unordered_map_hash_function[hash_function]() const;
+    key_equal xref:#unordered_map_key_eq[key_eq]() const;
 
-  ~unordered_map();
+    // map operations
+    iterator         xref:#unordered_map_find[find](const key_type& k);
+    const_iterator   xref:#unordered_map_find[find](const key_type& k) const;
+    template<class K>
+      iterator       xref:#unordered_map_find[find](const K& k);
+    template<class K>
+      const_iterator xref:#unordered_map_find[find](const K& k) const;
+    template<typename CompatibleKey, typename CompatibleHash, typename CompatiblePredicate>
+      iterator       xref:#unordered_map_find[find](CompatibleKey const& k, CompatibleHash const& hash,
+                          CompatiblePredicate const& eq);
+    template<typename CompatibleKey, typename CompatibleHash, typename CompatiblePredicate>
+      const_iterator xref:#unordered_map_find[find](CompatibleKey const& k, CompatibleHash const& hash,
+                          CompatiblePredicate const& eq) const;      
+    size_type        xref:#unordered_map_count[count](const key_type& k) const;
+    template<class K>
+      size_type      xref:#unordered_map_count[count](const K& k) const;
+    bool             xref:#unordered_map_contains[contains](const key_type& k) const;
+    template<class K>
+      bool           xref:#unordered_map_contains[contains](const K& k) const;
+    pair<iterator, iterator>               xref:#unordered_map_equal_range[equal_range](const key_type& k);
+    pair<const_iterator, const_iterator>   xref:#unordered_map_equal_range[equal_range](const key_type& k) const;
+    template<class K>
+      pair<iterator, iterator>             xref:#unordered_map_equal_range[equal_range](const K& k);
+    template<class K>
+      pair<const_iterator, const_iterator> xref:#unordered_map_equal_range[equal_range](const K& k) const;
 
-  unordered_map& operator=(unordered_map const& other);
-  unordered_map& operator=(unordered_map&& other);
-  unordered_map& operator=(initializer_list<value_type> il);
+    // element access
+    mapped_type& xref:#unordered_map_operator[operator[+]+](const key_type& k);
+    mapped_type& xref:#unordered_map_operator[operator[+]+](key_type&& k);
+    mapped_type& xref:#unordered_map_at[at](const key_type& k);
+    const mapped_type& xref:#unordered_map_at[at](const key_type& k) const;
 
-  // size and capacity
-  bool empty() const;
-  size_type size() const;
-  size_type max_size() const;
+    // bucket interface
+    size_type xref:#unordered_map_bucket_count[bucket_count]() const noexcept;
+    size_type xref:#unordered_map_max_bucket_count[max_bucket_count]() const noexcept;
+    size_type xref:#unordered_map_bucket_size[bucket_size](size_type n) const;
+    size_type xref:#unordered_map_bucket[bucket](const key_type& k) const;
+    local_iterator xref:#unordered_map_begin_2[begin](size_type n);
+    const_local_iterator xref:#unordered_map_begin_2[begin](size_type n) const;
+    local_iterator xref:#unordered_map_end_2[end](size_type n);
+    const_local_iterator xref:#unordered_map_end_2[end](size_type n) const;
+    const_local_iterator xref:#unordered_map_cbegin_2[cbegin](size_type n) const;
+    const_local_iterator xref:#unordered_map_cend_2[cend](size_type n) const;
 
-  // iterators
-  iterator begin();
-  const_iterator begin() const;
-
-  iterator end();
-  const_iterator end() const;
-
-  const_iterator cbegin() const;
-  const_iterator cend() const;
-
-  // modifiers
-  template<typename... Args>
-  std::pair<iterator, bool>
-  emplace(Args&&... args);
-
-  template<typename... Args>
-  iterator
-  emplace_hint(const_iterator hint, Args&&... args);
-
-  std::pair<iterator, bool>
-  insert(value_type const& obj);
-
-  std::pair<iterator, bool>
-  insert(value_type&& obj);
-
-  template <class P>
-  std::pair<iterator, bool>
-  insert(P&& value);
-
-  insert_return_type insert(node_type&& nh);
-
-  iterator insert(const_iterator hint, value_type const& obj);
-  iterator insert(const_iterator hint, value_type&& obj);
-  iterator insert(const_iterator hint, node_type&& nh);
-
-  template <class P>
-  iterator
-  insert(const_iterator hint, P&& value);
-
-  template<typename InputIterator>
-  void insert(InputIterator first, InputIterator last);
-
-  void insert(initializer_list<value_type> il);
-
-  node_type extract(const_iterator position);
-  node_type extract(key_type const& k);
-
-  template<typename K>
-  node_type extract(K&& k);
-
-  iterator erase(const_iterator position);
-  iterator erase(const_iterator first, const_iterator last);
-  size_type erase(key_type const& k);
-
-  template<typename K>
-  size_type erase(K&& k);
-
-  void quick_erase(const_iterator position);
-  void erase_return_void(const_iterator position);
-
-  void clear();
-  void swap(unordered_map& other);
-
-  template<typename H2, typename P2>
-  void merge(unordered_map<Key, Mapped, H2, P2, Alloc>& source);
-
-  template<typename H2, typename P2>
-  void merge(unordered_map<Key, Mapped, H2, P2, Alloc>&& source);
-
-  // observers
-  allocator_type get_allocator() const;
-  hasher hash_function() const;
-  key_equal key_eq() const;
-
-  // lookup
-  iterator find(key_type const& k);
-  const_iterator find(key_type const& k) const;
-
-  template<typename K>
-  iterator
-  find(K const& k);
-
-  template<typename K>
-  const_iterator
-  find(K const& k) const;
-
-  template<
-    typename CompatibleKey,
-    typename CompatibleHash,
-    typename CompatiblePredicate>
-  iterator
-  find(CompatibleKey const& k,
-       CompatibleHash const& hash,
-       CompatiblePredicate const&) eq;
-
-  template<
-    typename CompatibleKey,
-    typename CompatibleHash,
-    typename CompatiblePredicate>
-  const_iterator
-  find(CompatibleKey const& k,
-       CompatibleHash const& hash,
-       CompatiblePredicate const& eq) const;
-
-  bool contains(key_type const& key) const;
-
-  template<typename K>
-  bool contains(K const& key);
-
-  size_type count(key_type const& k) const;
-
-  template<typename K>
-  size_type count(K const& k) const;
-
-  std::pair<iterator, iterator>
-  equal_range(key_type const& k);
-
-  std::pair<const_iterator, const_iterator>
-  equal_range(key_type const& k) const;
-
-  template<typename K>
-  std::pair<iterator, iterator>
-  equal_range(K const& k);
-
-  template<typename K>
-  std::pair<const_iterator, const_iterator>
-  equal_range(K const& k) const;
-
-  mapped_type& operator[](key_type const& k);
-
-  Mapped& at(key_type const& k);
-  Mapped const& at(key_type const& k) const;
-
-  // bucket interface
-  size_type bucket_count() const;
-  size_type max_bucket_count() const;
-  size_type bucket_size(size_type n) const;
-  size_type bucket(key_type const& k) const;
-
-  local_iterator begin(size_type n);
-  const_local_iterator begin(size_type n) const;
-
-  local_iterator end(size_type n);
-  const_local_iterator end(size_type n) const;
-
-  const_local_iterator cbegin(size_type n) const;
-  const_local_iterator cend(size_type n) const;
-
-  // hash policy
-  float load_factor() const;
-  float max_load_factor() const;
-
-  void max_load_factor(float z);
-
-  void rehash(size_type n);
-  void reserve(size_type n);
-};
+    // hash policy
+    float xref:#unordered_map_load_factor[load_factor]() const noexcept;
+    float xref:#unordered_map_max_load_factor[max_load_factor]() const noexcept;
+    void xref:#unordered_map_set_max_load_factor[max_load_factor](float z);
+    void xref:#unordered_map_rehash[rehash](size_type n);
+    void xref:#unordered_map_reserve[reserve](size_type n);
+  };
+}
 
 // Equality Comparisons
-template<
-  typename Key,
-  typename Mapped,
-  typename Hash,
-  typename Pred,
-  typename Alloc>
-bool operator==(unordered_map<Key, Mapped, Hash, Pred, Alloc> const& x,
-                unordered_map<Key, Mapped, Hash, Pred, Alloc> const& y);
+template<class Key, class T, class Hash, class Pred, class Alloc>
+  bool xref:#unordered_map_operator_2[operator==](const unordered_map<Key, T, Hash, Pred, Alloc>& x,
+                  const unordered_map<Key, T, Hash, Pred, Alloc>& y);
 
-template<
-  typename Key,
-  typename Mapped,
-  typename Hash,
-  typename Pred,
-  typename Alloc>
-bool operator!=(unordered_map<Key, Mapped, Hash, Pred, Alloc> const& x,
-                unordered_map<Key, Mapped, Hash, Pred, Alloc> const& y);
+template<class Key, class T, class Hash, class Pred, class Alloc>
+  bool xref:#unordered_map_operator_3[operator!=](const unordered_map<Key, T, Hash, Pred, Alloc>& x,
+                  const unordered_map<Key, T, Hash, Pred, Alloc>& y);
 
 // swap
-template<typename Key, typename Mapped, typename Hash, typename Pred,
-         typename Alloc>
-void swap(unordered_map<Key, Mapped, Hash, Pred, Alloc>& x,
-          unordered_map<Key, Mapped, Hash, Pred, Alloc>& y);
+template<class Key, class T, class Hash, class Pred, class Alloc>
+  void xref:#unordered_map_swap_2[swap](unordered_map<Key, T, Hash, Pred, Alloc>& x,
+            unordered_map<Key, T, Hash, Pred, Alloc>& y)
+    noexcept(noexcept(x.swap(y)));
 -----
 
 ---
@@ -579,8 +500,10 @@ unordered_map(InputIterator f,
 
 Constructs an empty container with at least `n` buckets, using `a` as the allocator, with the default hash function and key equality predicate and a maximum load factor of `1.0` and inserts the elements from `[f, l)` into it.
 
+---
 Requires:: `hasher`, `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
+---
 ==== Iterator Range Constructor with Bucket Count and Hasher
 [source,c++,subs="quotes,macros"]
 ----

--- a/doc/unordered/unordered_map.adoc
+++ b/doc/unordered/unordered_map.adoc
@@ -350,6 +350,7 @@ Constructs an empty container using `hasher()` as the hash function,
 `key_equal()` as the key equality predicate, `allocator_type()` as the allocator
 and a maximum load factor of `1.0`.
 
+[horizontal]
 Postconditions:: `size() == 0`
 Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
@@ -367,8 +368,8 @@ Constructs an empty container with at least `n` buckets, using `hf` as the hash
 function, `eql` as the key equality predicate, `a` as the allocator and a maximum
 load factor of `1.0`.
 
+[horizontal]
 Postconditions:: `size() == 0`
-
 Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
 ---
@@ -386,6 +387,7 @@ template<class InputIterator>
 
 Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `eql` as the key equality predicate, `a` as the allocator and a maximum load factor of `1.0` and inserts the elements from `[f, l)` into it.
 
+[horizontal]
 Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
 ---
@@ -410,8 +412,8 @@ unordered_map(unordered_map&& other);
 
 The move constructor.
 
+[horizontal]
 Notes:: This is implemented using Boost.Move.
-
 Requires:: `value_type` is move-constructible. On compilers without rvalue reference support the emulation does not support moving without calling `boost::move` if `value_type` is not copyable.
 So, for example, you can't return the container from a function.
 
@@ -442,6 +444,7 @@ unordered_map(unordered_map&& other, Allocator const& a);
 
 Construct a container moving ``other``'s contained elements, and having the hash function, predicate and maximum load factor, but using allocate `a`.
 
+[horizontal]
 Notes:: This is implemented using Boost.Move.
 Requires:: `value_type` is move insertable.
 
@@ -459,6 +462,7 @@ unordered_map(initializer_list<value_type> il,
 
 Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `eql` as the key equality predicate, `a` as the allocator and a maximum load factor of `1.0` and inserts the elements from `il` into it.
 
+[horizontal]
 Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
 ---
@@ -470,6 +474,7 @@ unordered_map(size_type n, allocator_type const& a);
 
 Constructs an empty container with at least `n` buckets, using `hf` as the hash function, the default hash function and key equality predicate, `a` as the allocator and a maximum load factor of `1.0`.
 
+[horizontal]
 Postconditions:: `size() == 0`
 Requires:: `hasher` and `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
@@ -482,6 +487,7 @@ unordered_map(size_type n, hasher const& hf, allocator_type const& a);
 
 Constructs an empty container with at least `n` buckets, using `hf` as the hash function, the default key equality predicate, `a` as the allocator and a maximum load factor of `1.0`.
 
+[horizontal]
 Postconditions:: `size() == 0`
 Requires:: `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
@@ -496,10 +502,11 @@ template<class InputIterator>
 
 Constructs an empty container with at least `n` buckets, using `a` as the allocator, with the default hash function and key equality predicate and a maximum load factor of `1.0` and inserts the elements from `[f, l)` into it.
 
----
+[horizontal]
 Requires:: `hasher`, `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
 ---
+
 ==== Iterator Range Constructor with Bucket Count and Hasher
 [source,c++,subs="+quotes"]
 ----
@@ -510,6 +517,7 @@ Requires:: `hasher`, `key_equal` need to be https://en.cppreference.com/w/cpp/na
 
 Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `a` as the allocator, with the default key equality predicate and a maximum load factor of `1.0` and inserts the elements from `[f, l)` into it.
 
+[horizontal]
 Requires:: `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
 ---
@@ -519,6 +527,8 @@ Requires:: `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/D
 ```c++
 ~unordered_map();
 ```
+
+[horizontal]
 Note:: The destructor is applied to every element, and all memory is deallocated
 
 ---
@@ -535,6 +545,7 @@ The assignment operator. Copies the contained elements, hash function, predicate
 
 If `Alloc::propagate_on_container_copy_assignment` exists and `Alloc::propagate_on_container_copy_assignment::value` is `true`, the allocator is overwritten, if not the copied elements are created using the existing allocator.
 
+[horizontal]
 Requires:: `value_type` is copy constructible
 
 ---
@@ -550,8 +561,8 @@ The move assignment operator.
 
 If `Alloc::propagate_on_container_move_assignment` exists and `Alloc::propagate_on_container_move_assignment::value` is `true`, the allocator is overwritten, if not the moved elements are created using the existing allocator.
 
+[horizontal]
 Notes:: On compilers without rvalue references, this is emulated using Boost.Move. Note that on some compilers the copy assignment operator may be used in some circumstances.
-
 Requires:: `value_type` is move constructible.
 
 ---
@@ -573,6 +584,7 @@ iterator begin() noexcept;
 const_iterator begin() const noexcept;
 ```
 
+[horizontal]
 Returns:: An iterator referring to the first element of the container, or if the container is empty the past-the-end value for the container.
 
 ---
@@ -583,6 +595,7 @@ iterator end() noexcept;
 const_iterator end() const noexcept;
 ```
 
+[horizontal]
 Returns:: An iterator which refers to the past-the-end value for the container.
 
 ---
@@ -591,6 +604,8 @@ Returns:: An iterator which refers to the past-the-end value for the container.
 ```c++
 const_iterator cbegin() const noexcept;
 ```
+
+[horizontal]
 Returns:: A `const_iterator` referring to the first element of the container, or if the container is empty the past-the-end value for the container.
 
 ---
@@ -600,6 +615,7 @@ Returns:: A `const_iterator` referring to the first element of the container, or
 const_iterator cend() const noexcept;
 ```
 
+[horizontal]
 Returns:: A `const_iterator` which refers to the past-the-end value for the container.
 
 ---
@@ -612,6 +628,7 @@ Returns:: A `const_iterator` which refers to the past-the-end value for the cont
 bool empty() const noexcept;
 ```
 
+[horizontal]
 Returns:: `size() == 0`
 
 ---
@@ -622,6 +639,7 @@ Returns:: `size() == 0`
 size_type size() const noexcept;
 ```
 
+[horizontal]
 Returns:: `std::distance(begin(), end())`
 
 ---
@@ -632,6 +650,7 @@ Returns:: `std::distance(begin(), end())`
 size_type max_size() const noexcept;
 ```
 
+[horizontal]
 Returns:: `size()` of the largest possible container.
 
 ---
@@ -645,13 +664,11 @@ template<class... Args> std::pair<iterator, bool> emplace(Args&&... args);
 
 Inserts an object, constructed with the arguments `args`, in the container if and only if there is no element in the container with an equivalent key.
 
+[horizontal]
 Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `args`.
-
 Returns:: The bool component of the return type is true if an insert took place. +
 If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
-
 Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-
 Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor.
 Pointers and references to elements are never invalidated.
 If the compiler doesn't support variadic template arguments or rvalue references, this is emulated for up to `10` arguments, with no support for rvalue references or move semantics.
@@ -668,12 +685,10 @@ Inserts an object, constructed with the arguments `args`, in the container if an
 
 `position` is a suggestion to where the element should be inserted.
 
+[horizontal]
 Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `args`.
-
 Returns:: If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
-
 Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-
 Notes:: The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key.
 Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor.
 Pointers and references to elements are never invalidated.
@@ -689,12 +704,10 @@ std::pair<iterator, bool> insert(const value_type& obj);
 
 Inserts `obj` in the container if and only if there is no element in the container with an equivalent key.
 
+[horizontal]
 Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/CopyInsertable[CopyInsertable^].
-
 Returns:: The bool component of the return type is true if an insert took place. If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
-
 Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-
 Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated.
 
 ---
@@ -706,12 +719,10 @@ std::pair<iterator, bool> insert(value_type&& obj);
 
 Inserts `obj` in the container if and only if there is no element in the container with an equivalent key.
 
+[horizontal]
 Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/MoveInsertable[MoveInsertable^].
-
 Returns:: The bool component of the return type is true if an insert took place. If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
-
 Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-
 Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated.
 
 ---
@@ -725,6 +736,7 @@ Inserts an element into the container by performing `emplace(std::forward<P>(val
 
 Only participates in overload resolution if `std::is_constructible<value_type, P&&>::value` is `true`.
 
+[horizontal]
 Returns:: The bool component of the return type is true if an insert took place. If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
 
 ---
@@ -737,12 +749,10 @@ Inserts `obj` in the container if and only if there is no element in the contain
 
 `hint` is a suggestion to where the element should be inserted.
 
+[horizontal]
 Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/CopyInsertable[CopyInsertable^].
-
 Returns:: If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
-
 Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-
 Notes:: The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated.
 
 ---
@@ -756,12 +766,10 @@ Inserts `obj` in the container if and only if there is no element in the contain
 
 `hint` is a suggestion to where the element should be inserted.
 
+[horizontal]
 Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/MoveInsertable[MoveInsertable^].
-
 Returns:: If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
-
 Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-
 Notes:: The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated.
 
 ---
@@ -778,8 +786,8 @@ Only participates in overload resolution if `std::is_constructible<value_type, P
 
 `hint` is a suggestion to where the element should be inserted.
 
+[horizontal]
 Returns:: If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
-
 Notes:: The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated.
 
 ---
@@ -791,10 +799,9 @@ template<class InputIterator> void insert(InputIterator first, InputIterator las
 
 Inserts a range of elements into the container. Elements are inserted if and only if there is no element in the container with an equivalent key.
 
+[horizontal]
 Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `*first`.
-
 Throws:: When inserting a single element, if an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-
 Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated.
 
 ---
@@ -806,10 +813,9 @@ void insert(initializer_list<value_type>);
 
 Inserts a range of elements into the container. Elements are inserted if and only if there is no element in the container with an equivalent key.
 
+[horizontal]
 Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `*first`.
-
 Throws:: When inserting a single element, if an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-
 Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated.
 
 ---
@@ -821,8 +827,8 @@ node_type extract(const_iterator position);
 
 Removes the element pointed to by `position`.
 
+[horizontal]
 Returns:: A `node_type` owning the element.
-
 Notes:: In C++17 a node extracted using this method can be inserted into a compatible `unordered_multimap`, but that is not supported yet.
 
 ---
@@ -834,10 +840,9 @@ node_type extract(const key_type& k);
 
 Removes an element with key equivalent to `k`.
 
+[horizontal]
 Returns:: A `node_type` owning the element if found, otherwise an empty `node_type`.
-
 Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
-
 Notes:: In C++17 a node extracted using this method can be inserted into a compatible `unordered_multimap`, but that is not supported yet.
 
 ---
@@ -851,10 +856,9 @@ Removes an element with key equivalent to `k`.
 
 This overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs and neither `iterator` nor `const_iterator` are implicitly convertible from `K`. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
 
+[horizontal]
 Returns:: A `node_type` owning the element if found, otherwise an empty `node_type`.
-
 Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
-
 Notes:: In C++17 a node extracted using this method can be inserted into a compatible `unordered_multimap`, but that is not supported yet.
 
 ---
@@ -868,12 +872,10 @@ If `nh` is empty, has no effect.
 
 Otherwise inserts the element owned by `nh` if and only if there is no element in the container with an equivalent key.
 
+[horizontal]
 Requires:: `nh` is empty or `nh.get_allocator()` is equal to the container's allocator.
-
 Returns:: If `nh` was empty, returns an `insert_return_type` with: `inserted` equal to `false`, `position` equal to `end()` and `node` empty. Otherwise if there was already an element with an equivalent key, returns an `insert_return_type` with: `inserted` equal to `false`, `position` pointing to a matching element and `node` contains the node from `nh`. Otherwise if the insertion succeeded, returns an `insert_return_type` with: `inserted` equal to `true`, `position` pointing to the newly inserted element and `node` empty.
-
 Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-
 Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated. In C++17 this can be used to insert a node extracted from a compatible `unordered_multimap`, but that is not supported yet.
 
 ---
@@ -891,12 +893,10 @@ If there is already an element in the container with an equivalent key has no ef
 
 `hint` is a suggestion to where the element should be inserted.
 
+[horizontal]
 Requires:: `nh` is empty or `nh.get_allocator()` is equal to the container's allocator.
-
 Returns:: If `nh` was empty returns `end()`. If there was already an element in the container with an equivalent key returns an iterator pointing to that. Otherwise returns an iterator pointing to the newly inserted element.
-
 Throws:: If an exception is thrown by an operation other than a call to hasher the function has no effect.
-
 Notes:: The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated. In C++17 this can be used to insert a node extracted from a compatible `unordered_multimap`, but that is not supported yet.
 
 ---
@@ -910,10 +910,9 @@ iterator erase(const_iterator position);
 
 Erase the element pointed to by `position`.
 
+[horizontal]
 Returns:: The iterator following `position` before the erasure.
-
 Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
-
 Notes:: In older versions this could be inefficient because it had to search through several buckets to find the position of the returned iterator. The data structure has been changed so that this is no longer the case, and the alternative erase methods have been deprecated.
 
 ---
@@ -925,8 +924,8 @@ size_type erase(const key_type& k);
 
 Erase all elements with key equivalent to `k`.
 
+[horizontal]
 Returns:: The number of elements erased.
-
 Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
 
 ---
@@ -940,8 +939,8 @@ Erase all elements with key equivalent to `k`.
 
 This overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs and neither `iterator` nor `const_iterator` are implicitly convertible from `K`. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
 
+[horizontal]
 Returns:: The number of elements erased.
-
 Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
 
 ---
@@ -954,8 +953,8 @@ iterator erase(const_iterator first, const_iterator last);
 
 Erases the elements in the range from `first` to `last`.
 
+[horizontal]
 Returns:: The iterator following the erased elements - i.e. `last`.
-
 Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`. In this implementation, this overload doesn't call either function object's methods so it is no throw, but this might not be true in other implementations.
 
 ---
@@ -967,8 +966,8 @@ void quick_erase(const_iterator position);
 
 Erase the element pointed to by `position`.
 
+[horizontal]
 Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`. In this implementation, this overload doesn't call either function object's methods so it is no throw, but this might not be true in other implementations.
-
 Notes:: This method was implemented because returning an iterator to the next element from erase was expensive, but the container has been redesigned so that is no longer the case. So this method is now deprecated.
 
 ---
@@ -980,8 +979,8 @@ void erase_return_void(const_iterator position);
 
 Erase the element pointed to by `position`.
 
+[horizontal]
 Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`. In this implementation, this overload doesn't call either function object's methods so it is no throw, but this might not be true in other implementations.
-
 Notes:: This method was implemented because returning an iterator to the next element from erase was expensive, but the container has been redesigned so that is no longer the case. So this method is now deprecated.
 
 ---
@@ -998,8 +997,8 @@ Swaps the contents of the container with the parameter.
 
 If `Allocator::propagate_on_container_swap` is declared and `Allocator::propagate_on_container_swap::value` is `true` then the containers' allocators are swapped. Otherwise, swapping with unequal allocators results in undefined behavior.
 
+[horizontal]
 Throws:: Doesn't throw an exception unless it is thrown by the copy constructor or copy assignment operator of `key_equal` or `hasher`.
-
 Notes:: The exception specifications aren't quite the same as the C++11 standard, as the equality predicate and hash function are swapped using their copy constructors.
 
 ---
@@ -1011,8 +1010,8 @@ void clear();
 
 Erases all elements in the container.
 
+[horizontal]
 Postconditions:: `size() == 0`
-
 Throws:: Never throws an exception.
 
 ---
@@ -1023,6 +1022,7 @@ template<typename H2, typename P2>
 void merge(unordered_map<Key, T, H2, P2, Alloc>& source);
 ```
 
+[horizontal]
 Notes:: Does not support merging with a compatible `unordered_multimap` yet.
 
 ---
@@ -1033,6 +1033,7 @@ template<typename H2, typename P2>
 void merge(unordered_map<Key, T, H2, P2, Alloc>&& source);
 ```
 
+[horizontal]
 Notes:: Does not support merging with a compatible `unordered_multimap` yet.
 
 ---
@@ -1051,6 +1052,7 @@ allocator_type get_allocator() const;
 hasher hash_function() const;
 ```
 
+[horizontal]
 Returns:: The container's hash function.
 
 ---
@@ -1060,6 +1062,7 @@ Returns:: The container's hash function.
 key_equal key_eq() const;
 ```
 
+[horizontal]
 Returns:: The container's key equality predicate
 
 ---
@@ -1083,8 +1086,8 @@ template<typename CompatibleKey, typename CompatibleHash, typename CompatiblePre
 
 ```
 
+[horizontal]
 Returns:: An iterator pointing to an element with key equivalent to `k`, or `b.end()` if no such element exists.
-
 Notes:: The templated overloads containing `CompatibleKey`, `CompatibleHash` and `CompatiblePredicate` are non-standard extensions which allow you to use a compatible hash function and equality predicate for a key of a different type in order to avoid an expensive type cast. In general, its use is not encouraged and instead the `K` member function templates should be used. +
 The `template <typename K>` overloads only participate in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
 
@@ -1097,8 +1100,8 @@ template<class K>
   size_type      count(const K& k) const;
 ```
 
+[horizontal]
 Returns:: The number of elements with key equivalent to `k`.
-
 Notes:: The `template <typename K>` overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
 
 ---
@@ -1110,8 +1113,8 @@ template<class K>
   bool           contains(const K& k) const;
 ```
 
+[horizontal]
 Returns:: A boolean indicating whether or not there is an element with key equal to `key` in the container
-
 Notes:: The `template <typename K>` overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
 
 ---
@@ -1126,8 +1129,8 @@ template<class K>
   pair<const_iterator, const_iterator> equal_range(const K& k) const;
 ```
 
+[horizontal]
 Returns:: A range containing all elements with key equivalent to `k`. If the container doesn't contain any such elements, returns `std::make_pair(b.end(), b.end())`.
-
 Notes:: The `template <typename K>` overloads only participate in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
 
 ---
@@ -1138,12 +1141,10 @@ mapped_type& operator[](const key_type& k);
 mapped_type& operator[](key_type&& k);
 ```
 
+[horizontal]
 Effects:: If the container does not already contain an elements with a key equivalent to `k`, inserts the value `std::pair<key_type const, mapped_type>(k, mapped_type())`.
-
 Returns:: A reference to `x.second` where `x` is the element already in the container, or the newly inserted element with a key equivalent to `k`.
-
 Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-
 Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated.
 
 ---
@@ -1154,8 +1155,8 @@ mapped_type& at(const key_type& k);
 const mapped_type& at(const key_type& k) const;
 ```
 
+[horizontal]
 Returns:: A reference to `x.second` where `x` is the (unique) element whose key is equivalent to `k`.
-
 Throws:: An exception object of type `std::out_of_range` if no such element is present.
 
 ---
@@ -1167,6 +1168,7 @@ Throws:: An exception object of type `std::out_of_range` if no such element is p
 size_type bucket_count() const noexcept;
 ```
 
+[horizontal]
 Returns:: The number of buckets.
 
 ---
@@ -1176,6 +1178,7 @@ Returns:: The number of buckets.
 size_type max_bucket_count() const noexcept;
 ```
 
+[horizontal]
 Returns:: An upper bound on the number of buckets.
 
 ---
@@ -1185,8 +1188,8 @@ Returns:: An upper bound on the number of buckets.
 size_type bucket_size(size_type n) const;
 ```
 
+[horizontal]
 Requires:: `n < bucket_count()`
-
 Returns:: The number of elements in bucket `n`.
 
 ---
@@ -1196,8 +1199,8 @@ Returns:: The number of elements in bucket `n`.
 size_type bucket(const key_type& k) const;
 ```
 
+[horizontal]
 Returns:: The index of the bucket which would contain an element with key `k`.
-
 Postconditions:: The return value is less than `bucket_count()`.
 
 ---
@@ -1209,8 +1212,8 @@ local_iterator begin(size_type n);
 const_local_iterator begin(size_type n) const;
 ```
 
+[horizontal]
 Requires:: `n` shall be in the range `[0, bucket_count())`.
-
 Returns:: A local iterator pointing the first element in the bucket with index `n`.
 
 ---
@@ -1221,8 +1224,8 @@ local_iterator end(size_type n);
 const_local_iterator end(size_type n) const;
 ```
 
+[horizontal]
 Requires:: `n` shall be in the range `[0, bucket_count())`.
-
 Returns:: A local iterator pointing the 'one past the end' element in the bucket with index `n`.
 
 ---
@@ -1232,8 +1235,8 @@ Returns:: A local iterator pointing the 'one past the end' element in the bucket
 const_local_iterator cbegin(size_type n) const;
 ```
 
+[horizontal]
 Requires:: `n` shall be in the range `[0, bucket_count())`.
-
 Returns:: A constant local iterator pointing the first element in the bucket with index `n`.
 
 ---
@@ -1243,8 +1246,8 @@ Returns:: A constant local iterator pointing the first element in the bucket wit
 const_local_iterator cend(size_type n) const;
 ```
 
+[horizontal]
 Requires:: `n` shall be in the range `[0, bucket_count())`.
-
 Returns:: A constant local iterator pointing the 'one past the end' element in the bucket with index `n`.
 
 ---
@@ -1256,6 +1259,7 @@ Returns:: A constant local iterator pointing the 'one past the end' element in t
 float load_factor() const noexcept;
 ```
 
+[horizontal]
 Returns:: The average number of elements per bucket.
 
 ---
@@ -1266,6 +1270,7 @@ Returns:: The average number of elements per bucket.
 float max_load_factor() const noexcept;
 ```
 
+[horizontal]
 Returns:: Returns the current maximum load factor.
 
 ---
@@ -1275,6 +1280,7 @@ Returns:: Returns the current maximum load factor.
 void max_load_factor(float z);
 ```
 
+[horizontal]
 Effects:: Changes the container's maximum load factor, using `z` as a hint.
 
 ---
@@ -1289,6 +1295,7 @@ Changes the number of buckets so that there at least `n` buckets, and so that th
 
 Invalidates iterators, and changes the order of elements. Pointers and references to elements are not invalidated.
 
+[horizontal]
 Throws:: The function has no effect if an exception is thrown, unless it is thrown by the container's hash function or comparison function.
 
 ---
@@ -1300,6 +1307,7 @@ void reserve(size_type n);
 
 Invalidates iterators, and changes the order of elements. Pointers and references to elements are not invalidated.
 
+[horizontal]
 Throws:: The function has no effect if an exception is thrown, unless it is thrown by the container's hash function or comparison function.
 
 === Equality Comparisons
@@ -1313,6 +1321,7 @@ template<class Key, class T, class Hash, class Pred, class Alloc>
 
 Return `true` if `x.size() == y.size()` and for every element in `x`, there is an element in `y` with the same key, with an equal value (using `operator==` to compare the value types).
 
+[horizontal]
 Notes:: The behavior of this function was changed to match the C++11 standard in Boost 1.48. Behavior is undefined if the two containers don't have equivalent equality predicates.
 
 ---
@@ -1326,6 +1335,7 @@ template<class Key, class T, class Hash, class Pred, class Alloc>
 
 Return `false` if `x.size() == y.size()` and for every element in `x`, there is an element in `y` with the same key, with an equal value (using `operator==` to compare the value types).
 
+[horizontal]
 Notes:: The behavior of this function was changed to match the C++11 standard in Boost 1.48. Behavior is undefined if the two containers don't have equivalent equality predicates.
 
 === Swap
@@ -1340,10 +1350,9 @@ Swaps the contents of `x` and `y`.
 
 If `Allocator::propagate_on_container_swap` is declared and `Allocator::propagate_on_container_swap::value` is `true` then the containers' allocators are swapped. Otherwise, swapping with unequal allocators results in undefined behavior.
 
+[horizontal]
 Effects:: `x.swap(y)`
-
 Throws:: Doesn't throw an exception unless it is thrown by the copy constructor or copy assignment operator of `key_equal` or `hasher`.
-
 Notes:: The exception specifications aren't quite the same as the C++11 standard, as the equality predicate and hash function are swapped using their copy constructors.
 
 

--- a/doc/unordered/unordered_map.adoc
+++ b/doc/unordered/unordered_map.adoc
@@ -212,8 +212,8 @@ template<class Key, class T, class Hash, class Pred, class Alloc>
 |_Key_
 |`Key` must be https://en.cppreference.com/w/cpp/named_req/Erasable[Erasable^] from the container (i.e. `allocator_traits` can destroy it).
 
-|_Mapped_
-|`Mapped` must be https://en.cppreference.com/w/cpp/named_req/Erasable[Erasable^] from the container (i.e. `allocator_traits` can destroy it).
+|_T_
+|`T` must be https://en.cppreference.com/w/cpp/named_req/Erasable[Erasable^] from the container (i.e. `allocator_traits` can destroy it).
 
 |_Hash_
 |A unary function object type that acts a hash function for a `Key`. It takes a single argument of type `Key` and returns a value of type `std::size_t`.
@@ -221,7 +221,7 @@ template<class Key, class T, class Hash, class Pred, class Alloc>
 |_Pred_
 |A binary function object that implements an equivalence relation on values of type `Key`. A binary function object that induces an equivalence relation on values of type `Key`. It takes two arguments of type `Key` and returns a value of type bool.
 
-|_Alloc_
+|_Allocator_
 |An allocator whose value type is the same as the container's value type.
 
 |===
@@ -358,16 +358,33 @@ Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` 
 ==== Bucket Count Constructor
 ```c++
 explicit unordered_map(size_type n,
-                       hasher const& hf = hasher(),
-                       key_equal const& eq = key_equal(),
-                       allocator_type const& a = allocator_type());
+                       const hasher& hf = hasher(),
+                       const key_equal& eql = key_equal(),
+                       const allocator_type& a = allocator_type());
 ```
 
 Constructs an empty container with at least `n` buckets, using `hf` as the hash
-function, `eq` as the key equality predicate, `a` as the allocator and a maximum
+function, `eql` as the key equality predicate, `a` as the allocator and a maximum
 load factor of `1.0`.
 
 Postconditions:: `size() == 0`
+
+Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
+==== Iterator Range Constructor
+[source,c++,subs="+quotes"]
+----
+template<class InputIterator>
+  unordered_map(InputIterator f, InputIterator l,
+                size_type n = _implementation-defined_,
+                const hasher& hf = hasher(),
+                const key_equal& eql = key_equal(),
+                const allocator_type& a = allocator_type());
+----
+
+Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `eql` as the key equality predicate, `a` as the allocator and a maximum load factor of `1.0` and inserts the elements from `[f, l)` into it.
 
 Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
@@ -430,6 +447,22 @@ Requires:: `value_type` is move insertable.
 
 ---
 
+==== Initializer List Constructor
+[source,c++,subs="+quotes"]
+----
+unordered_map(initializer_list<value_type> il,
+              size_type n = _implementation-defined_
+              const hasher& hf = hasher(),
+              const key_equal& eql = key_equal(),
+              const allocator_type& a = allocator_type());
+----
+
+Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `eql` as the key equality predicate, `a` as the allocator and a maximum load factor of `1.0` and inserts the elements from `il` into it.
+
+Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
 ==== Bucket Count Constructor with Allocator
 ```c++
 unordered_map(size_type n, allocator_type const& a);
@@ -454,48 +487,11 @@ Requires:: `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/D
 
 ---
 
-==== Initializer List Constructor
-[source,c++,subs="quotes,macros"]
-----
-unordered_map(initializer_list++<++value_type++>++ il,
-              size_type n = _implementation-defined_,
-              hasher const& hf = hasher(),
-              key_equal const& eq = key_equal(),
-              allocator_type const& a = allocator_type());
-----
-
-Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `eq` as the key equality predicate, `a` as the allocator and a maximum load factor of `1.0` and inserts the elements from `il` into it.
-
-Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
-
----
-
-==== Iterator Range Constructor
-[source,c++,subs="quotes,macros"]
-----
-template++<++typename InputIterator++>++
-unordered_map(InputIterator f,
-              InputIterator l,
-              size_type n = _implementation-defined_,
-              hasher const& hf = hasher(),
-              key_equal const& eq = key_equal(),
-              allocator_type const& a = allocator_type());
-----
-
-Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `eq` as the key equality predicate, `a` as the allocator and a maximum load factor of `1.0` and inserts the elements from `[f, l)` into it.
-
-Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
-
----
-
 ==== Iterator Range Constructor with Bucket Count and Allocator
-[source,c++,subs="quotes,macros"]
+[source,c++,subs="+quotes"]
 ----
-template++<++typename InputIterator++>++
-unordered_map(InputIterator f,
-              InputIterator l,
-              size_type n,
-              allocator_type const& a);
+template<class InputIterator>
+  unordered_map(InputIterator f, InputIterator l, size_type n, const allocator_type& a);
 ----
 
 Constructs an empty container with at least `n` buckets, using `a` as the allocator, with the default hash function and key equality predicate and a maximum load factor of `1.0` and inserts the elements from `[f, l)` into it.
@@ -505,14 +501,11 @@ Requires:: `hasher`, `key_equal` need to be https://en.cppreference.com/w/cpp/na
 
 ---
 ==== Iterator Range Constructor with Bucket Count and Hasher
-[source,c++,subs="quotes,macros"]
+[source,c++,subs="+quotes"]
 ----
-template++<++typename InputIterator++>++
-unordered_map(InputIterator f,
-              InputIterator l,
-              size_type n,
-              hasher const& hf,
-              allocator_type const& a);
+    template<class InputIterator>
+      unordered_map(InputIterator f, InputIterator l, size_type n, const hasher& hf,
+                    const allocator_type& a);
 ----
 
 Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `a` as the allocator, with the default key equality predicate and a maximum load factor of `1.0` and inserts the elements from `[f, l)` into it.
@@ -548,7 +541,10 @@ Requires:: `value_type` is copy constructible
 
 ==== Move Assignment
 ```c++
-unordered_map& operator=(unordered_map&& other);
+unordered_map& operator=(unordered_map&& other)
+  noexcept(boost::allocator_traits<Allocator>::is_always_equal::value &&
+           boost::is_nothrow_move_assignable_v<Hash> &&
+           boost::is_nothrow_move_assignable_v<Pred>);
 ```
 The move assignment operator.
 
@@ -569,12 +565,51 @@ Assign from values in initializer list. All existing elements are either overwri
 
 Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/CopyInsertable[CopyInsertable^] into the container and https://en.cppreference.com/w/cpp/named_req/CopyAssignable[CopyAssignable^].
 
+=== Iterators
+
+==== begin
+```c++
+iterator begin() noexcept;
+const_iterator begin() const noexcept;
+```
+
+Returns:: An iterator referring to the first element of the container, or if the container is empty the past-the-end value for the container.
+
+---
+
+==== end
+```c++
+iterator end() noexcept;
+const_iterator end() const noexcept;
+```
+
+Returns:: An iterator which refers to the past-the-end value for the container.
+
+---
+
+==== cbegin
+```c++
+const_iterator cbegin() const noexcept;
+```
+Returns:: A `const_iterator` referring to the first element of the container, or if the container is empty the past-the-end value for the container.
+
+---
+
+==== cend
+```c++
+const_iterator cend() const noexcept;
+```
+
+Returns:: A `const_iterator` which refers to the past-the-end value for the container.
+
+---
+
 === Size and Capacity
 
 ==== empty
 
 ```c++
-bool empty() const;
+bool empty() const noexcept;
 ```
 
 Returns:: `size() == 0`
@@ -584,7 +619,7 @@ Returns:: `size() == 0`
 ==== size
 
 ```c++
-size_type size() const;
+size_type size() const noexcept;
 ```
 
 Returns:: `std::distance(begin(), end())`
@@ -594,49 +629,10 @@ Returns:: `std::distance(begin(), end())`
 ==== max_size
 
 ```c++
-size_type max_size() const;
+size_type max_size() const noexcept;
 ```
 
 Returns:: `size()` of the largest possible container.
-
----
-
-=== Iterators
-
-==== begin
-```c++
-iterator begin();
-const_iterator begin() const;
-```
-
-Returns:: An iterator referring to the first element of the container, or if the container is empty the past-the-end value for the container.
-
----
-
-==== end
-```c++
-iterator end();
-const_iterator end() const;
-```
-
-Returns:: An iterator which refers to the past-the-end value for the container.
-
----
-
-==== cbegin
-```c++
-const_iterator cbegin() const;
-```
-Returns:: A `const_iterator` referring to the first element of the container, or if the container is empty the past-the-end value for the container.
-
----
-
-==== cend
-```c++
-const_iterator cend() const;
-```
-
-Returns:: A `const_iterator` which refers to the past-the-end value for the container.
 
 ---
 
@@ -644,9 +640,7 @@ Returns:: A `const_iterator` which refers to the past-the-end value for the cont
 
 ==== emplace
 ```c++
-template<typename... Args>
-std::pair<iterator, bool>
-emplace(Args&&... args);
+template<class... Args> std::pair<iterator, bool> emplace(Args&&... args);
 ```
 
 Inserts an object, constructed with the arguments `args`, in the container if and only if there is no element in the container with an equivalent key.
@@ -667,14 +661,12 @@ Since existing `std::pair` implementations don't support `std::piecewise_constru
 
 ==== emplace_hint
 ```c++
-template<typename... Args>
-iterator
-emplace_hint(const_iterator hint, Args&&... args);
+    template<class... Args> iterator emplace_hint(const_iterator position, Args&&... args);
 ```
 
 Inserts an object, constructed with the arguments `args`, in the container if and only if there is no element in the container with an equivalent key.
 
-`hint` is a suggestion to where the element should be inserted.
+`position` is a suggestion to where the element should be inserted.
 
 Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `args`.
 
@@ -692,8 +684,7 @@ Since existing `std::pair` implementations don't support `std::piecewise_constru
 
 ==== Copy Insert
 ```c++
-std::pair<iterator, bool>
-insert(value_type const& obj);
+std::pair<iterator, bool> insert(const value_type& obj);
 ```
 
 Inserts `obj` in the container if and only if there is no element in the container with an equivalent key.
@@ -710,8 +701,7 @@ Notes:: Can invalidate iterators, but only if the insert causes the load factor 
 
 ==== Move Insert
 ```c++
-std::pair<iterator, bool>
-insert(value_type&& obj);
+std::pair<iterator, bool> insert(value_type&& obj);
 ```
 
 Inserts `obj` in the container if and only if there is no element in the container with an equivalent key.
@@ -728,9 +718,7 @@ Notes:: Can invalidate iterators, but only if the insert causes the load factor 
 
 ==== Emplace Insert
 ```c++
-template <class P>
-std::pair<iterator, bool>
-insert(P&& value);
+template<class P> std::pair<iterator, bool> insert(P&& obj);
 ```
 
 Inserts an element into the container by performing `emplace(std::forward<P>(value))`.
@@ -741,29 +729,9 @@ Returns:: The bool component of the return type is true if an insert took place.
 
 ---
 
-==== Insert with `node_handle`
-```c++
-insert_return_type
-insert(node_type&& nh);
-```
-
-If `nh` is empty, has no effect.
-
-Otherwise inserts the element owned by `nh` if and only if there is no element in the container with an equivalent key.
-
-Requires:: `nh` is empty or `nh.get_allocator()` is equal to the container's allocator.
-
-Returns:: If `nh` was empty, returns an `insert_return_type` with: `inserted` equal to `false`, `position` equal to `end()` and `node` empty. Otherwise if there was already an element with an equivalent key, returns an `insert_return_type` with: `inserted` equal to `false`, `position` pointing to a matching element and `node` contains the node from `nh`. Otherwise if the insertion succeeded, returns an `insert_return_type` with: `inserted` equal to `true`, `position` pointing to the newly inserted element and `node` empty.
-
-Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-
-Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated. In C++17 this can be used to insert a node extracted from a compatible `unordered_multimap`, but that is not supported yet.
-
----
-
 ==== Copy Insert with Hint
 ```c++
-iterator insert(const_iterator hint, value_type const& obj);
+iterator insert(const_iterator hint, const value_type& obj);
 ```
 Inserts `obj` in the container if and only if there is no element in the container with an equivalent key.
 
@@ -801,9 +769,7 @@ Notes:: The standard is fairly vague on the meaning of the hint. But the only pr
 ==== Emplace Insert with Hint
 
 ```c++
-template <class P>
-std::pair<iterator, bool>
-insert(const_iterator hint, P&& value);
+template<class P> iterator insert(const_iterator hint, P&& obj);
 ```
 
 Inserts an element into the container by performing `emplace_hint(hint, std::forward<P>(value))`.
@@ -815,6 +781,100 @@ Only participates in overload resolution if `std::is_constructible<value_type, P
 Returns:: If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
 
 Notes:: The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated.
+
+---
+
+==== Insert Iterator Range
+```c++
+template<class InputIterator> void insert(InputIterator first, InputIterator last);
+```
+
+Inserts a range of elements into the container. Elements are inserted if and only if there is no element in the container with an equivalent key.
+
+Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `*first`.
+
+Throws:: When inserting a single element, if an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+
+Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated.
+
+---
+
+==== Insert Initializer List
+```c++
+void insert(initializer_list<value_type>);
+```
+
+Inserts a range of elements into the container. Elements are inserted if and only if there is no element in the container with an equivalent key.
+
+Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `*first`.
+
+Throws:: When inserting a single element, if an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+
+Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated.
+
+---
+
+==== Extract by Iterator
+```c++
+node_type extract(const_iterator position);
+```
+
+Removes the element pointed to by `position`.
+
+Returns:: A `node_type` owning the element.
+
+Notes:: In C++17 a node extracted using this method can be inserted into a compatible `unordered_multimap`, but that is not supported yet.
+
+---
+
+==== Extract by Key
+```c++
+node_type extract(const key_type& k);
+```
+
+Removes an element with key equivalent to `k`.
+
+Returns:: A `node_type` owning the element if found, otherwise an empty `node_type`.
+
+Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
+
+Notes:: In C++17 a node extracted using this method can be inserted into a compatible `unordered_multimap`, but that is not supported yet.
+
+---
+
+==== Transparent Extract by Key
+```c++
+template<class K> node_type extract(K&& k);
+```
+
+Removes an element with key equivalent to `k`.
+
+This overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs and neither `iterator` nor `const_iterator` are implicitly convertible from `K`. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
+
+Returns:: A `node_type` owning the element if found, otherwise an empty `node_type`.
+
+Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
+
+Notes:: In C++17 a node extracted using this method can be inserted into a compatible `unordered_multimap`, but that is not supported yet.
+
+---
+
+==== Insert with `node_handle`
+```c++
+insert_return_type insert(node_type&& nh);
+```
+
+If `nh` is empty, has no effect.
+
+Otherwise inserts the element owned by `nh` if and only if there is no element in the container with an equivalent key.
+
+Requires:: `nh` is empty or `nh.get_allocator()` is equal to the container's allocator.
+
+Returns:: If `nh` was empty, returns an `insert_return_type` with: `inserted` equal to `false`, `position` equal to `end()` and `node` empty. Otherwise if there was already an element with an equivalent key, returns an `insert_return_type` with: `inserted` equal to `false`, `position` pointing to a matching element and `node` contains the node from `nh`. Otherwise if the insertion succeeded, returns an `insert_return_type` with: `inserted` equal to `true`, `position` pointing to the newly inserted element and `node` empty.
+
+Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+
+Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated. In C++17 this can be used to insert a node extracted from a compatible `unordered_multimap`, but that is not supported yet.
 
 ---
 
@@ -841,84 +901,10 @@ Notes:: The standard is fairly vague on the meaning of the hint. But the only pr
 
 ---
 
-==== Insert Iterator Range
-```c++
-template<typename InputIterator>
-void insert(InputIterator first, InputIterator last);
-```
-
-Inserts a range of elements into the container. Elements are inserted if and only if there is no element in the container with an equivalent key.
-
-Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `*first`.
-
-Throws:: When inserting a single element, if an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-
-Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated.
-
----
-
-==== Insert Initializer List
-```c++
-void insert(initializer_list<value_type> il);
-```
-
-Inserts a range of elements into the container. Elements are inserted if and only if there is no element in the container with an equivalent key.
-
-Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `*first`.
-
-Throws:: When inserting a single element, if an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-
-Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated.
-
----
-
-==== Extract by Iterator
-```c++
-node_type extract(const_iterator position);
-```
-
-Removes the element pointed to by `position`.
-
-Returns:: A `node_type` owning the element.
-
-Notes:: In C++17 a node extracted using this method can be inserted into a compatible `unordered_multimap`, but that is not supported yet.
-
----
-
-==== Transparent Extract by Key
-```c++
-template<typename K>
-node_type extract(K&& k);
-```
-
-Removes an element with key equivalent to `k`.
-
-This overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs and neither `iterator` nor `const_iterator` are implicitly convertible from `K`. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
-
-Returns:: A `node_type` owning the element if found, otherwise an empty `node_type`.
-
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
-
-Notes:: In C++17 a node extracted using this method can be inserted into a compatible `unordered_multimap`, but that is not supported yet.
-
----
-
-==== Extract by Key
-```c++
-node_type extract(key_type const& k);
-```
-
-Removes an element with key equivalent to `k`.
-
-Returns:: A `node_type` owning the element if found, otherwise an empty `node_type`.
-
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
-
-Notes:: In C++17 a node extracted using this method can be inserted into a compatible `unordered_multimap`, but that is not supported yet.
-
 ==== Erase by Position
 
 ```c++
+iterator erase(iterator position);
 iterator erase(const_iterator position);
 ```
 
@@ -929,6 +915,34 @@ Returns:: The iterator following `position` before the erasure.
 Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
 
 Notes:: In older versions this could be inefficient because it had to search through several buckets to find the position of the returned iterator. The data structure has been changed so that this is no longer the case, and the alternative erase methods have been deprecated.
+
+---
+
+==== Erase by Key
+```c++
+size_type erase(const key_type& k);
+```
+
+Erase all elements with key equivalent to `k`.
+
+Returns:: The number of elements erased.
+
+Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
+
+---
+
+==== Transparent Erase by Key
+```c++
+template<class K> size_type erase(K&& k);
+```
+
+Erase all elements with key equivalent to `k`.
+
+This overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs and neither `iterator` nor `const_iterator` are implicitly convertible from `K`. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
+
+Returns:: The number of elements erased.
+
+Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
 
 ---
 
@@ -943,35 +957,6 @@ Erases the elements in the range from `first` to `last`.
 Returns:: The iterator following the erased elements - i.e. `last`.
 
 Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`. In this implementation, this overload doesn't call either function object's methods so it is no throw, but this might not be true in other implementations.
-
----
-
-==== Transparent Erase by Key
-```c++
-template<typename K>
-size_type erase(K&& k);
-```
-
-Erase all elements with key equivalent to `k`.
-
-This overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs and neither `iterator` nor `const_iterator` are implicitly convertible from `K`. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
-
-Returns:: The number of elements erased.
-
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
-
----
-
-==== Erase by Key
-```c++
-size_type erase(key_type const& k);
-```
-
-Erase all elements with key equivalent to `k`.
-
-Returns:: The number of elements erased.
-
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
 
 ---
 
@@ -1001,6 +986,24 @@ Notes:: This method was implemented because returning an iterator to the next el
 
 ---
 
+==== swap
+```c++
+void swap(unordered_map& other)
+  noexcept(boost::allocator_traits<Allocator>::is_always_equal::value &&
+           boost::is_nothrow_swappable_v<Hash> &&
+           boost::is_nothrow_swappable_v<Pred>);
+```
+
+Swaps the contents of the container with the parameter.
+
+If `Allocator::propagate_on_container_swap` is declared and `Allocator::propagate_on_container_swap::value` is `true` then the containers' allocators are swapped. Otherwise, swapping with unequal allocators results in undefined behavior.
+
+Throws:: Doesn't throw an exception unless it is thrown by the copy constructor or copy assignment operator of `key_equal` or `hasher`.
+
+Notes:: The exception specifications aren't quite the same as the C++11 standard, as the equality predicate and hash function are swapped using their copy constructors.
+
+---
+
 ==== clear
 ```c++
 void clear();
@@ -1014,25 +1017,10 @@ Throws:: Never throws an exception.
 
 ---
 
-==== swap
-```c++
-void swap(unordered_map& other);
-```
-
-Swaps the contents of the container with the parameter.
-
-If `Allocator::propagate_on_container_swap` is declared and `Allocator::propagate_on_container_swap::value` is `true` then the containers' allocators are swapped. Otherwise, swapping with unequal allocators results in undefined behavior.
-
-Throws:: Doesn't throw an exception unless it is thrown by the copy constructor or copy assignment operator of `key_equal` or `hasher`.
-
-Notes:: The exception specifications aren't quite the same as the C++11 standard, as the equality predicate and hash function are swapped using their copy constructors.
-
----
-
 ==== merge
 ```c++
 template<typename H2, typename P2>
-void merge(unordered_map<Key, Mapped, H2, P2, Alloc>& source);
+void merge(unordered_map<Key, T, H2, P2, Alloc>& source);
 ```
 
 Notes:: Does not support merging with a compatible `unordered_multimap` yet.
@@ -1042,7 +1030,7 @@ Notes:: Does not support merging with a compatible `unordered_multimap` yet.
 ==== merge (rvalue reference)
 ```c++
 template<typename H2, typename P2>
-void merge(unordered_map<Key, Mapped, H2, P2, Alloc>&& source);
+void merge(unordered_map<Key, T, H2, P2, Alloc>&& source);
 ```
 
 Notes:: Does not support merging with a compatible `unordered_multimap` yet.
@@ -1056,6 +1044,8 @@ Notes:: Does not support merging with a compatible `unordered_multimap` yet.
 allocator_type get_allocator() const;
 ```
 
+---
+
 ==== hash_function
 ```
 hasher hash_function() const;
@@ -1065,6 +1055,7 @@ Returns:: The container's hash function.
 
 ---
 
+==== key_eq
 ```
 key_equal key_eq() const;
 ```
@@ -1077,34 +1068,18 @@ Returns:: The container's key equality predicate
 
 ==== find
 ```c++
-iterator find(key_type const& k);
-const_iterator find(key_type const& k) const;
-
-template<typename K>
-iterator
-find(K const& k);
-
-template<typename K>
-const_iterator
-find(K const& k) const;
-
-template<
-  typename CompatibleKey,
-  typename CompatibleHash,
-  typename CompatiblePredicate>
-iterator
-find(CompatibleKey const& k,
-     CompatibleHash const& hash,
-     CompatiblePredicate const& eq);
-
-template<
-  typename CompatibleKey,
-  typename CompatibleHash,
-  typename CompatiblePredicate>
-const_iterator
-find(CompatibleKey const& k,
-      CompatibleHash const& hash,
-      CompatiblePredicate const& eq) const;
+iterator         find(const key_type& k);
+const_iterator   find(const key_type& k) const;
+template<class K>
+  iterator       find(const K& k);
+template<class K>
+  const_iterator find(const K& k) const;
+template<typename CompatibleKey, typename CompatibleHash, typename CompatiblePredicate>
+  iterator       find(CompatibleKey const& k, CompatibleHash const& hash,
+                      CompatiblePredicate const& eq);
+template<typename CompatibleKey, typename CompatibleHash, typename CompatiblePredicate>
+  const_iterator find(CompatibleKey const& k, CompatibleHash const& hash,
+                      CompatiblePredicate const& eq) const;
 
 ```
 
@@ -1115,24 +1090,11 @@ The `template <typename K>` overloads only participate in overload resolution if
 
 ---
 
-==== contains
-```c++
-template<typename K>
-bool contains(K const& key);
-bool contains(key_type const& key) const;
-```
-
-Returns:: A boolean indicating whether or not there is an element with key equal to `key` in the container
-
-Notes:: The `template <typename K>` overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
-
----
-
 ==== count
 ```c++
-template<typename K>
-size_type count(K const& k) const;
-size_type count(key_type const& k) const;
+size_type        count(const key_type& k) const;
+template<class K>
+  size_type      count(const K& k) const;
 ```
 
 Returns:: The number of elements with key equivalent to `k`.
@@ -1141,21 +1103,27 @@ Notes:: The `template <typename K>` overload only participates in overload resol
 
 ---
 
+==== contains
+```c++
+bool             contains(const key_type& k) const;
+template<class K>
+  bool           contains(const K& k) const;
+```
+
+Returns:: A boolean indicating whether or not there is an element with key equal to `key` in the container
+
+Notes:: The `template <typename K>` overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
+
+---
+
 ==== equal_range
 ```c++
-std::pair<iterator, iterator>
-equal_range(key_type const& k);
-
-std::pair<const_iterator, const_iterator>
-equal_range(key_type const& k) const;
-
-template<typename K>
-std::pair<iterator, iterator>
-equal_range(K const& k);
-
-template<typename K>
-std::pair<const_iterator, const_iterator>
-equal_range(K const& k) const;
+pair<iterator, iterator>               equal_range(const key_type& k);
+pair<const_iterator, const_iterator>   equal_range(const key_type& k) const;
+template<class K>
+  pair<iterator, iterator>             equal_range(const K& k);
+template<class K>
+  pair<const_iterator, const_iterator> equal_range(const K& k) const;
 ```
 
 Returns:: A range containing all elements with key equivalent to `k`. If the container doesn't contain any such elements, returns `std::make_pair(b.end(), b.end())`.
@@ -1166,7 +1134,8 @@ Notes:: The `template <typename K>` overloads only participate in overload resol
 
 ==== operator++[++++]++
 ```c++
-mapped_type& operator[](key_type const& k);
+mapped_type& operator[](const key_type& k);
+mapped_type& operator[](key_type&& k);
 ```
 
 Effects:: If the container does not already contain an elements with a key equivalent to `k`, inserts the value `std::pair<key_type const, mapped_type>(k, mapped_type())`.
@@ -1181,8 +1150,8 @@ Notes:: Can invalidate iterators, but only if the insert causes the load factor 
 
 ==== at
 ```c++
-Mapped& at(key_type const& k);
-Mapped const& at(key_type const& k) const;
+mapped_type& at(const key_type& k);
+const mapped_type& at(const key_type& k) const;
 ```
 
 Returns:: A reference to `x.second` where `x` is the (unique) element whose key is equivalent to `k`.
@@ -1195,7 +1164,7 @@ Throws:: An exception object of type `std::out_of_range` if no such element is p
 
 ==== bucket_count
 ```c++
-size_type bucket_count() const;
+size_type bucket_count() const noexcept;
 ```
 
 Returns:: The number of buckets.
@@ -1204,7 +1173,7 @@ Returns:: The number of buckets.
 
 ==== max_bucket_count
 ```c++
-size_type max_bucket_count() const;
+size_type max_bucket_count() const noexcept;
 ```
 
 Returns:: An upper bound on the number of buckets.
@@ -1224,7 +1193,7 @@ Returns:: The number of elements in bucket `n`.
 
 ==== bucket
 ```c++
-size_type bucket(key_type const& k) const;
+size_type bucket(const key_type& k) const;
 ```
 
 Returns:: The index of the bucket which would contain an element with key `k`.
@@ -1284,7 +1253,7 @@ Returns:: A constant local iterator pointing the 'one past the end' element in t
 
 ==== load_factor
 ```c++
-float load_factor() const;
+float load_factor() const noexcept;
 ```
 
 Returns:: The average number of elements per bucket.
@@ -1294,7 +1263,7 @@ Returns:: The average number of elements per bucket.
 ==== max_load_factor
 
 ```c++
-float max_load_factor() const;
+float max_load_factor() const noexcept;
 ```
 
 Returns:: Returns the current maximum load factor.
@@ -1337,14 +1306,9 @@ Throws:: The function has no effect if an exception is thrown, unless it is thro
 
 ==== operator==
 ```c++
-template<
-  typename Key,
-  typename Mapped,
-  typename Hash,
-  typename Pred,
-  typename Alloc>
-bool operator==(unordered_map<Key, Mapped, Hash, Pred, Alloc> const& x,
-                unordered_map<Key, Mapped, Hash, Pred, Alloc> const& y);
+template<class Key, class T, class Hash, class Pred, class Alloc>
+  bool operator==(const unordered_map<Key, T, Hash, Pred, Alloc>& x,
+                  const unordered_map<Key, T, Hash, Pred, Alloc>& y);
 ```
 
 Return `true` if `x.size() == y.size()` and for every element in `x`, there is an element in `y` with the same key, with an equal value (using `operator==` to compare the value types).
@@ -1355,14 +1319,9 @@ Notes:: The behavior of this function was changed to match the C++11 standard in
 
 ==== operator!=
 ```c++
-template<
-  typename Key,
-  typename Mapped,
-  typename Hash,
-  typename Pred,
-  typename Alloc>
-bool operator!=(unordered_map<Key, Mapped, Hash, Pred, Alloc> const& x,
-                unordered_map<Key, Mapped, Hash, Pred, Alloc> const& y);
+template<class Key, class T, class Hash, class Pred, class Alloc>
+  bool operator!=(const unordered_map<Key, T, Hash, Pred, Alloc>& x,
+                  const unordered_map<Key, T, Hash, Pred, Alloc>& y);
 ```
 
 Return `false` if `x.size() == y.size()` and for every element in `x`, there is an element in `y` with the same key, with an equal value (using `operator==` to compare the value types).
@@ -1371,10 +1330,10 @@ Notes:: The behavior of this function was changed to match the C++11 standard in
 
 === Swap
 ```c++
-template<typename Key, typename Mapped, typename Hash, typename Pred,
-         typename Alloc>
-void swap(unordered_map<Key, Mapped, Hash, Pred, Alloc>& x,
-          unordered_map<Key, Mapped, Hash, Pred, Alloc>& y);
+template<class Key, class T, class Hash, class Pred, class Alloc>
+  void swap(unordered_map<Key, T, Hash, Pred, Alloc>& x,
+            unordered_map<Key, T, Hash, Pred, Alloc>& y)
+    noexcept(noexcept(x.swap(y)));
 ```
 
 Swaps the contents of `x` and `y`.

--- a/doc/unordered/unordered_map.adoc
+++ b/doc/unordered/unordered_map.adoc
@@ -401,6 +401,7 @@ The copy constructor. Copies the contained elements, hash function, predicate, m
 
 If `Allocator::select_on_container_copy_construction` exists and has the right signature, the allocator will be constructed from its result.
 
+[horizontal]
 Requires:: `value_type` is copy constructible
 
 ---
@@ -414,7 +415,9 @@ The move constructor.
 
 [horizontal]
 Notes:: This is implemented using Boost.Move.
-Requires:: `value_type` is move-constructible. On compilers without rvalue reference support the emulation does not support moving without calling `boost::move` if `value_type` is not copyable.
+Requires:: `value_type` is move-constructible. +
++
+On compilers without rvalue reference support the emulation does not support moving without calling `boost::move` if `value_type` is not copyable.
 So, for example, you can't return the container from a function.
 
 ---
@@ -574,6 +577,7 @@ unordered_map& operator=(initializer_list<value_type> il);
 
 Assign from values in initializer list. All existing elements are either overwritten by the new elements or destroyed.
 
+[horizontal]
 Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/CopyInsertable[CopyInsertable^] into the container and https://en.cppreference.com/w/cpp/named_req/CopyAssignable[CopyAssignable^].
 
 === Iterators
@@ -667,11 +671,15 @@ Inserts an object, constructed with the arguments `args`, in the container if an
 [horizontal]
 Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `args`.
 Returns:: The bool component of the return type is true if an insert took place. +
++
 If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
 Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor.
-Pointers and references to elements are never invalidated.
-If the compiler doesn't support variadic template arguments or rvalue references, this is emulated for up to `10` arguments, with no support for rvalue references or move semantics.
+Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated. +
++
+If the compiler doesn't support variadic template arguments or rvalue references, this is emulated for up to `10` arguments, with no support for rvalue references or move semantics. +
++
 Since existing `std::pair` implementations don't support `std::piecewise_construct` this emulates it, but using `boost::unordered::piecewise_construct`.
 
 ---
@@ -689,10 +697,14 @@ Inserts an object, constructed with the arguments `args`, in the container if an
 Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `args`.
 Returns:: If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
 Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-Notes:: The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key.
-Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor.
-Pointers and references to elements are never invalidated.
-If the compiler doesn't support variadic template arguments or rvalue references, this is emulated for up to 10 arguments, with no support for rvalue references or move semantics.
+Notes:: The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. +
++
+Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated. +
++
+If the compiler doesn't support variadic template arguments or rvalue references, this is emulated for up to 10 arguments, with no support for rvalue references or move semantics. +
++
 Since existing `std::pair` implementations don't support `std::piecewise_construct` this emulates it, but using `boost::unordered::piecewise_construct`.
 
 ---
@@ -706,9 +718,13 @@ Inserts `obj` in the container if and only if there is no element in the contain
 
 [horizontal]
 Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/CopyInsertable[CopyInsertable^].
-Returns:: The bool component of the return type is true if an insert took place. If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
+Returns:: The bool component of the return type is true if an insert took place. +
++
+If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
 Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated.
+Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated.
 
 ---
 
@@ -721,9 +737,13 @@ Inserts `obj` in the container if and only if there is no element in the contain
 
 [horizontal]
 Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/MoveInsertable[MoveInsertable^].
-Returns:: The bool component of the return type is true if an insert took place. If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
+Returns:: The bool component of the return type is true if an insert took place. +
++
+If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
 Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated.
+Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated.
 
 ---
 
@@ -737,7 +757,9 @@ Inserts an element into the container by performing `emplace(std::forward<P>(val
 Only participates in overload resolution if `std::is_constructible<value_type, P&&>::value` is `true`.
 
 [horizontal]
-Returns:: The bool component of the return type is true if an insert took place. If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
+Returns:: The bool component of the return type is true if an insert took place. +
++
+If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
 
 ---
 
@@ -753,7 +775,11 @@ Inserts `obj` in the container if and only if there is no element in the contain
 Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/CopyInsertable[CopyInsertable^].
 Returns:: If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
 Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-Notes:: The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated.
+Notes:: The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. +
++
+Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated.
 
 ---
 
@@ -770,7 +796,11 @@ Inserts `obj` in the container if and only if there is no element in the contain
 Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/MoveInsertable[MoveInsertable^].
 Returns:: If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
 Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-Notes:: The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated.
+Notes:: The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. +
++
+Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated.
 
 ---
 
@@ -788,7 +818,11 @@ Only participates in overload resolution if `std::is_constructible<value_type, P
 
 [horizontal]
 Returns:: If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
-Notes:: The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated.
+Notes:: The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. +
++
+Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated.
 
 ---
 
@@ -802,7 +836,9 @@ Inserts a range of elements into the container. Elements are inserted if and onl
 [horizontal]
 Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `*first`.
 Throws:: When inserting a single element, if an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated.
+Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated.
 
 ---
 
@@ -816,7 +852,9 @@ Inserts a range of elements into the container. Elements are inserted if and onl
 [horizontal]
 Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `*first`.
 Throws:: When inserting a single element, if an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated.
+Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated.
 
 ---
 
@@ -874,9 +912,17 @@ Otherwise inserts the element owned by `nh` if and only if there is no element i
 
 [horizontal]
 Requires:: `nh` is empty or `nh.get_allocator()` is equal to the container's allocator.
-Returns:: If `nh` was empty, returns an `insert_return_type` with: `inserted` equal to `false`, `position` equal to `end()` and `node` empty. Otherwise if there was already an element with an equivalent key, returns an `insert_return_type` with: `inserted` equal to `false`, `position` pointing to a matching element and `node` contains the node from `nh`. Otherwise if the insertion succeeded, returns an `insert_return_type` with: `inserted` equal to `true`, `position` pointing to the newly inserted element and `node` empty.
+Returns:: If `nh` was empty, returns an `insert_return_type` with: `inserted` equal to `false`, `position` equal to `end()` and `node` empty. +
++
+Otherwise if there was already an element with an equivalent key, returns an `insert_return_type` with: `inserted` equal to `false`, `position` pointing to a matching element and `node` contains the node from `nh`. +
++
+Otherwise if the insertion succeeded, returns an `insert_return_type` with: `inserted` equal to `true`, `position` pointing to the newly inserted element and `node` empty.
 Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated. In C++17 this can be used to insert a node extracted from a compatible `unordered_multimap`, but that is not supported yet.
+Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated. +
++
+In C++17 this can be used to insert a node extracted from a compatible `unordered_multimap`, but that is not supported yet.
 
 ---
 
@@ -895,9 +941,19 @@ If there is already an element in the container with an equivalent key has no ef
 
 [horizontal]
 Requires:: `nh` is empty or `nh.get_allocator()` is equal to the container's allocator.
-Returns:: If `nh` was empty returns `end()`. If there was already an element in the container with an equivalent key returns an iterator pointing to that. Otherwise returns an iterator pointing to the newly inserted element.
+Returns:: If `nh` was empty returns `end()`. +
++
+If there was already an element in the container with an equivalent key returns an iterator pointing to that. +
++
+Otherwise returns an iterator pointing to the newly inserted element.
 Throws:: If an exception is thrown by an operation other than a call to hasher the function has no effect.
-Notes:: The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated. In C++17 this can be used to insert a node extracted from a compatible `unordered_multimap`, but that is not supported yet.
+Notes:: The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. +
++
+Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated. +
++
+In C++17 this can be used to insert a node extracted from a compatible `unordered_multimap`, but that is not supported yet.
 
 ---
 
@@ -955,7 +1011,9 @@ Erases the elements in the range from `first` to `last`.
 
 [horizontal]
 Returns:: The iterator following the erased elements - i.e. `last`.
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`. In this implementation, this overload doesn't call either function object's methods so it is no throw, but this might not be true in other implementations.
+Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`. +
++
+In this implementation, this overload doesn't call either function object's methods so it is no throw, but this might not be true in other implementations.
 
 ---
 
@@ -967,7 +1025,9 @@ void quick_erase(const_iterator position);
 Erase the element pointed to by `position`.
 
 [horizontal]
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`. In this implementation, this overload doesn't call either function object's methods so it is no throw, but this might not be true in other implementations.
+Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`. +
++
+In this implementation, this overload doesn't call either function object's methods so it is no throw, but this might not be true in other implementations.
 Notes:: This method was implemented because returning an iterator to the next element from erase was expensive, but the container has been redesigned so that is no longer the case. So this method is now deprecated.
 
 ---
@@ -980,7 +1040,9 @@ void erase_return_void(const_iterator position);
 Erase the element pointed to by `position`.
 
 [horizontal]
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`. In this implementation, this overload doesn't call either function object's methods so it is no throw, but this might not be true in other implementations.
+Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`. +
++
+In this implementation, this overload doesn't call either function object's methods so it is no throw, but this might not be true in other implementations.
 Notes:: This method was implemented because returning an iterator to the next element from erase was expensive, but the container has been redesigned so that is no longer the case. So this method is now deprecated.
 
 ---
@@ -1089,6 +1151,7 @@ template<typename CompatibleKey, typename CompatibleHash, typename CompatiblePre
 [horizontal]
 Returns:: An iterator pointing to an element with key equivalent to `k`, or `b.end()` if no such element exists.
 Notes:: The templated overloads containing `CompatibleKey`, `CompatibleHash` and `CompatiblePredicate` are non-standard extensions which allow you to use a compatible hash function and equality predicate for a key of a different type in order to avoid an expensive type cast. In general, its use is not encouraged and instead the `K` member function templates should be used. +
++
 The `template <typename K>` overloads only participate in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
 
 ---
@@ -1145,7 +1208,9 @@ mapped_type& operator[](key_type&& k);
 Effects:: If the container does not already contain an elements with a key equivalent to `k`, inserts the value `std::pair<key_type const, mapped_type>(k, mapped_type())`.
 Returns:: A reference to `x.second` where `x` is the element already in the container, or the newly inserted element with a key equivalent to `k`.
 Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated.
+Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated.
 
 ---
 
@@ -1322,7 +1387,9 @@ template<class Key, class T, class Hash, class Pred, class Alloc>
 Return `true` if `x.size() == y.size()` and for every element in `x`, there is an element in `y` with the same key, with an equal value (using `operator==` to compare the value types).
 
 [horizontal]
-Notes:: The behavior of this function was changed to match the C++11 standard in Boost 1.48. Behavior is undefined if the two containers don't have equivalent equality predicates.
+Notes:: The behavior of this function was changed to match the C++11 standard in Boost 1.48. +
++
+Behavior is undefined if the two containers don't have equivalent equality predicates.
 
 ---
 
@@ -1336,7 +1403,9 @@ template<class Key, class T, class Hash, class Pred, class Alloc>
 Return `false` if `x.size() == y.size()` and for every element in `x`, there is an element in `y` with the same key, with an equal value (using `operator==` to compare the value types).
 
 [horizontal]
-Notes:: The behavior of this function was changed to match the C++11 standard in Boost 1.48. Behavior is undefined if the two containers don't have equivalent equality predicates.
+Notes:: The behavior of this function was changed to match the C++11 standard in Boost 1.48. +
++
+Behavior is undefined if the two containers don't have equivalent equality predicates.
 
 === Swap
 ```c++

--- a/doc/unordered/unordered_map.adoc
+++ b/doc/unordered/unordered_map.adoc
@@ -351,8 +351,8 @@ Constructs an empty container using `hasher()` as the hash function,
 and a maximum load factor of `1.0`.
 
 [horizontal]
-Postconditions:: `size() == 0`
-Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+Postconditions:;; `size() == 0`
+Requires:;; If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
 ---
 
@@ -369,8 +369,8 @@ function, `eql` as the key equality predicate, `a` as the allocator and a maximu
 load factor of `1.0`.
 
 [horizontal]
-Postconditions:: `size() == 0`
-Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+Postconditions:;; `size() == 0`
+Requires:;; If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
 ---
 
@@ -388,7 +388,7 @@ template<class InputIterator>
 Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `eql` as the key equality predicate, `a` as the allocator and a maximum load factor of `1.0` and inserts the elements from `[f, l)` into it.
 
 [horizontal]
-Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+Requires:;; If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
 ---
 
@@ -402,7 +402,7 @@ The copy constructor. Copies the contained elements, hash function, predicate, m
 If `Allocator::select_on_container_copy_construction` exists and has the right signature, the allocator will be constructed from its result.
 
 [horizontal]
-Requires:: `value_type` is copy constructible
+Requires:;; `value_type` is copy constructible
 
 ---
 
@@ -414,8 +414,8 @@ unordered_map(unordered_map&& other);
 The move constructor.
 
 [horizontal]
-Notes:: This is implemented using Boost.Move.
-Requires:: `value_type` is move-constructible. +
+Notes:;; This is implemented using Boost.Move.
+Requires:;; `value_type` is move-constructible. +
 +
 On compilers without rvalue reference support the emulation does not support moving without calling `boost::move` if `value_type` is not copyable.
 So, for example, you can't return the container from a function.
@@ -448,8 +448,8 @@ unordered_map(unordered_map&& other, Allocator const& a);
 Construct a container moving ``other``'s contained elements, and having the hash function, predicate and maximum load factor, but using allocate `a`.
 
 [horizontal]
-Notes:: This is implemented using Boost.Move.
-Requires:: `value_type` is move insertable.
+Notes:;; This is implemented using Boost.Move.
+Requires:;; `value_type` is move insertable.
 
 ---
 
@@ -466,7 +466,7 @@ unordered_map(initializer_list<value_type> il,
 Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `eql` as the key equality predicate, `a` as the allocator and a maximum load factor of `1.0` and inserts the elements from `il` into it.
 
 [horizontal]
-Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+Requires:;; If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
 ---
 
@@ -478,8 +478,8 @@ unordered_map(size_type n, allocator_type const& a);
 Constructs an empty container with at least `n` buckets, using `hf` as the hash function, the default hash function and key equality predicate, `a` as the allocator and a maximum load factor of `1.0`.
 
 [horizontal]
-Postconditions:: `size() == 0`
-Requires:: `hasher` and `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+Postconditions:;; `size() == 0`
+Requires:;; `hasher` and `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
 ---
 
@@ -491,8 +491,8 @@ unordered_map(size_type n, hasher const& hf, allocator_type const& a);
 Constructs an empty container with at least `n` buckets, using `hf` as the hash function, the default key equality predicate, `a` as the allocator and a maximum load factor of `1.0`.
 
 [horizontal]
-Postconditions:: `size() == 0`
-Requires:: `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+Postconditions:;; `size() == 0`
+Requires:;; `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
 ---
 
@@ -506,7 +506,7 @@ template<class InputIterator>
 Constructs an empty container with at least `n` buckets, using `a` as the allocator, with the default hash function and key equality predicate and a maximum load factor of `1.0` and inserts the elements from `[f, l)` into it.
 
 [horizontal]
-Requires:: `hasher`, `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+Requires:;; `hasher`, `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
 ---
 
@@ -521,7 +521,7 @@ Requires:: `hasher`, `key_equal` need to be https://en.cppreference.com/w/cpp/na
 Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `a` as the allocator, with the default key equality predicate and a maximum load factor of `1.0` and inserts the elements from `[f, l)` into it.
 
 [horizontal]
-Requires:: `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+Requires:;; `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
 ---
 
@@ -532,7 +532,7 @@ Requires:: `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/D
 ```
 
 [horizontal]
-Note:: The destructor is applied to every element, and all memory is deallocated
+Note:;; The destructor is applied to every element, and all memory is deallocated
 
 ---
 
@@ -549,7 +549,7 @@ The assignment operator. Copies the contained elements, hash function, predicate
 If `Alloc::propagate_on_container_copy_assignment` exists and `Alloc::propagate_on_container_copy_assignment::value` is `true`, the allocator is overwritten, if not the copied elements are created using the existing allocator.
 
 [horizontal]
-Requires:: `value_type` is copy constructible
+Requires:;; `value_type` is copy constructible
 
 ---
 
@@ -565,8 +565,8 @@ The move assignment operator.
 If `Alloc::propagate_on_container_move_assignment` exists and `Alloc::propagate_on_container_move_assignment::value` is `true`, the allocator is overwritten, if not the moved elements are created using the existing allocator.
 
 [horizontal]
-Notes:: On compilers without rvalue references, this is emulated using Boost.Move. Note that on some compilers the copy assignment operator may be used in some circumstances.
-Requires:: `value_type` is move constructible.
+Notes:;; On compilers without rvalue references, this is emulated using Boost.Move. Note that on some compilers the copy assignment operator may be used in some circumstances.
+Requires:;; `value_type` is move constructible.
 
 ---
 
@@ -578,7 +578,7 @@ unordered_map& operator=(initializer_list<value_type> il);
 Assign from values in initializer list. All existing elements are either overwritten by the new elements or destroyed.
 
 [horizontal]
-Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/CopyInsertable[CopyInsertable^] into the container and https://en.cppreference.com/w/cpp/named_req/CopyAssignable[CopyAssignable^].
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/CopyInsertable[CopyInsertable^] into the container and https://en.cppreference.com/w/cpp/named_req/CopyAssignable[CopyAssignable^].
 
 === Iterators
 
@@ -589,7 +589,7 @@ const_iterator begin() const noexcept;
 ```
 
 [horizontal]
-Returns:: An iterator referring to the first element of the container, or if the container is empty the past-the-end value for the container.
+Returns:;; An iterator referring to the first element of the container, or if the container is empty the past-the-end value for the container.
 
 ---
 
@@ -600,7 +600,7 @@ const_iterator end() const noexcept;
 ```
 
 [horizontal]
-Returns:: An iterator which refers to the past-the-end value for the container.
+Returns:;; An iterator which refers to the past-the-end value for the container.
 
 ---
 
@@ -610,7 +610,7 @@ const_iterator cbegin() const noexcept;
 ```
 
 [horizontal]
-Returns:: A `const_iterator` referring to the first element of the container, or if the container is empty the past-the-end value for the container.
+Returns:;; A `const_iterator` referring to the first element of the container, or if the container is empty the past-the-end value for the container.
 
 ---
 
@@ -620,7 +620,7 @@ const_iterator cend() const noexcept;
 ```
 
 [horizontal]
-Returns:: A `const_iterator` which refers to the past-the-end value for the container.
+Returns:;; A `const_iterator` which refers to the past-the-end value for the container.
 
 ---
 
@@ -633,7 +633,7 @@ bool empty() const noexcept;
 ```
 
 [horizontal]
-Returns:: `size() == 0`
+Returns:;; `size() == 0`
 
 ---
 
@@ -644,7 +644,7 @@ size_type size() const noexcept;
 ```
 
 [horizontal]
-Returns:: `std::distance(begin(), end())`
+Returns:;; `std::distance(begin(), end())`
 
 ---
 
@@ -655,7 +655,7 @@ size_type max_size() const noexcept;
 ```
 
 [horizontal]
-Returns:: `size()` of the largest possible container.
+Returns:;; `size()` of the largest possible container.
 
 ---
 
@@ -669,12 +669,12 @@ template<class... Args> std::pair<iterator, bool> emplace(Args&&... args);
 Inserts an object, constructed with the arguments `args`, in the container if and only if there is no element in the container with an equivalent key.
 
 [horizontal]
-Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `args`.
-Returns:: The bool component of the return type is true if an insert took place. +
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `args`.
+Returns:;; The bool component of the return type is true if an insert took place. +
 +
 If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
-Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
+Throws:;; If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
 +
 Pointers and references to elements are never invalidated. +
 +
@@ -694,10 +694,10 @@ Inserts an object, constructed with the arguments `args`, in the container if an
 `position` is a suggestion to where the element should be inserted.
 
 [horizontal]
-Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `args`.
-Returns:: If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
-Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-Notes:: The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. +
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `args`.
+Returns:;; If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
+Throws:;; If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. +
 +
 Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
 +
@@ -717,12 +717,12 @@ std::pair<iterator, bool> insert(const value_type& obj);
 Inserts `obj` in the container if and only if there is no element in the container with an equivalent key.
 
 [horizontal]
-Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/CopyInsertable[CopyInsertable^].
-Returns:: The bool component of the return type is true if an insert took place. +
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/CopyInsertable[CopyInsertable^].
+Returns:;; The bool component of the return type is true if an insert took place. +
 +
 If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
-Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
+Throws:;; If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
 +
 Pointers and references to elements are never invalidated.
 
@@ -736,12 +736,12 @@ std::pair<iterator, bool> insert(value_type&& obj);
 Inserts `obj` in the container if and only if there is no element in the container with an equivalent key.
 
 [horizontal]
-Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/MoveInsertable[MoveInsertable^].
-Returns:: The bool component of the return type is true if an insert took place. +
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/MoveInsertable[MoveInsertable^].
+Returns:;; The bool component of the return type is true if an insert took place. +
 +
 If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
-Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
+Throws:;; If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
 +
 Pointers and references to elements are never invalidated.
 
@@ -757,7 +757,7 @@ Inserts an element into the container by performing `emplace(std::forward<P>(val
 Only participates in overload resolution if `std::is_constructible<value_type, P&&>::value` is `true`.
 
 [horizontal]
-Returns:: The bool component of the return type is true if an insert took place. +
+Returns:;; The bool component of the return type is true if an insert took place. +
 +
 If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
 
@@ -772,10 +772,10 @@ Inserts `obj` in the container if and only if there is no element in the contain
 `hint` is a suggestion to where the element should be inserted.
 
 [horizontal]
-Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/CopyInsertable[CopyInsertable^].
-Returns:: If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
-Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-Notes:: The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. +
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/CopyInsertable[CopyInsertable^].
+Returns:;; If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
+Throws:;; If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. +
 +
 Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
 +
@@ -793,10 +793,10 @@ Inserts `obj` in the container if and only if there is no element in the contain
 `hint` is a suggestion to where the element should be inserted.
 
 [horizontal]
-Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/MoveInsertable[MoveInsertable^].
-Returns:: If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
-Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-Notes:: The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. +
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/MoveInsertable[MoveInsertable^].
+Returns:;; If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
+Throws:;; If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. +
 +
 Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
 +
@@ -817,8 +817,8 @@ Only participates in overload resolution if `std::is_constructible<value_type, P
 `hint` is a suggestion to where the element should be inserted.
 
 [horizontal]
-Returns:: If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
-Notes:: The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. +
+Returns:;; If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
+Notes:;; The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. +
 +
 Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
 +
@@ -834,9 +834,9 @@ template<class InputIterator> void insert(InputIterator first, InputIterator las
 Inserts a range of elements into the container. Elements are inserted if and only if there is no element in the container with an equivalent key.
 
 [horizontal]
-Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `*first`.
-Throws:: When inserting a single element, if an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `*first`.
+Throws:;; When inserting a single element, if an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
 +
 Pointers and references to elements are never invalidated.
 
@@ -850,9 +850,9 @@ void insert(initializer_list<value_type>);
 Inserts a range of elements into the container. Elements are inserted if and only if there is no element in the container with an equivalent key.
 
 [horizontal]
-Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `*first`.
-Throws:: When inserting a single element, if an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `*first`.
+Throws:;; When inserting a single element, if an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
 +
 Pointers and references to elements are never invalidated.
 
@@ -866,8 +866,8 @@ node_type extract(const_iterator position);
 Removes the element pointed to by `position`.
 
 [horizontal]
-Returns:: A `node_type` owning the element.
-Notes:: In C++17 a node extracted using this method can be inserted into a compatible `unordered_multimap`, but that is not supported yet.
+Returns:;; A `node_type` owning the element.
+Notes:;; In C++17 a node extracted using this method can be inserted into a compatible `unordered_multimap`, but that is not supported yet.
 
 ---
 
@@ -879,9 +879,9 @@ node_type extract(const key_type& k);
 Removes an element with key equivalent to `k`.
 
 [horizontal]
-Returns:: A `node_type` owning the element if found, otherwise an empty `node_type`.
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
-Notes:: In C++17 a node extracted using this method can be inserted into a compatible `unordered_multimap`, but that is not supported yet.
+Returns:;; A `node_type` owning the element if found, otherwise an empty `node_type`.
+Throws:;; Only throws an exception if it is thrown by `hasher` or `key_equal`.
+Notes:;; In C++17 a node extracted using this method can be inserted into a compatible `unordered_multimap`, but that is not supported yet.
 
 ---
 
@@ -895,9 +895,9 @@ Removes an element with key equivalent to `k`.
 This overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs and neither `iterator` nor `const_iterator` are implicitly convertible from `K`. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
 
 [horizontal]
-Returns:: A `node_type` owning the element if found, otherwise an empty `node_type`.
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
-Notes:: In C++17 a node extracted using this method can be inserted into a compatible `unordered_multimap`, but that is not supported yet.
+Returns:;; A `node_type` owning the element if found, otherwise an empty `node_type`.
+Throws:;; Only throws an exception if it is thrown by `hasher` or `key_equal`.
+Notes:;; In C++17 a node extracted using this method can be inserted into a compatible `unordered_multimap`, but that is not supported yet.
 
 ---
 
@@ -911,14 +911,14 @@ If `nh` is empty, has no effect.
 Otherwise inserts the element owned by `nh` if and only if there is no element in the container with an equivalent key.
 
 [horizontal]
-Requires:: `nh` is empty or `nh.get_allocator()` is equal to the container's allocator.
-Returns:: If `nh` was empty, returns an `insert_return_type` with: `inserted` equal to `false`, `position` equal to `end()` and `node` empty. +
+Requires:;; `nh` is empty or `nh.get_allocator()` is equal to the container's allocator.
+Returns:;; If `nh` was empty, returns an `insert_return_type` with: `inserted` equal to `false`, `position` equal to `end()` and `node` empty. +
 +
 Otherwise if there was already an element with an equivalent key, returns an `insert_return_type` with: `inserted` equal to `false`, `position` pointing to a matching element and `node` contains the node from `nh`. +
 +
 Otherwise if the insertion succeeded, returns an `insert_return_type` with: `inserted` equal to `true`, `position` pointing to the newly inserted element and `node` empty.
-Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
+Throws:;; If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
 +
 Pointers and references to elements are never invalidated. +
 +
@@ -940,14 +940,14 @@ If there is already an element in the container with an equivalent key has no ef
 `hint` is a suggestion to where the element should be inserted.
 
 [horizontal]
-Requires:: `nh` is empty or `nh.get_allocator()` is equal to the container's allocator.
-Returns:: If `nh` was empty returns `end()`. +
+Requires:;; `nh` is empty or `nh.get_allocator()` is equal to the container's allocator.
+Returns:;; If `nh` was empty returns `end()`. +
 +
 If there was already an element in the container with an equivalent key returns an iterator pointing to that. +
 +
 Otherwise returns an iterator pointing to the newly inserted element.
-Throws:: If an exception is thrown by an operation other than a call to hasher the function has no effect.
-Notes:: The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. +
+Throws:;; If an exception is thrown by an operation other than a call to hasher the function has no effect.
+Notes:;; The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. +
 +
 Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
 +
@@ -967,9 +967,9 @@ iterator erase(const_iterator position);
 Erase the element pointed to by `position`.
 
 [horizontal]
-Returns:: The iterator following `position` before the erasure.
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
-Notes:: In older versions this could be inefficient because it had to search through several buckets to find the position of the returned iterator. The data structure has been changed so that this is no longer the case, and the alternative erase methods have been deprecated.
+Returns:;; The iterator following `position` before the erasure.
+Throws:;; Only throws an exception if it is thrown by `hasher` or `key_equal`.
+Notes:;; In older versions this could be inefficient because it had to search through several buckets to find the position of the returned iterator. The data structure has been changed so that this is no longer the case, and the alternative erase methods have been deprecated.
 
 ---
 
@@ -981,8 +981,8 @@ size_type erase(const key_type& k);
 Erase all elements with key equivalent to `k`.
 
 [horizontal]
-Returns:: The number of elements erased.
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
+Returns:;; The number of elements erased.
+Throws:;; Only throws an exception if it is thrown by `hasher` or `key_equal`.
 
 ---
 
@@ -996,8 +996,8 @@ Erase all elements with key equivalent to `k`.
 This overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs and neither `iterator` nor `const_iterator` are implicitly convertible from `K`. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
 
 [horizontal]
-Returns:: The number of elements erased.
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
+Returns:;; The number of elements erased.
+Throws:;; Only throws an exception if it is thrown by `hasher` or `key_equal`.
 
 ---
 
@@ -1010,8 +1010,8 @@ iterator erase(const_iterator first, const_iterator last);
 Erases the elements in the range from `first` to `last`.
 
 [horizontal]
-Returns:: The iterator following the erased elements - i.e. `last`.
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`. +
+Returns:;; The iterator following the erased elements - i.e. `last`.
+Throws:;; Only throws an exception if it is thrown by `hasher` or `key_equal`. +
 +
 In this implementation, this overload doesn't call either function object's methods so it is no throw, but this might not be true in other implementations.
 
@@ -1025,10 +1025,10 @@ void quick_erase(const_iterator position);
 Erase the element pointed to by `position`.
 
 [horizontal]
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`. +
+Throws:;; Only throws an exception if it is thrown by `hasher` or `key_equal`. +
 +
 In this implementation, this overload doesn't call either function object's methods so it is no throw, but this might not be true in other implementations.
-Notes:: This method was implemented because returning an iterator to the next element from erase was expensive, but the container has been redesigned so that is no longer the case. So this method is now deprecated.
+Notes:;; This method was implemented because returning an iterator to the next element from erase was expensive, but the container has been redesigned so that is no longer the case. So this method is now deprecated.
 
 ---
 
@@ -1040,10 +1040,10 @@ void erase_return_void(const_iterator position);
 Erase the element pointed to by `position`.
 
 [horizontal]
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`. +
+Throws:;; Only throws an exception if it is thrown by `hasher` or `key_equal`. +
 +
 In this implementation, this overload doesn't call either function object's methods so it is no throw, but this might not be true in other implementations.
-Notes:: This method was implemented because returning an iterator to the next element from erase was expensive, but the container has been redesigned so that is no longer the case. So this method is now deprecated.
+Notes:;; This method was implemented because returning an iterator to the next element from erase was expensive, but the container has been redesigned so that is no longer the case. So this method is now deprecated.
 
 ---
 
@@ -1060,8 +1060,8 @@ Swaps the contents of the container with the parameter.
 If `Allocator::propagate_on_container_swap` is declared and `Allocator::propagate_on_container_swap::value` is `true` then the containers' allocators are swapped. Otherwise, swapping with unequal allocators results in undefined behavior.
 
 [horizontal]
-Throws:: Doesn't throw an exception unless it is thrown by the copy constructor or copy assignment operator of `key_equal` or `hasher`.
-Notes:: The exception specifications aren't quite the same as the C++11 standard, as the equality predicate and hash function are swapped using their copy constructors.
+Throws:;; Doesn't throw an exception unless it is thrown by the copy constructor or copy assignment operator of `key_equal` or `hasher`.
+Notes:;; The exception specifications aren't quite the same as the C++11 standard, as the equality predicate and hash function are swapped using their copy constructors.
 
 ---
 
@@ -1073,8 +1073,8 @@ void clear();
 Erases all elements in the container.
 
 [horizontal]
-Postconditions:: `size() == 0`
-Throws:: Never throws an exception.
+Postconditions:;; `size() == 0`
+Throws:;; Never throws an exception.
 
 ---
 
@@ -1085,7 +1085,7 @@ void merge(unordered_map<Key, T, H2, P2, Alloc>& source);
 ```
 
 [horizontal]
-Notes:: Does not support merging with a compatible `unordered_multimap` yet.
+Notes:;; Does not support merging with a compatible `unordered_multimap` yet.
 
 ---
 
@@ -1096,7 +1096,7 @@ void merge(unordered_map<Key, T, H2, P2, Alloc>&& source);
 ```
 
 [horizontal]
-Notes:: Does not support merging with a compatible `unordered_multimap` yet.
+Notes:;; Does not support merging with a compatible `unordered_multimap` yet.
 
 ---
 
@@ -1115,7 +1115,7 @@ hasher hash_function() const;
 ```
 
 [horizontal]
-Returns:: The container's hash function.
+Returns:;; The container's hash function.
 
 ---
 
@@ -1125,7 +1125,7 @@ key_equal key_eq() const;
 ```
 
 [horizontal]
-Returns:: The container's key equality predicate
+Returns:;; The container's key equality predicate
 
 ---
 
@@ -1149,8 +1149,8 @@ template<typename CompatibleKey, typename CompatibleHash, typename CompatiblePre
 ```
 
 [horizontal]
-Returns:: An iterator pointing to an element with key equivalent to `k`, or `b.end()` if no such element exists.
-Notes:: The templated overloads containing `CompatibleKey`, `CompatibleHash` and `CompatiblePredicate` are non-standard extensions which allow you to use a compatible hash function and equality predicate for a key of a different type in order to avoid an expensive type cast. In general, its use is not encouraged and instead the `K` member function templates should be used. +
+Returns:;; An iterator pointing to an element with key equivalent to `k`, or `b.end()` if no such element exists.
+Notes:;; The templated overloads containing `CompatibleKey`, `CompatibleHash` and `CompatiblePredicate` are non-standard extensions which allow you to use a compatible hash function and equality predicate for a key of a different type in order to avoid an expensive type cast. In general, its use is not encouraged and instead the `K` member function templates should be used. +
 +
 The `template <typename K>` overloads only participate in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
 
@@ -1164,8 +1164,8 @@ template<class K>
 ```
 
 [horizontal]
-Returns:: The number of elements with key equivalent to `k`.
-Notes:: The `template <typename K>` overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
+Returns:;; The number of elements with key equivalent to `k`.
+Notes:;; The `template <typename K>` overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
 
 ---
 
@@ -1177,8 +1177,8 @@ template<class K>
 ```
 
 [horizontal]
-Returns:: A boolean indicating whether or not there is an element with key equal to `key` in the container
-Notes:: The `template <typename K>` overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
+Returns:;; A boolean indicating whether or not there is an element with key equal to `key` in the container
+Notes:;; The `template <typename K>` overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
 
 ---
 
@@ -1193,8 +1193,8 @@ template<class K>
 ```
 
 [horizontal]
-Returns:: A range containing all elements with key equivalent to `k`. If the container doesn't contain any such elements, returns `std::make_pair(b.end(), b.end())`.
-Notes:: The `template <typename K>` overloads only participate in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
+Returns:;; A range containing all elements with key equivalent to `k`. If the container doesn't contain any such elements, returns `std::make_pair(b.end(), b.end())`.
+Notes:;; The `template <typename K>` overloads only participate in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
 
 ---
 
@@ -1205,10 +1205,10 @@ mapped_type& operator[](key_type&& k);
 ```
 
 [horizontal]
-Effects:: If the container does not already contain an elements with a key equivalent to `k`, inserts the value `std::pair<key_type const, mapped_type>(k, mapped_type())`.
-Returns:: A reference to `x.second` where `x` is the element already in the container, or the newly inserted element with a key equivalent to `k`.
-Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
+Effects:;; If the container does not already contain an elements with a key equivalent to `k`, inserts the value `std::pair<key_type const, mapped_type>(k, mapped_type())`.
+Returns:;; A reference to `x.second` where `x` is the element already in the container, or the newly inserted element with a key equivalent to `k`.
+Throws:;; If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
 +
 Pointers and references to elements are never invalidated.
 
@@ -1221,8 +1221,8 @@ const mapped_type& at(const key_type& k) const;
 ```
 
 [horizontal]
-Returns:: A reference to `x.second` where `x` is the (unique) element whose key is equivalent to `k`.
-Throws:: An exception object of type `std::out_of_range` if no such element is present.
+Returns:;; A reference to `x.second` where `x` is the (unique) element whose key is equivalent to `k`.
+Throws:;; An exception object of type `std::out_of_range` if no such element is present.
 
 ---
 
@@ -1234,7 +1234,7 @@ size_type bucket_count() const noexcept;
 ```
 
 [horizontal]
-Returns:: The number of buckets.
+Returns:;; The number of buckets.
 
 ---
 
@@ -1244,7 +1244,7 @@ size_type max_bucket_count() const noexcept;
 ```
 
 [horizontal]
-Returns:: An upper bound on the number of buckets.
+Returns:;; An upper bound on the number of buckets.
 
 ---
 
@@ -1254,8 +1254,8 @@ size_type bucket_size(size_type n) const;
 ```
 
 [horizontal]
-Requires:: `n < bucket_count()`
-Returns:: The number of elements in bucket `n`.
+Requires:;; `n < bucket_count()`
+Returns:;; The number of elements in bucket `n`.
 
 ---
 
@@ -1265,8 +1265,8 @@ size_type bucket(const key_type& k) const;
 ```
 
 [horizontal]
-Returns:: The index of the bucket which would contain an element with key `k`.
-Postconditions:: The return value is less than `bucket_count()`.
+Returns:;; The index of the bucket which would contain an element with key `k`.
+Postconditions:;; The return value is less than `bucket_count()`.
 
 ---
 
@@ -1278,8 +1278,8 @@ const_local_iterator begin(size_type n) const;
 ```
 
 [horizontal]
-Requires:: `n` shall be in the range `[0, bucket_count())`.
-Returns:: A local iterator pointing the first element in the bucket with index `n`.
+Requires:;; `n` shall be in the range `[0, bucket_count())`.
+Returns:;; A local iterator pointing the first element in the bucket with index `n`.
 
 ---
 
@@ -1290,8 +1290,8 @@ const_local_iterator end(size_type n) const;
 ```
 
 [horizontal]
-Requires:: `n` shall be in the range `[0, bucket_count())`.
-Returns:: A local iterator pointing the 'one past the end' element in the bucket with index `n`.
+Requires:;; `n` shall be in the range `[0, bucket_count())`.
+Returns:;; A local iterator pointing the 'one past the end' element in the bucket with index `n`.
 
 ---
 
@@ -1301,8 +1301,8 @@ const_local_iterator cbegin(size_type n) const;
 ```
 
 [horizontal]
-Requires:: `n` shall be in the range `[0, bucket_count())`.
-Returns:: A constant local iterator pointing the first element in the bucket with index `n`.
+Requires:;; `n` shall be in the range `[0, bucket_count())`.
+Returns:;; A constant local iterator pointing the first element in the bucket with index `n`.
 
 ---
 
@@ -1312,8 +1312,8 @@ const_local_iterator cend(size_type n) const;
 ```
 
 [horizontal]
-Requires:: `n` shall be in the range `[0, bucket_count())`.
-Returns:: A constant local iterator pointing the 'one past the end' element in the bucket with index `n`.
+Requires:;; `n` shall be in the range `[0, bucket_count())`.
+Returns:;; A constant local iterator pointing the 'one past the end' element in the bucket with index `n`.
 
 ---
 
@@ -1325,7 +1325,7 @@ float load_factor() const noexcept;
 ```
 
 [horizontal]
-Returns:: The average number of elements per bucket.
+Returns:;; The average number of elements per bucket.
 
 ---
 
@@ -1336,7 +1336,7 @@ float max_load_factor() const noexcept;
 ```
 
 [horizontal]
-Returns:: Returns the current maximum load factor.
+Returns:;; Returns the current maximum load factor.
 
 ---
 
@@ -1346,7 +1346,7 @@ void max_load_factor(float z);
 ```
 
 [horizontal]
-Effects:: Changes the container's maximum load factor, using `z` as a hint.
+Effects:;; Changes the container's maximum load factor, using `z` as a hint.
 
 ---
 
@@ -1361,7 +1361,7 @@ Changes the number of buckets so that there at least `n` buckets, and so that th
 Invalidates iterators, and changes the order of elements. Pointers and references to elements are not invalidated.
 
 [horizontal]
-Throws:: The function has no effect if an exception is thrown, unless it is thrown by the container's hash function or comparison function.
+Throws:;; The function has no effect if an exception is thrown, unless it is thrown by the container's hash function or comparison function.
 
 ---
 
@@ -1373,7 +1373,7 @@ void reserve(size_type n);
 Invalidates iterators, and changes the order of elements. Pointers and references to elements are not invalidated.
 
 [horizontal]
-Throws:: The function has no effect if an exception is thrown, unless it is thrown by the container's hash function or comparison function.
+Throws:;; The function has no effect if an exception is thrown, unless it is thrown by the container's hash function or comparison function.
 
 === Equality Comparisons
 
@@ -1387,7 +1387,7 @@ template<class Key, class T, class Hash, class Pred, class Alloc>
 Return `true` if `x.size() == y.size()` and for every element in `x`, there is an element in `y` with the same key, with an equal value (using `operator==` to compare the value types).
 
 [horizontal]
-Notes:: The behavior of this function was changed to match the C++11 standard in Boost 1.48. +
+Notes:;; The behavior of this function was changed to match the C++11 standard in Boost 1.48. +
 +
 Behavior is undefined if the two containers don't have equivalent equality predicates.
 
@@ -1403,7 +1403,7 @@ template<class Key, class T, class Hash, class Pred, class Alloc>
 Return `false` if `x.size() == y.size()` and for every element in `x`, there is an element in `y` with the same key, with an equal value (using `operator==` to compare the value types).
 
 [horizontal]
-Notes:: The behavior of this function was changed to match the C++11 standard in Boost 1.48. +
+Notes:;; The behavior of this function was changed to match the C++11 standard in Boost 1.48. +
 +
 Behavior is undefined if the two containers don't have equivalent equality predicates.
 
@@ -1420,8 +1420,8 @@ Swaps the contents of `x` and `y`.
 If `Allocator::propagate_on_container_swap` is declared and `Allocator::propagate_on_container_swap::value` is `true` then the containers' allocators are swapped. Otherwise, swapping with unequal allocators results in undefined behavior.
 
 [horizontal]
-Effects:: `x.swap(y)`
-Throws:: Doesn't throw an exception unless it is thrown by the copy constructor or copy assignment operator of `key_equal` or `hasher`.
-Notes:: The exception specifications aren't quite the same as the C++11 standard, as the equality predicate and hash function are swapped using their copy constructors.
+Effects:;; `x.swap(y)`
+Throws:;; Doesn't throw an exception unless it is thrown by the copy constructor or copy assignment operator of `key_equal` or `hasher`.
+Notes:;; The exception specifications aren't quite the same as the C++11 standard, as the equality predicate and hash function are swapped using their copy constructors.
 
 

--- a/doc/unordered/unordered_multimap.adoc
+++ b/doc/unordered/unordered_multimap.adoc
@@ -7,271 +7,192 @@
 
 === Synopsis
 
-[source,c++,subs=+quotes]
+[listing,subs="+macros,+quotes"]
 -----
 // #include <boost/unordered_map.hpp>
 
-template<
-  typename Key,
-  typename Mapped,
-  typename Hash = boost::hash<Key>,
-  typename Pred = std::equal_to<Key>,
-  typename Alloc = std::allocator<std::pair<Key const, Mapped>> >
-class unordered_multimap {
-public:
-  // types
-  typedef Key                                    key_type;
-  typedef std::pair<Key const, Mapped>           value_type;
-  typedef Mapped                                 mapped_type;
-  typedef Hash                                   hasher;
-  typedef Pred                                   key_equal;
-  typedef Alloc                                  allocator_type;
-  typedef typename allocator_type::pointer       pointer;
-  typedef typename allocator_type::const_pointer const_pointer;
-  typedef value_type&                            reference;
-  typedef value_type const&                      const_reference;
-  typedef _implementation-defined_                 size_type;
-  typedef _implementation-defined_                 difference_type;
-  typedef _implementation-defined_                 iterator;
-  typedef _implementation-defined_                 const_iterator;
-  typedef _implementation-defined_                 local_iterator;
-  typedef _implementation-defined_                 const_local_iterator;
-  typedef _implementation-defined_                 node_type;
-  typedef _implementation-defined_                 insert_return_type;
+namespace boost {
+  template<class Key,
+           class T,
+           class Hash = boost::hash<Key>,
+           class Pred = std::equal_to<Key>,
+           class Allocator = std::allocator<std::pair<const Key, T>>>
+  class unordered_multimap {
+  public:
+    // types
+    using key_type             = Key;
+    using mapped_type          = T;
+    using value_type           = std::pair<const Key, T>;
+    using hasher               = Hash;
+    using key_equal            = Pred;
+    using allocator_type       = Allocator;
+    using pointer              = typename boost::allocator_traits<Allocator>::pointer;
+    using const_pointer        = typename boost::allocator_traits<Allocator>::const_pointer;
+    using reference            = value_type&;
+    using const_reference      = const value_type&;
+    using size_type            = _implementation-defined_;
+    using difference_type      = _implementation-defined_;
 
-  // construct/copy/destruct
-  unordered_multimap();
+    using iterator             = _implementation-defined_;
+    using const_iterator       = _implementation-defined_;
+    using local_iterator       = _implementation-defined_;
+    using const_local_iterator = _implementation-defined_;
+    using node_type            = _implementation-defined_;
 
-  explicit unordered_multimap(size_type n,
-                              hasher const& hf = hasher(),
-                              key_equal const& eq = key_equal(),
-                              allocator_type const& a  = allocator_type());
+    // construct/copy/destroy
+    xref:#unordered_multimap_default_constructor[unordered_multimap]();
+    explicit xref:#unordered_multimap_bucket_count_constructor[unordered_multimap](size_type n,
+                                const hasher& hf = hasher(),
+                                const key_equal& eql = key_equal(),
+                                const allocator_type& a = allocator_type());
+    template<class InputIterator>
+      xref:#unordered_multimap_iterator_range_constructor[unordered_multimap](InputIterator f, InputIterator l,
+                         size_type n = _implementation-defined_,
+                         const hasher& hf = hasher(),
+                         const key_equal& eql = key_equal(),
+                         const allocator_type& a = allocator_type());
+    xref:#unordered_multimap_copy_constructor[unordered_multimap](const unordered_multimap& other);
+    xref:#unordered_multimap_move_constructor[unordered_multimap](unordered_multimap&& other);
+    explicit xref:#unordered_multimap_allocator_constructor[unordered_multimap](const Allocator& a);
+    xref:#unordered_multimap_copy_constructor_with_allocator[unordered_multimap](const unordered_multimap& other, const Allocator& a);
+    xref:#unordered_multimap_move_constructor_with_allocator[unordered_multimap](unordered_multimap&& other, const Allocator& a);
+    xref:#unordered_multimap_initializer_list_constructor[unordered_multimap](initializer_list<value_type> il,
+                       size_type n = _implementation-defined_,
+                       const hasher& hf = hasher(),
+                       const key_equal& eql = key_equal(),
+                       const allocator_type& a = allocator_type());
+    xref:#unordered_multimap_bucket_count_constructor_with_allocator[unordered_multimap](size_type n, const allocator_type& a);
+    xref:#unordered_multimap_bucket_count_constructor_with_hasher_and_allocator[unordered_multimap](size_type n, const hasher& hf, const allocator_type& a);
+    template<class InputIterator>
+      xref:#unordered_multimap_iterator_range_constructor_with_bucket_count_and_allocator[unordered_multimap](InputIterator f, InputIterator l, size_type n, const allocator_type& a);
+    template<class InputIterator>
+      xref:#unordered_multimap_iterator_range_constructor_with_bucket_count_and_hasher[unordered_multimap](InputIterator f, InputIterator l, size_type n, const hasher& hf,
+                         const allocator_type& a);
+    xref:#unordered_multimap_initializer_list_constructor[unordered_multimap](initializer_list<value_type> il, size_type n, const hasher& hf,
+                       const allocator_type& a);
+    xref:#unordered_multimap_destructor[~unordered_multimap]();
+    unordered_multimap& xref:#unordered_multimap_copy_assignment[operator++=++](const unordered_multimap& other);
+    unordered_multimap& xref:#unordered_multimap_move_assignment[operator++=++](unordered_multimap&& other)
+      noexcept(boost::allocator_traits<Allocator>::is_always_equal::value &&
+               boost::is_nothrow_move_assignable_v<Hash> &&
+               boost::is_nothrow_move_assignable_v<Pred>);
+    unordered_multimap& xref:#unordered_multimap_initializer_list_assignment[operator++=++](initializer_list<value_type> il);
+    allocator_type xref:#unordered_multimap_get_allocator[get_allocator]() const noexcept;
 
-  unordered_multimap(unordered_multimap const& other);
-  unordered_multimap(unordered_multimap&& other);
+    // iterators
+    iterator       xref:#unordered_multimap_begin[begin]() noexcept;
+    const_iterator xref:#unordered_multimap_begin[begin]() const noexcept;
+    iterator       xref:#unordered_multimap_end[end]() noexcept;
+    const_iterator xref:#unordered_multimap_end[end]() const noexcept;
+    const_iterator xref:#unordered_multimap_cbegin[cbegin]() const noexcept;
+    const_iterator xref:#unordered_multimap_cend[cend]() const noexcept;
 
-  explicit unordered_multimap(Allocator const& a);
-  unordered_multimap(unordered_multimap const& other, Allocator const& a);
-  unordered_multimap(unordered_multimap&& other, Allocator const& a);
+    // capacity
+    bool xref:#unordered_multimap_empty[empty]() const noexcept;
+    size_type xref:#unordered_multimap_size[size]() const noexcept;
+    size_type xref:#unordered_multimap_max_size[max_size]() const noexcept;
 
-  unordered_multimap(size_type n, allocator_type const& a);
-  unordered_multimap(size_type n, hasher const& hf, allocator_type const& a);
+    // modifiers
+    template<class... Args> iterator xref:#unordered_multimap_emplace[emplace](Args&&... args);
+    template<class... Args> iterator xref:#unordered_multimap_emplace_hint[emplace_hint](const_iterator position, Args&&... args);
+    iterator xref:#unordered_multimap_copy_insert[insert](const value_type& obj);
+    iterator xref:#unordered_multimap_move_insert[insert](value_type&& obj);
+    template<class P> iterator xref:#unordered_multimap_emplace_insert[insert](P&& obj);
+    iterator xref:#unordered_multimap_copy_insert_with_hint[insert](const_iterator hint, const value_type& obj);
+    iterator xref:#unordered_multimap_move_insert_with_hint[insert](const_iterator hint, value_type&& obj);
+    template<class P> iterator xref:#unordered_multimap_emplace_insert_with_hint[insert](const_iterator hint, P&& obj);
+    template<class InputIterator> void xref:#unordered_multimap_insert_iterator_range[insert](InputIterator first, InputIterator last);
+    void xref:#unordered_multimap_insert_initializer_list[insert](initializer_list<value_type> il);
 
-  unordered_multimap(initializer_list<value_type> il,
-                     size_type n = _implementation-defined_,
-                     hasher const& hf = hasher(),
-                     key_equal const& eq = key_equal(),
-                     allocator_type const& a = allocator_type());
+    node_type xref:#unordered_multimap_extract_by_iterator[extract](const_iterator position);
+    node_type xref:#unordered_multimap_extract_by_key[extract](const key_type& k);
+    template<class K> node_type xref:#unordered_multimap_transparent_extract_by_key[extract](K&& k);
+    iterator xref:#unordered_multimap_insert_with_node_handle[insert](node_type&& nh);
+    iterator xref:#unordered_multimap_insert_with_hint_and_node_handle[insert](const_iterator hint, node_type&& nh);
 
-  template<typename InputIterator>
-  unordered_multimap(InputIterator f,
-                     InputIterator l,
-                     size_type n = _implementation-defined_,
-                     hasher const& hf = hasher(),
-                     key_equal const& eq = key_equal(),
-                     allocator_type const& a  = allocator_type());
+    iterator  xref:#unordered_multimap_erase_by_position[erase](iterator position);
+    iterator  xref:#unordered_multimap_erase_by_position[erase](const_iterator position);
+    size_type xref:#unordered_multimap_erase_by_key[erase](const key_type& k);
+    template<class K> size_type xref:#unordered_multimap_transparent_erase_by_key[erase](K&& k);
+    iterator  xref:#unordered_multimap_erase_range[erase](const_iterator first, const_iterator last);
+    void      xref:#unordered_multimap_quick_erase[quick_erase](const_iterator position);
+    void      xref:#unordered_multimap_erase_return_void[erase_return_void](const_iterator position);
+    void      xref:#unordered_multimap_swap[swap](unordered_multimap& other)
+      noexcept(boost::allocator_traits<Allocator>::is_always_equal::value &&
+               boost::is_nothrow_swappable_v<Hash> &&
+               boost::is_nothrow_swappable_v<Pred>);
+    void      xref:#unordered_multimap_clear[clear]() noexcept;
 
-  template<typename InputIterator>
-  unordered_multimap(InputIterator f,
-                     InputIterator l,
-                     size_type n,
-                     allocator_type const& a);
+    template<class H2, class P2>
+      void xref:#unordered_multimap_merge[merge](unordered_multimap<Key, T, H2, P2, Allocator>& source);
+    template<class H2, class P2>
+      void xref:#unordered_multimap_merge_rvalue_reference[merge](unordered_multimap<Key, T, H2, P2, Allocator>&& source);
 
-  template<typename InputIterator>
-  unordered_multimap(InputIterator f,
-                     InputIterator l,
-                     size_type n,
-                     hasher const& hf,
-                     allocator_type const& a);
+    // observers
+    hasher xref:#unordered_multimap_hash_function[hash_function]() const;
+    key_equal xref:#unordered_multimap_key_eq[key_eq]() const;
 
-  ~unordered_multimap();
+    // map operations
+    iterator         xref:#unordered_multimap_find[find](const key_type& k);
+    const_iterator   xref:#unordered_multimap_find[find](const key_type& k) const;
+    template<class K>
+      iterator       xref:#unordered_multimap_find[find](const K& k);
+    template<class K>
+      const_iterator xref:#unordered_multimap_find[find](const K& k) const;
+    template<typename CompatibleKey, typename CompatibleHash, typename CompatiblePredicate>
+      iterator       xref:#unordered_multimap_find[find](CompatibleKey const& k, CompatibleHash const& hash,
+                          CompatiblePredicate const& eq);
+    template<typename CompatibleKey, typename CompatibleHash, typename CompatiblePredicate>
+      const_iterator xref:#unordered_multimap_find[find](CompatibleKey const& k, CompatibleHash const& hash,
+                          CompatiblePredicate const& eq) const;
+    size_type        xref:#unordered_multimap_count[count](const key_type& k) const;
+    template<class K>
+      size_type      xref:#unordered_multimap_count[count](const K& k) const;
+    bool             xref:#unordered_multimap_contains[contains](const key_type& k) const;
+    template<class K>
+      bool           xref:#unordered_multimap_contains[contains](const K& k) const;
+    pair<iterator, iterator>               xref:#unordered_multimap_equal_range[equal_range](const key_type& k);
+    pair<const_iterator, const_iterator>   xref:#unordered_multimap_equal_range[equal_range](const key_type& k) const;
+    template<class K>
+      pair<iterator, iterator>             xref:#unordered_multimap_equal_range[equal_range](const K& k);
+    template<class K>
+      pair<const_iterator, const_iterator> xref:#unordered_multimap_equal_range[equal_range](const K& k) const;
 
-  unordered_multimap& operator=(unordered_multimap const& other);
-  unordered_multimap& operator=(unordered_multimap&& other);
-  unordered_multimap& operator=(initializer_list<value_type> il);
+    // bucket interface
+    size_type xref:#unordered_multimap_bucket_count[bucket_count]() const noexcept;
+    size_type xref:#unordered_multimap_max_bucket_count[max_bucket_count]() const noexcept;
+    size_type xref:#unordered_multimap_bucket_size[bucket_size](size_type n) const;
+    size_type xref:#unordered_multimap_bucket[bucket](const key_type& k) const;
+    local_iterator xref:#unordered_multimap_begin_2[begin](size_type n);
+    const_local_iterator xref:#unordered_multimap_begin_2[begin](size_type n) const;
+    local_iterator xref:#unordered_multimap_end_2[end](size_type n);
+    const_local_iterator xref:#unordered_multimap_end_2[end](size_type n) const;
+    const_local_iterator xref:#unordered_multimap_cbegin_2[cbegin](size_type n) const;
+    const_local_iterator xref:#unordered_multimap_cend_2[cend](size_type n) const;
 
-  // size and capacity
-  bool empty() const;
-  size_type size() const;
-  size_type max_size() const;
-
-  // iterators
-  iterator begin();
-  const_iterator begin() const;
-
-  iterator end();
-  const_iterator end() const;
-
-  const_iterator cbegin() const;
-  const_iterator cend() const;
-
-  // modifiers
-  template<typename... Args>
-  iterator
-  emplace(Args&&... args);
-
-  template<typename... Args>
-  iterator
-  emplace_hint(const_iterator hint, Args&&... args);
-
-  iterator
-  insert(value_type const& obj);
-
-  iterator
-  insert(value_type&& obj);
-
-  template <class P>
-  iterator
-  insert(P&& value);
-
-  insert_return_type insert(node_type&& nh);
-
-  iterator insert(const_iterator hint, value_type const& obj);
-  iterator insert(const_iterator hint, value_type&& obj);
-  iterator insert(const_iterator hint, node_type&& nh);
-
-  template <class P>
-  iterator
-  insert(const_iterator hint, P&& value);
-
-  template<typename InputIterator>
-  void insert(InputIterator first, InputIterator last);
-
-  void insert(initializer_list<value_type> il);
-
-  node_type extract(const_iterator position);
-  node_type extract(key_type const& k);
-
-  template<typename K>
-  node_type extract(K&& k);
-
-  iterator erase(const_iterator position);
-  iterator erase(const_iterator first, const_iterator last);
-  size_type erase(key_type const& k);
-
-  template<typename K>
-  size_type erase(K&& k);
-
-  void quick_erase(const_iterator position);
-  void erase_return_void(const_iterator position);
-
-  void clear();
-  void swap(unordered_multimap& other);
-
-  template<typename H2, typename P2>
-  void merge(unordered_multimap<Key, Mapped, H2, P2, Alloc>& source);
-
-  template<typename H2, typename P2>
-  void merge(unordered_multimap<Key, Mapped, H2, P2, Alloc>&& source);
-
-  // observers
-  allocator_type get_allocator() const;
-  hasher hash_function() const;
-  key_equal key_eq() const;
-
-  // lookup
-  iterator find(key_type const& k);
-  const_iterator find(key_type const& k) const;
-
-  template<typename K>
-  iterator
-  find(K const& k);
-
-  template<typename K>
-  const_iterator
-  find(K const& k) const;
-
-  template<
-    typename CompatibleKey,
-    typename CompatibleHash,
-    typename CompatiblePredicate>
-  iterator
-  find(CompatibleKey const& k,
-       CompatibleHash const& hash,
-       CompatiblePredicate const&) eq;
-
-  template<
-    typename CompatibleKey,
-    typename CompatibleHash,
-    typename CompatiblePredicate>
-  const_iterator
-  find(CompatibleKey const& k,
-       CompatibleHash const& hash,
-       CompatiblePredicate const& eq) const;
-
-  bool contains(key_type const& key) const;
-
-  template<typename K>
-  bool contains(K const& key);
-
-  size_type count(key_type const& k) const;
-
-  template<typename K>
-  size_type count(K const& k) const;
-
-  std::pair<iterator, iterator>
-  equal_range(key_type const& k);
-
-  std::pair<const_iterator, const_iterator>
-  equal_range(key_type const& k) const;
-
-  template<typename K>
-  std::pair<iterator, iterator>
-  equal_range(K const& k);
-
-  template<typename K>
-  std::pair<const_iterator, const_iterator>
-  equal_range(K const& k) const;
-
-  // bucket interface
-  size_type bucket_count() const;
-  size_type max_bucket_count() const;
-  size_type bucket_size(size_type n) const;
-  size_type bucket(key_type const& k) const;
-
-  local_iterator begin(size_type n);
-  const_local_iterator begin(size_type n) const;
-
-  local_iterator end(size_type n);
-  const_local_iterator end(size_type n) const;
-
-  const_local_iterator cbegin(size_type n) const;
-  const_local_iterator cend(size_type n) const;
-
-  // hash policy
-  float load_factor() const;
-  float max_load_factor() const;
-
-  void max_load_factor(float z);
-
-  void rehash(size_type n);
-  void reserve(size_type n);
-};
+    // hash policy
+    float xref:#unordered_multimap_load_factor[load_factor]() const noexcept;
+    float xref:#unordered_multimap_max_load_factor[max_load_factor]() const noexcept;
+    void xref:#unordered_multimap_max_load_factor[max_load_factor](float z);
+    void xref:#unordered_multimap_rehash[rehash](size_type n);
+    void xref:#unordered_multimap_reserve[reserve](size_type n);
+  };
+}
 
 // Equality Comparisons
-template<
-  typename Key,
-  typename Mapped,
-  typename Hash,
-  typename Pred,
-  typename Alloc>
-bool operator==(unordered_multimap<Key, Mapped, Hash, Pred, Alloc> const& x,
-                unordered_multimap<Key, Mapped, Hash, Pred, Alloc> const& y);
+template<class Key, class T, class Hash, class Pred, class Alloc>
+  bool xref:#unordered_multimap_operator[operator++==++](const unordered_multimap<Key, T, Hash, Pred, Alloc>& x,
+                  const unordered_multimap<Key, T, Hash, Pred, Alloc>& y);
 
-template<
-  typename Key,
-  typename Mapped,
-  typename Hash,
-  typename Pred,
-  typename Alloc>
-bool operator!=(unordered_multimap<Key, Mapped, Hash, Pred, Alloc> const& x,
-                unordered_multimap<Key, Mapped, Hash, Pred, Alloc> const& y);
+template<class Key, class T, class Hash, class Pred, class Alloc>
+  bool xref:#unordered_multimap_operator_2[operator!=](const unordered_multimap<Key, T, Hash, Pred, Alloc>& x,
+                  const unordered_multimap<Key, T, Hash, Pred, Alloc>& y);
 
 // swap
-template<typename Key, typename Mapped, typename Hash, typename Pred,
-         typename Alloc>
-void swap(unordered_multimap<Key, Mapped, Hash, Pred, Alloc>& x,
-          unordered_multimap<Key, Mapped, Hash, Pred, Alloc>& y);
+template<class Key, class T, class Hash, class Pred, class Alloc>
+  void xref:#unordered_multimap_swap_2[swap](unordered_multimap<Key, T, Hash, Pred, Alloc>& x,
+            unordered_multimap<Key, T, Hash, Pred, Alloc>& y)
+    noexcept(noexcept(x.swap(y)));
 -----
 
 ---

--- a/doc/unordered/unordered_multimap.adoc
+++ b/doc/unordered/unordered_multimap.adoc
@@ -207,8 +207,8 @@ template<class Key, class T, class Hash, class Pred, class Alloc>
 |_Key_
 |`Key` must be https://en.cppreference.com/w/cpp/named_req/Erasable[Erasable^] from the container (i.e. `allocator_traits` can destroy it).
 
-|_Mapped_
-|`Mapped` must be https://en.cppreference.com/w/cpp/named_req/Erasable[Erasable^] from the container (i.e. `allocator_traits` can destroy it).
+|_T_
+|`T` must be https://en.cppreference.com/w/cpp/named_req/Erasable[Erasable^] from the container (i.e. `allocator_traits` can destroy it).
 
 |_Hash_
 |A unary function object type that acts a hash function for a `Key`. It takes a single argument of type `Key` and returns a value of type `std::size_t`.
@@ -216,7 +216,7 @@ template<class Key, class T, class Hash, class Pred, class Alloc>
 |_Pred_
 |A binary function object that implements an equivalence relation on values of type `Key`. A binary function object that induces an equivalence relation on values of type `Key`. It takes two arguments of type `Key` and returns a value of type bool.
 
-|_Alloc_
+|_Allocator_
 |An allocator whose value type is the same as the container's value type.
 
 |===
@@ -323,15 +323,6 @@ See node_handle_map for details.
 
 ---
 
-[source,c++,subs=+quotes]
-----
-typedef _implementation-defined_ insert_return_type;
-----
-
-Structure returned by inserting node_type.
-
----
-
 === Constructors
 
 ==== Default Constructor
@@ -351,13 +342,13 @@ Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` 
 ==== Bucket Count Constructor
 ```c++
 explicit unordered_multimap(size_type n,
-                            hasher const& hf = hasher(),
-                            key_equal const& eq = key_equal(),
-                            allocator_type const& a = allocator_type());
+                            const hasher& hf = hasher(),
+                            const key_equal& eql = key_equal(),
+                            const allocator_type& a = allocator_type());
 ```
 
 Constructs an empty container with at least `n` buckets, using `hf` as the hash
-function, `eq` as the key equality predicate, `a` as the allocator and a maximum
+function, `eql` as the key equality predicate, `a` as the allocator and a maximum
 load factor of `1.0`.
 
 Postconditions:: `size() == 0`
@@ -366,9 +357,26 @@ Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` 
 
 ---
 
+==== Iterator Range Constructor
+[source,c++,subs="+quotes"]
+----
+template<class InputIterator>
+unordered_multimap(InputIterator f, InputIterator l,
+                   size_type n = _implementation-defined_,
+                   const hasher& hf = hasher(),
+                   const key_equal& eql = key_equal(),
+                   const allocator_type& a = allocator_type());
+----
+
+Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `eql` as the key equality predicate, `a` as the allocator and a maximum load factor of `1.0` and inserts the elements from `[f, l)` into it.
+
+Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
 ==== Copy Constructor
 ```c++
-unordered_multimap(unordered_multimap const& other);
+unordered_multimap(const unordered_multimap& other);
 ```
 
 The copy constructor. Copies the contained elements, hash function, predicate, maximum load factor and allocator.
@@ -395,7 +403,7 @@ So, for example, you can't return the container from a function.
 
 ==== Allocator Constructor
 ```c++
-explicit unordered_multimap(Allocator const& a);
+explicit unordered_multimap(const Allocator& a);
 ```
 
 Constructs an empty container, using allocator `a`.
@@ -404,7 +412,7 @@ Constructs an empty container, using allocator `a`.
 
 ==== Copy Constructor with Allocator
 ```c++
-unordered_multimap(unordered_multimap const& other, Allocator const& a);
+unordered_multimap(const unordered_multimap& other, const Allocator& a);
 ```
 
 Constructs an container, copying ``other``'s contained elements, hash function, predicate, maximum load factor, but using allocator `a`.
@@ -413,7 +421,7 @@ Constructs an container, copying ``other``'s contained elements, hash function, 
 
 ==== Move Constructor with Allocator
 ```c++
-unordered_multimap(unordered_multimap&& other, Allocator const& a);
+unordered_multimap(unordered_multimap&& other, const Allocator& a);
 ```
 
 Construct a container moving ``other``'s contained elements, and having the hash function, predicate and maximum load factor, but using allocate `a`.
@@ -423,9 +431,24 @@ Requires:: `value_type` is move insertable.
 
 ---
 
+==== Initializer List Constructor
+[source,c++,subs="+quotes"]
+----
+unordered_multimap(initializer_list<value_type> il,
+                   size_type n = _implementation-defined_,
+                   const hasher& hf = hasher(),
+                   const key_equal& eql = key_equal(),
+                   const allocator_type& a = allocator_type());
+----
+
+Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `eql` as the key equality predicate, `a` as the allocator and a maximum load factor of `1.0` and inserts the elements from `il` into it.
+
+Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
 ==== Bucket Count Constructor with Allocator
 ```c++
-unordered_multimap(size_type n, allocator_type const& a);
+unordered_multimap(size_type n, const allocator_type& a);
 ```
 
 Constructs an empty container with at least `n` buckets, using `hf` as the hash function, the default hash function and key equality predicate, `a` as the allocator and a maximum load factor of `1.0`.
@@ -437,7 +460,7 @@ Requires:: `hasher` and `key_equal` need to be https://en.cppreference.com/w/cpp
 
 ==== Bucket Count Constructor with Hasher and Allocator
 ```c++
-unordered_multimap(size_type n, hasher const& hf, allocator_type const& a);
+unordered_multimap(size_type n, const hasher& hf, const allocator_type& a);
 ```
 
 Constructs an empty container with at least `n` buckets, using `hf` as the hash function, the default key equality predicate, `a` as the allocator and a maximum load factor of `1.0`.
@@ -447,63 +470,25 @@ Requires:: `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/D
 
 ---
 
-==== Initializer List Constructor
-[source,c++,subs="quotes,macros"]
-----
-unordered_multimap(initializer_list++<++value_type++>++ il,
-                   size_type n = _implementation-defined_,
-                   hasher const& hf = hasher(),
-                   key_equal const& eq = key_equal(),
-                   allocator_type const& a = allocator_type());
-----
-
-Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `eq` as the key equality predicate, `a` as the allocator and a maximum load factor of `1.0` and inserts the elements from `il` into it.
-
-Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
-
----
-
-==== Iterator Range Constructor
-[source,c++,subs="quotes,macros"]
-----
-template++<++typename InputIterator++>++
-unordered_multimap(InputIterator f,
-                   InputIterator l,
-                   size_type n = _implementation-defined_,
-                   hasher const& hf = hasher(),
-                   key_equal const& eq = key_equal(),
-                   allocator_type const& a = allocator_type());
-----
-
-Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `eq` as the key equality predicate, `a` as the allocator and a maximum load factor of `1.0` and inserts the elements from `[f, l)` into it.
-
-Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
-
----
-
 ==== Iterator Range Constructor with Bucket Count and Allocator
-[source,c++,subs="quotes,macros"]
+[source,c++,subs="+quotes"]
 ----
-template++<++typename InputIterator++>++
-unordered_multimap(InputIterator f,
-                   InputIterator l,
-                   size_type n,
-                   allocator_type const& a);
+template<class InputIterator>
+  unordered_multimap(InputIterator f, InputIterator l, size_type n, const allocator_type& a);
 ----
 
 Constructs an empty container with at least `n` buckets, using `a` as the allocator, with the default hash function and key equality predicate and a maximum load factor of `1.0` and inserts the elements from `[f, l)` into it.
 
 Requires:: `hasher`, `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
+---
+
 ==== Iterator Range Constructor with Bucket Count and Hasher
-[source,c++,subs="quotes,macros"]
+[source,c++,subs="+quotes"]
 ----
-template++<++typename InputIterator++>++
-unordered_multimap(InputIterator f,
-                   InputIterator l,
-                   size_type n,
-                   hasher const& hf,
-                   allocator_type const& a);
+template<class InputIterator>
+  unordered_multimap(InputIterator f, InputIterator l, size_type n, const hasher& hf,
+                     const allocator_type& a);
 ----
 
 Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `a` as the allocator, with the default key equality predicate and a maximum load factor of `1.0` and inserts the elements from `[f, l)` into it.
@@ -526,7 +511,7 @@ Note:: The destructor is applied to every element, and all memory is deallocated
 ==== Copy Assignment
 
 ```c++
-unordered_multimap& operator=(unordered_multimap const& other);
+unordered_multimap& operator=(const unordered_multimap& other);
 ```
 
 The assignment operator. Copies the contained elements, hash function, predicate and maximum load factor but not the allocator.
@@ -539,7 +524,10 @@ Requires:: `value_type` is copy constructible
 
 ==== Move Assignment
 ```c++
-unordered_multimap& operator=(unordered_multimap&& other);
+unordered_multimap& operator=(unordered_multimap&& other)
+  noexcept(boost::allocator_traits<Allocator>::is_always_equal::value &&
+           boost::is_nothrow_move_assignable_v<Hash> &&
+           boost::is_nothrow_move_assignable_v<Pred>);
 ```
 The move assignment operator.
 
@@ -560,12 +548,51 @@ Assign from values in initializer list. All existing elements are either overwri
 
 Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/CopyInsertable[CopyInsertable^] into the container and https://en.cppreference.com/w/cpp/named_req/CopyAssignable[CopyAssignable^].
 
+=== Iterators
+
+==== begin
+```c++
+iterator begin() noexcept;
+const_iterator begin() const noexcept;
+```
+
+Returns:: An iterator referring to the first element of the container, or if the container is empty the past-the-end value for the container.
+
+---
+
+==== end
+```c++
+iterator       end() noexcept;
+const_iterator end() const noexcept;
+```
+
+Returns:: An iterator which refers to the past-the-end value for the container.
+
+---
+
+==== cbegin
+```c++
+const_iterator cbegin() const noexcept;
+```
+Returns:: A `const_iterator` referring to the first element of the container, or if the container is empty the past-the-end value for the container.
+
+---
+
+==== cend
+```c++
+const_iterator cend() const noexcept;
+```
+
+Returns:: A `const_iterator` which refers to the past-the-end value for the container.
+
+---
+
 === Size and Capacity
 
 ==== empty
 
 ```c++
-bool empty() const;
+bool empty() const noexcept;
 ```
 
 Returns:: `size() == 0`
@@ -575,7 +602,7 @@ Returns:: `size() == 0`
 ==== size
 
 ```c++
-size_type size() const;
+size_type size() const noexcept;
 ```
 
 Returns:: `std::distance(begin(), end())`
@@ -585,49 +612,10 @@ Returns:: `std::distance(begin(), end())`
 ==== max_size
 
 ```c++
-size_type max_size() const;
+size_type max_size() const noexcept;
 ```
 
 Returns:: `size()` of the largest possible container.
-
----
-
-=== Iterators
-
-==== begin
-```c++
-iterator begin();
-const_iterator begin() const;
-```
-
-Returns:: An iterator referring to the first element of the container, or if the container is empty the past-the-end value for the container.
-
----
-
-==== end
-```c++
-iterator end();
-const_iterator end() const;
-```
-
-Returns:: An iterator which refers to the past-the-end value for the container.
-
----
-
-==== cbegin
-```c++
-const_iterator cbegin() const;
-```
-Returns:: A `const_iterator` referring to the first element of the container, or if the container is empty the past-the-end value for the container.
-
----
-
-==== cend
-```c++
-const_iterator cend() const;
-```
-
-Returns:: A `const_iterator` which refers to the past-the-end value for the container.
 
 ---
 
@@ -635,9 +623,7 @@ Returns:: A `const_iterator` which refers to the past-the-end value for the cont
 
 ==== emplace
 ```c++
-template<typename... Args>
-iterator
-emplace(Args&&... args);
+template<class... Args> iterator emplace(Args&&... args);
 ```
 
 Inserts an object, constructed with the arguments `args`, in the container.
@@ -657,14 +643,12 @@ Since existing `std::pair` implementations don't support `std::piecewise_constru
 
 ==== emplace_hint
 ```c++
-template<typename... Args>
-iterator
-emplace_hint(const_iterator hint, Args&&... args);
+template<class... Args> iterator emplace_hint(const_iterator position, Args&&... args);
 ```
 
 Inserts an object, constructed with the arguments args, in the container.
 
-`hint` is a suggestion to where the element should be inserted.
+`position` is a suggestion to where the element should be inserted.
 
 Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `args`.
 
@@ -682,8 +666,7 @@ Since existing `std::pair` implementations don't support `std::piecewise_constru
 
 ==== Copy Insert
 ```c++
-iterator
-insert(value_type const& obj);
+iterator insert(const value_type& obj);
 ```
 
 Inserts `obj` in the container.
@@ -700,8 +683,7 @@ Notes:: Can invalidate iterators, but only if the insert causes the load factor 
 
 ==== Move Insert
 ```c++
-iterator
-insert(value_type&& obj);
+iterator insert(value_type&& obj);
 ```
 
 Inserts `obj` in the container.
@@ -718,9 +700,7 @@ Notes:: Can invalidate iterators, but only if the insert causes the load factor 
 
 ==== Emplace Insert
 ```c++
-template <class P>
-iterator
-insert(P&& value);
+template<class P> iterator insert(P&& obj);
 ```
 
 Inserts an element into the container by performing `emplace(std::forward<P>(value))`.
@@ -731,29 +711,9 @@ Returns:: An iterator pointing to the inserted element.
 
 ---
 
-==== Insert with `node_handle`
-```c++
-insert_return_type
-insert(node_type&& nh);
-```
-
-If `nh` is empty, has no effect.
-
-Otherwise inserts the element owned by `nh`.
-
-Requires:: `nh` is empty or `nh.get_allocator()` is equal to the container's allocator.
-
-Returns:: If `nh` was empty, returns `end()`. Otherwise returns an iterator pointing to the newly inserted element.
-
-Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-
-Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated. In C++17 this can be used to insert a node extracted from a compatible `unordered_map`, but that is not supported yet.
-
----
-
 ==== Copy Insert with Hint
 ```c++
-iterator insert(const_iterator hint, value_type const& obj);
+iterator insert(const_iterator hint, const value_type& obj);
 ```
 Inserts `obj` in the container.
 
@@ -790,9 +750,7 @@ Notes:: The standard is fairly vague on the meaning of the hint. But the only pr
 
 ==== Emplace Insert with Hint
 ```c++
-template <class P>
-iterator
-insert(const_iterator hint, P&& value);
+template<class P> iterator insert(const_iterator hint, P&& obj);
 ```
 
 Inserts an element into the container by performing `emplace_hint(hint, std::forward<P>(value))`.
@@ -807,33 +765,9 @@ Notes:: The standard is fairly vague on the meaning of the hint. But the only pr
 
 ---
 
-==== Insert with Hint and `node_handle`
-```c++
-iterator insert(const_iterator hint, node_type&& nh);
-```
-
-If `nh` is empty, has no effect.
-
-Otherwise inserts the element owned by `nh`.
-
-`hint` is a suggestion to where the element should be inserted.
-
-Requires:: `nh` is empty or `nh.get_allocator()` is equal to the container's allocator.
-
-Returns:: If `nh` was empty, returns `end()`. +
-+
-Otherwise returns an iterator pointing to the newly inserted element.
-
-Throws:: If an exception is thrown by an operation other than a call to hasher the function has no effect.
-
-Notes:: The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated. In C++17 this can be used to insert a node extracted from a compatible `unordered_map`, but that is not supported yet.
-
----
-
 ==== Insert Iterator Range
 ```c++
-template<typename InputIterator>
-void insert(InputIterator first, InputIterator last);
+template<class InputIterator> void insert(InputIterator first, InputIterator last);
 ```
 
 Inserts a range of elements into the container.
@@ -874,10 +808,24 @@ Notes:: In C++17 a node extracted using this method can be inserted into a compa
 
 ---
 
+==== Extract by Key
+```c++
+node_type extract(const key_type& k);
+```
+
+Removes an element with key equivalent to `k`.
+
+Returns:: A `node_type` owning the element if found, otherwise an empty `node_type`.
+
+Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
+
+Notes:: In C++17 a node extracted using this method can be inserted into a compatible `unordered_map`, but that is not supported yet.
+
+---
+
 ==== Transparent Extract by Key
 ```c++
-template<typename K>
-node_type extract(K&& k);
+template<class K> node_type extract(K&& k);
 ```
 
 Removes an element with key equivalent to `k`.
@@ -892,22 +840,52 @@ Notes:: In C++17 a node extracted using this method can be inserted into a compa
 
 ---
 
-==== Extract by Key
+==== Insert with `node_handle`
 ```c++
-node_type extract(key_type const& k);
+iterator insert(node_type&& nh);
 ```
 
-Removes an element with key equivalent to `k`.
+If `nh` is empty, has no effect.
 
-Returns:: A `node_type` owning the element if found, otherwise an empty `node_type`.
+Otherwise inserts the element owned by `nh`.
 
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
+Requires:: `nh` is empty or `nh.get_allocator()` is equal to the container's allocator.
 
-Notes:: In C++17 a node extracted using this method can be inserted into a compatible `unordered_map`, but that is not supported yet.
+Returns:: If `nh` was empty, returns `end()`. Otherwise returns an iterator pointing to the newly inserted element.
+
+Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+
+Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated. In C++17 this can be used to insert a node extracted from a compatible `unordered_map`, but that is not supported yet.
+
+---
+
+==== Insert with Hint and `node_handle`
+```c++
+iterator insert(const_iterator hint, node_type&& nh);
+```
+
+If `nh` is empty, has no effect.
+
+Otherwise inserts the element owned by `nh`.
+
+`hint` is a suggestion to where the element should be inserted.
+
+Requires:: `nh` is empty or `nh.get_allocator()` is equal to the container's allocator.
+
+Returns:: If `nh` was empty, returns `end()`. +
++
+Otherwise returns an iterator pointing to the newly inserted element.
+
+Throws:: If an exception is thrown by an operation other than a call to hasher the function has no effect.
+
+Notes:: The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated. In C++17 this can be used to insert a node extracted from a compatible `unordered_map`, but that is not supported yet.
+
+---
 
 ==== Erase by Position
 
 ```c++
+iterator erase(iterator position);
 iterator erase(const_iterator position);
 ```
 
@@ -918,6 +896,34 @@ Returns:: The iterator following `position` before the erasure.
 Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
 
 Notes:: In older versions this could be inefficient because it had to search through several buckets to find the position of the returned iterator. The data structure has been changed so that this is no longer the case, and the alternative erase methods have been deprecated.
+
+---
+
+==== Erase by Key
+```c++
+size_type erase(const key_type& k);
+```
+
+Erase all elements with key equivalent to `k`.
+
+Returns:: The number of elements erased.
+
+Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
+
+---
+
+==== Transparent Erase by Key
+```c++
+template<class K> size_type erase(K&& k);
+```
+
+Erase all elements with key equivalent to `k`.
+
+This overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs and neither `iterator` nor `const_iterator` are implicitly convertible from `K`. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
+
+Returns:: The number of elements erased.
+
+Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
 
 ---
 
@@ -932,35 +938,6 @@ Erases the elements in the range from `first` to `last`.
 Returns:: The iterator following the erased elements - i.e. `last`.
 
 Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`. In this implementation, this overload doesn't call either function object's methods so it is no throw, but this might not be true in other implementations.
-
----
-
-==== Transparent Erase by Key
-```c++
-template<typename K>
-size_type erase(K&& k);
-```
-
-Erase all elements with key equivalent to `k`.
-
-This overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs and neither `iterator` nor `const_iterator` are implicitly convertible from `K`. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
-
-Returns:: The number of elements erased.
-
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
-
----
-
-==== Erase by Key
-```c++
-size_type erase(key_type const& k);
-```
-
-Erase all elements with key equivalent to `k`.
-
-Returns:: The number of elements erased.
-
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
 
 ---
 
@@ -990,22 +967,12 @@ Notes:: This method was implemented because returning an iterator to the next el
 
 ---
 
-==== clear
-```c++
-void clear();
-```
-
-Erases all elements in the container.
-
-Postconditions:: `size() == 0`
-
-Throws:: Never throws an exception.
-
----
-
 ==== swap
 ```c++
-void swap(unordered_multimap& other);
+void swap(unordered_multimap& other)
+  noexcept(boost::allocator_traits<Allocator>::is_always_equal::value &&
+           boost::is_nothrow_swappable_v<Hash> &&
+           boost::is_nothrow_swappable_v<Pred>);
 ```
 
 Swaps the contents of the container with the parameter.
@@ -1018,10 +985,23 @@ Notes:: The exception specifications aren't quite the same as the C++11 standard
 
 ---
 
+==== clear
+```c++
+void clear() noexcept;
+```
+
+Erases all elements in the container.
+
+Postconditions:: `size() == 0`
+
+Throws:: Never throws an exception.
+
+---
+
 ==== merge
 ```c++
-template<typename H2, typename P2>
-void merge(unordered_multimap<Key, Mapped, H2, P2, Alloc>& source);
+template<class H2, class P2>
+  void merge(unordered_multimap<Key, T, H2, P2, Allocator>& source);
 ```
 
 Notes:: Does not support merging with a compatible `unordered_map` yet.
@@ -1030,8 +1010,8 @@ Notes:: Does not support merging with a compatible `unordered_map` yet.
 
 ==== merge (rvalue reference)
 ```c++
-template<typename H2, typename P2>
-void merge(unordered_multimap<Key, Mapped, H2, P2, Alloc>&& source);
+template<class H2, class P2>
+  void merge(unordered_multimap<Key, T, H2, P2, Allocator>&& source);
 ```
 
 Notes:: Does not support merging with a compatible `unordered_map` yet.
@@ -1056,6 +1036,7 @@ Returns:: The container's hash function.
 
 ---
 
+==== key_eq
 ```
 key_equal key_eq() const;
 ```
@@ -1068,34 +1049,18 @@ Returns:: The container's key equality predicate
 
 ==== find
 ```c++
-iterator find(key_type const& k);
-const_iterator find(key_type const& k) const;
-
-template<typename K>
-iterator
-find(K const& k);
-
-template<typename K>
-const_iterator
-find(K const& k) const;
-
-template<
-  typename CompatibleKey,
-  typename CompatibleHash,
-  typename CompatiblePredicate>
-iterator
-find(CompatibleKey const& k,
-     CompatibleHash const& hash,
-     CompatiblePredicate const& eq);
-
-template<
-  typename CompatibleKey,
-  typename CompatibleHash,
-  typename CompatiblePredicate>
-const_iterator
-find(CompatibleKey const& k,
-      CompatibleHash const& hash,
-      CompatiblePredicate const& eq) const;
+iterator         find(const key_type& k);
+const_iterator   find(const key_type& k) const;
+template<class K>
+  iterator       find(const K& k);
+template<class K>
+  const_iterator find(const K& k) const;
+template<typename CompatibleKey, typename CompatibleHash, typename CompatiblePredicate>
+  iterator       find(CompatibleKey const& k, CompatibleHash const& hash,
+                      CompatiblePredicate const& eq);
+template<typename CompatibleKey, typename CompatibleHash, typename CompatiblePredicate>
+  const_iterator find(CompatibleKey const& k, CompatibleHash const& hash,
+                      CompatiblePredicate const& eq) const;
 
 ```
 
@@ -1106,24 +1071,11 @@ The `template <typename K>` overloads only participate in overload resolution if
 
 ---
 
-==== contains
-```c++
-template<typename K>
-bool contains(K const& key);
-bool contains(key_type const& key) const;
-```
-
-Returns:: A boolean indicating whether or not there is an element with key equal to `key` in the container
-
-Notes:: The `template <typename K>` overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
-
----
-
 ==== count
 ```c++
-template<typename K>
-size_type count(K const& k) const;
-size_type count(key_type const& k) const;
+size_type        count(const key_type& k) const;
+template<class K>
+  size_type      count(const K& k) const;
 ```
 
 Returns:: The number of elements with key equivalent to `k`.
@@ -1132,21 +1084,27 @@ Notes:: The `template <typename K>` overload only participates in overload resol
 
 ---
 
+==== contains
+```c++
+bool             contains(const key_type& k) const;
+template<class K>
+  bool           contains(const K& k) const;
+```
+
+Returns:: A boolean indicating whether or not there is an element with key equal to `key` in the container
+
+Notes:: The `template <typename K>` overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
+
+---
+
 ==== equal_range
 ```c++
-std::pair<iterator, iterator>
-equal_range(key_type const& k);
-
-std::pair<const_iterator, const_iterator>
-equal_range(key_type const& k) const;
-
-template<typename K>
-std::pair<iterator, iterator>
-equal_range(K const& k);
-
-template<typename K>
-std::pair<const_iterator, const_iterator>
-equal_range(K const& k) const;
+pair<iterator, iterator>               equal_range(const key_type& k);
+pair<const_iterator, const_iterator>   equal_range(const key_type& k) const;
+template<class K>
+  pair<iterator, iterator>             equal_range(const K& k);
+template<class K>
+  pair<const_iterator, const_iterator> equal_range(const K& k) const;
 ```
 
 Returns:: A range containing all elements with key equivalent to `k`. If the container doesn't contain any such elements, returns `std::make_pair(b.end(), b.end())`.
@@ -1159,7 +1117,7 @@ Notes:: The `template <typename K>` overloads only participate in overload resol
 
 ==== bucket_count
 ```c++
-size_type bucket_count() const;
+size_type bucket_count() const noexcept;
 ```
 
 Returns:: The number of buckets.
@@ -1168,7 +1126,7 @@ Returns:: The number of buckets.
 
 ==== max_bucket_count
 ```c++
-size_type max_bucket_count() const;
+size_type max_bucket_count() const noexcept;
 ```
 
 Returns:: An upper bound on the number of buckets.
@@ -1188,7 +1146,7 @@ Returns:: The number of elements in bucket `n`.
 
 ==== bucket
 ```c++
-size_type bucket(key_type const& k) const;
+size_type bucket(const key_type& k) const;
 ```
 
 Returns:: The index of the bucket which would contain an element with key `k`.
@@ -1248,7 +1206,7 @@ Returns:: A constant local iterator pointing the 'one past the end' element in t
 
 ==== load_factor
 ```c++
-float load_factor() const;
+float load_factor() const noexcept;
 ```
 
 Returns:: The average number of elements per bucket.
@@ -1258,7 +1216,7 @@ Returns:: The average number of elements per bucket.
 ==== max_load_factor
 
 ```c++
-float max_load_factor() const;
+float max_load_factor() const noexcept;
 ```
 
 Returns:: Returns the current maximum load factor.
@@ -1297,18 +1255,15 @@ Invalidates iterators, and changes the order of elements. Pointers and reference
 
 Throws:: The function has no effect if an exception is thrown, unless it is thrown by the container's hash function or comparison function.
 
+---
+
 === Equality Comparisons
 
 ==== operator==
 ```c++
-template<
-  typename Key,
-  typename Mapped,
-  typename Hash,
-  typename Pred,
-  typename Alloc>
-bool operator==(unordered_multimap<Key, Mapped, Hash, Pred, Alloc> const& x,
-                unordered_multimap<Key, Mapped, Hash, Pred, Alloc> const& y);
+template<class Key, class T, class Hash, class Pred, class Alloc>
+  bool operator==(const unordered_multimap<Key, T, Hash, Pred, Alloc>& x,
+                  const unordered_multimap<Key, T, Hash, Pred, Alloc>& y);
 ```
 
 Return `true` if `x.size() == y.size()` and for every equivalent key group in `x`, there is a group in `y` for the same key, which is a permutation (using `operator==` to compare the value types).
@@ -1319,26 +1274,23 @@ Notes:: The behavior of this function was changed to match the C++11 standard in
 
 ==== operator!=
 ```c++
-template<
-  typename Key,
-  typename Mapped,
-  typename Hash,
-  typename Pred,
-  typename Alloc>
-bool operator!=(unordered_multimap<Key, Mapped, Hash, Pred, Alloc> const& x,
-                unordered_multimap<Key, Mapped, Hash, Pred, Alloc> const& y);
+template<class Key, class T, class Hash, class Pred, class Alloc>
+  bool operator!=(const unordered_multimap<Key, T, Hash, Pred, Alloc>& x,
+                  const unordered_multimap<Key, T, Hash, Pred, Alloc>& y);
 ```
 
 Return `false` if `x.size() == y.size()` and for every equivalent key group in `x`, there is a group in `y` for the same key, which is a permutation (using `operator==` to compare the value types).
 
 Notes:: The behavior of this function was changed to match the C++11 standard in Boost 1.48. Behavior is undefined if the two containers don't have equivalent equality predicates.
 
+---
+
 === Swap
 ```c++
-template<typename Key, typename Mapped, typename Hash, typename Pred,
-         typename Alloc>
-void swap(unordered_multimap<Key, Mapped, Hash, Pred, Alloc>& x,
-          unordered_multimap<Key, Mapped, Hash, Pred, Alloc>& y);
+template<class Key, class T, class Hash, class Pred, class Alloc>
+  void swap(unordered_multimap<Key, T, Hash, Pred, Alloc>& x,
+            unordered_multimap<Key, T, Hash, Pred, Alloc>& y)
+    noexcept(noexcept(x.swap(y)));
 ```
 
 Swaps the contents of `x` and `y`.

--- a/doc/unordered/unordered_multimap.adoc
+++ b/doc/unordered/unordered_multimap.adoc
@@ -334,8 +334,9 @@ Constructs an empty container using `hasher()` as the hash function,
 `key_equal()` as the key equality predicate, `allocator_type()` as the allocator
 and a maximum load factor of `1.0`.
 
-Postconditions:: `size() == 0`
-Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+[horizontal]
+Postconditions:;; `size() == 0`
+Requires:;; If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
 ---
 
@@ -351,9 +352,9 @@ Constructs an empty container with at least `n` buckets, using `hf` as the hash
 function, `eql` as the key equality predicate, `a` as the allocator and a maximum
 load factor of `1.0`.
 
-Postconditions:: `size() == 0`
-
-Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+[horizontal]
+Postconditions:;; `size() == 0`
+Requires:;; If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
 ---
 
@@ -370,7 +371,8 @@ unordered_multimap(InputIterator f, InputIterator l,
 
 Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `eql` as the key equality predicate, `a` as the allocator and a maximum load factor of `1.0` and inserts the elements from `[f, l)` into it.
 
-Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+[horizontal]
+Requires:;; If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
 ---
 
@@ -383,7 +385,8 @@ The copy constructor. Copies the contained elements, hash function, predicate, m
 
 If `Allocator::select_on_container_copy_construction` exists and has the right signature, the allocator will be constructed from its result.
 
-Requires:: `value_type` is copy constructible
+[horizontal]
+Requires:;; `value_type` is copy constructible
 
 ---
 
@@ -394,9 +397,11 @@ unordered_multimap(unordered_multimap&& other);
 
 The move constructor.
 
-Notes:: This is implemented using Boost.Move.
-
-Requires:: `value_type` is move-constructible. On compilers without rvalue reference support the emulation does not support moving without calling `boost::move` if `value_type` is not copyable.
+[horizontal]
+Notes:;; This is implemented using Boost.Move.
+Requires:;; `value_type` is move-constructible. +
++
+On compilers without rvalue reference support the emulation does not support moving without calling `boost::move` if `value_type` is not copyable.
 So, for example, you can't return the container from a function.
 
 ---
@@ -426,8 +431,9 @@ unordered_multimap(unordered_multimap&& other, const Allocator& a);
 
 Construct a container moving ``other``'s contained elements, and having the hash function, predicate and maximum load factor, but using allocate `a`.
 
-Notes:: This is implemented using Boost.Move.
-Requires:: `value_type` is move insertable.
+[horizontal]
+Notes:;; This is implemented using Boost.Move.
+Requires:;; `value_type` is move insertable.
 
 ---
 
@@ -443,7 +449,8 @@ unordered_multimap(initializer_list<value_type> il,
 
 Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `eql` as the key equality predicate, `a` as the allocator and a maximum load factor of `1.0` and inserts the elements from `il` into it.
 
-Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+[horizontal]
+Requires:;; If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
 ---
 ==== Bucket Count Constructor with Allocator
@@ -453,8 +460,9 @@ unordered_multimap(size_type n, const allocator_type& a);
 
 Constructs an empty container with at least `n` buckets, using `hf` as the hash function, the default hash function and key equality predicate, `a` as the allocator and a maximum load factor of `1.0`.
 
-Postconditions:: `size() == 0`
-Requires:: `hasher` and `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+[horizontal]
+Postconditions:;; `size() == 0`
+Requires:;; `hasher` and `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
 ---
 
@@ -465,8 +473,9 @@ unordered_multimap(size_type n, const hasher& hf, const allocator_type& a);
 
 Constructs an empty container with at least `n` buckets, using `hf` as the hash function, the default key equality predicate, `a` as the allocator and a maximum load factor of `1.0`.
 
-Postconditions:: `size() == 0`
-Requires:: `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+[horizontal]
+Postconditions:;; `size() == 0`
+Requires:;; `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
 ---
 
@@ -479,7 +488,8 @@ template<class InputIterator>
 
 Constructs an empty container with at least `n` buckets, using `a` as the allocator, with the default hash function and key equality predicate and a maximum load factor of `1.0` and inserts the elements from `[f, l)` into it.
 
-Requires:: `hasher`, `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+[horizontal]
+Requires:;; `hasher`, `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
 ---
 
@@ -493,7 +503,8 @@ template<class InputIterator>
 
 Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `a` as the allocator, with the default key equality predicate and a maximum load factor of `1.0` and inserts the elements from `[f, l)` into it.
 
-Requires:: `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+[horizontal]
+Requires:;; `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
 ---
 
@@ -502,7 +513,9 @@ Requires:: `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/D
 ```c++
 ~unordered_multimap();
 ```
-Note:: The destructor is applied to every element, and all memory is deallocated
+
+[horizontal]
+Note:;; The destructor is applied to every element, and all memory is deallocated
 
 ---
 
@@ -518,7 +531,8 @@ The assignment operator. Copies the contained elements, hash function, predicate
 
 If `Alloc::propagate_on_container_copy_assignment` exists and `Alloc::propagate_on_container_copy_assignment::value` is `true`, the allocator is overwritten, if not the copied elements are created using the existing allocator.
 
-Requires:: `value_type` is copy constructible
+[horizontal]
+Requires:;; `value_type` is copy constructible
 
 ---
 
@@ -533,9 +547,9 @@ The move assignment operator.
 
 If `Alloc::propagate_on_container_move_assignment` exists and `Alloc::propagate_on_container_move_assignment::value` is `true`, the allocator is overwritten, if not the moved elements are created using the existing allocator.
 
-Notes:: On compilers without rvalue references, this is emulated using Boost.Move. Note that on some compilers the copy assignment operator may be used in some circumstances.
-
-Requires:: `value_type` is move constructible.
+[horizontal]
+Notes:;; On compilers without rvalue references, this is emulated using Boost.Move. Note that on some compilers the copy assignment operator may be used in some circumstances.
+Requires:;; `value_type` is move constructible.
 
 ---
 
@@ -546,7 +560,8 @@ unordered_multimap& operator=(initializer_list<value_type> il);
 
 Assign from values in initializer list. All existing elements are either overwritten by the new elements or destroyed.
 
-Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/CopyInsertable[CopyInsertable^] into the container and https://en.cppreference.com/w/cpp/named_req/CopyAssignable[CopyAssignable^].
+[horizontal]
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/CopyInsertable[CopyInsertable^] into the container and https://en.cppreference.com/w/cpp/named_req/CopyAssignable[CopyAssignable^].
 
 === Iterators
 
@@ -556,7 +571,8 @@ iterator begin() noexcept;
 const_iterator begin() const noexcept;
 ```
 
-Returns:: An iterator referring to the first element of the container, or if the container is empty the past-the-end value for the container.
+[horizontal]
+Returns:;; An iterator referring to the first element of the container, or if the container is empty the past-the-end value for the container.
 
 ---
 
@@ -566,7 +582,8 @@ iterator       end() noexcept;
 const_iterator end() const noexcept;
 ```
 
-Returns:: An iterator which refers to the past-the-end value for the container.
+[horizontal]
+Returns:;; An iterator which refers to the past-the-end value for the container.
 
 ---
 
@@ -574,7 +591,9 @@ Returns:: An iterator which refers to the past-the-end value for the container.
 ```c++
 const_iterator cbegin() const noexcept;
 ```
-Returns:: A `const_iterator` referring to the first element of the container, or if the container is empty the past-the-end value for the container.
+
+[horizontal]
+Returns:;; A `const_iterator` referring to the first element of the container, or if the container is empty the past-the-end value for the container.
 
 ---
 
@@ -583,7 +602,8 @@ Returns:: A `const_iterator` referring to the first element of the container, or
 const_iterator cend() const noexcept;
 ```
 
-Returns:: A `const_iterator` which refers to the past-the-end value for the container.
+[horizontal]
+Returns:;; A `const_iterator` which refers to the past-the-end value for the container.
 
 ---
 
@@ -595,7 +615,8 @@ Returns:: A `const_iterator` which refers to the past-the-end value for the cont
 bool empty() const noexcept;
 ```
 
-Returns:: `size() == 0`
+[horizontal]
+Returns:;; `size() == 0`
 
 ---
 
@@ -605,7 +626,8 @@ Returns:: `size() == 0`
 size_type size() const noexcept;
 ```
 
-Returns:: `std::distance(begin(), end())`
+[horizontal]
+Returns:;; `std::distance(begin(), end())`
 
 ---
 
@@ -615,7 +637,8 @@ Returns:: `std::distance(begin(), end())`
 size_type max_size() const noexcept;
 ```
 
-Returns:: `size()` of the largest possible container.
+[horizontal]
+Returns:;; `size()` of the largest possible container.
 
 ---
 
@@ -628,15 +651,16 @@ template<class... Args> iterator emplace(Args&&... args);
 
 Inserts an object, constructed with the arguments `args`, in the container.
 
-Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `args`.
-
-Returns:: An iterator pointing to the inserted element.
-
-Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-
-Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor.
-Pointers and references to elements are never invalidated.
-If the compiler doesn't support variadic template arguments or rvalue references, this is emulated for up to `10` arguments, with no support for rvalue references or move semantics.
+[horizontal]
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `args`.
+Returns:;; An iterator pointing to the inserted element.
+Throws:;; If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated. +
++
+If the compiler doesn't support variadic template arguments or rvalue references, this is emulated for up to `10` arguments, with no support for rvalue references or move semantics. +
++
 Since existing `std::pair` implementations don't support `std::piecewise_construct` this emulates it, but using `boost::unordered::piecewise_construct`.
 
 ---
@@ -650,16 +674,18 @@ Inserts an object, constructed with the arguments args, in the container.
 
 `position` is a suggestion to where the element should be inserted.
 
-Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `args`.
-
-Returns:: An iterator pointing to the inserted element.
-
-Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-
-Notes:: The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key.
-Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor.
-Pointers and references to elements are never invalidated.
-If the compiler doesn't support variadic template arguments or rvalue references, this is emulated for up to 10 arguments, with no support for rvalue references or move semantics.
+[horizontal]
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `args`.
+Returns:;; An iterator pointing to the inserted element.
+Throws:;; If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. +
++
+Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated. +
++
+If the compiler doesn't support variadic template arguments or rvalue references, this is emulated for up to 10 arguments, with no support for rvalue references or move semantics. +
++
 Since existing `std::pair` implementations don't support `std::piecewise_construct` this emulates it, but using `boost::unordered::piecewise_construct`.
 
 ---
@@ -671,13 +697,13 @@ iterator insert(const value_type& obj);
 
 Inserts `obj` in the container.
 
-Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/CopyInsertable[CopyInsertable^].
-
-Returns:: An iterator pointing to the inserted element.
-
-Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-
-Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated.
+[horizontal]
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/CopyInsertable[CopyInsertable^].
+Returns:;; An iterator pointing to the inserted element.
+Throws:;; If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated.
 
 ---
 
@@ -688,13 +714,13 @@ iterator insert(value_type&& obj);
 
 Inserts `obj` in the container.
 
-Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/MoveInsertable[MoveInsertable^].
-
-Returns:: An iterator pointing to the inserted element.
-
-Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-
-Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated.
+[horizontal]
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/MoveInsertable[MoveInsertable^].
+Returns:;; An iterator pointing to the inserted element.
+Throws:;; If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated.
 
 ---
 
@@ -707,7 +733,8 @@ Inserts an element into the container by performing `emplace(std::forward<P>(val
 
 Only participates in overload resolution if `std::is_constructible<value_type, P&&>::value` is `true`.
 
-Returns:: An iterator pointing to the inserted element.
+[horizontal]
+Returns:;; An iterator pointing to the inserted element.
 
 ---
 
@@ -719,13 +746,15 @@ Inserts `obj` in the container.
 
 `hint` is a suggestion to where the element should be inserted.
 
-Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/CopyInsertable[CopyInsertable^].
-
-Returns:: An iterator pointing to the inserted element.
-
-Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-
-Notes:: The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated.
+[horizontal]
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/CopyInsertable[CopyInsertable^].
+Returns:;; An iterator pointing to the inserted element.
+Throws:;; If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. +
++
+Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated.
 
 ---
 
@@ -738,13 +767,15 @@ Inserts `obj` in the container.
 
 `hint` is a suggestion to where the element should be inserted.
 
-Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/MoveInsertable[MoveInsertable^].
-
-Returns:: An iterator pointing to the inserted element.
-
-Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-
-Notes:: The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated.
+[horizontal]
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/MoveInsertable[MoveInsertable^].
+Returns:;; An iterator pointing to the inserted element.
+Throws:;; If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. +
++
+Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated.
 
 ---
 
@@ -759,9 +790,13 @@ Only participates in overload resolution if `std::is_constructible<value_type, P
 
 `hint` is a suggestion to where the element should be inserted.
 
-Returns:: An iterator pointing to the inserted element.
-
-Notes:: The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated.
+[horizontal]
+Returns:;; An iterator pointing to the inserted element.
+Notes:;; The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. +
++
+Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated.
 
 ---
 
@@ -772,11 +807,12 @@ template<class InputIterator> void insert(InputIterator first, InputIterator las
 
 Inserts a range of elements into the container.
 
-Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `*first`.
-
-Throws:: When inserting a single element, if an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-
-Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated.
+[horizontal]
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `*first`.
+Throws:;; When inserting a single element, if an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated.
 
 ---
 
@@ -787,11 +823,12 @@ void insert(initializer_list<value_type> il);
 
 Inserts a range of elements into the container.
 
-Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `*first`.
-
-Throws:: When inserting a single element, if an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-
-Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated.
+[horizontal]
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `*first`.
+Throws:;; When inserting a single element, if an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated.
 
 ---
 
@@ -802,9 +839,9 @@ node_type extract(const_iterator position);
 
 Removes the element pointed to by `position`.
 
-Returns:: A `node_type` owning the element.
-
-Notes:: In C++17 a node extracted using this method can be inserted into a compatible `unordered_map`, but that is not supported yet.
+[horizontal]
+Returns:;; A `node_type` owning the element.
+Notes:;; In C++17 a node extracted using this method can be inserted into a compatible `unordered_map`, but that is not supported yet.
 
 ---
 
@@ -815,11 +852,10 @@ node_type extract(const key_type& k);
 
 Removes an element with key equivalent to `k`.
 
-Returns:: A `node_type` owning the element if found, otherwise an empty `node_type`.
-
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
-
-Notes:: In C++17 a node extracted using this method can be inserted into a compatible `unordered_map`, but that is not supported yet.
+[horizontal]
+Returns:;; A `node_type` owning the element if found, otherwise an empty `node_type`.
+Throws:;; Only throws an exception if it is thrown by `hasher` or `key_equal`.
+Notes:;; In C++17 a node extracted using this method can be inserted into a compatible `unordered_map`, but that is not supported yet.
 
 ---
 
@@ -832,11 +868,10 @@ Removes an element with key equivalent to `k`.
 
 This overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs and neither `iterator` nor `const_iterator` are implicitly convertible from `K`. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
 
-Returns:: A `node_type` owning the element if found, otherwise an empty `node_type`.
-
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
-
-Notes:: In C++17 a node extracted using this method can be inserted into a compatible `unordered_map`, but that is not supported yet.
+[horizontal]
+Returns:;; A `node_type` owning the element if found, otherwise an empty `node_type`.
+Throws:;; Only throws an exception if it is thrown by `hasher` or `key_equal`.
+Notes:;; In C++17 a node extracted using this method can be inserted into a compatible `unordered_map`, but that is not supported yet.
 
 ---
 
@@ -849,13 +884,17 @@ If `nh` is empty, has no effect.
 
 Otherwise inserts the element owned by `nh`.
 
-Requires:: `nh` is empty or `nh.get_allocator()` is equal to the container's allocator.
-
-Returns:: If `nh` was empty, returns `end()`. Otherwise returns an iterator pointing to the newly inserted element.
-
-Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-
-Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated. In C++17 this can be used to insert a node extracted from a compatible `unordered_map`, but that is not supported yet.
+[horizontal]
+Requires:;; `nh` is empty or `nh.get_allocator()` is equal to the container's allocator.
+Returns:;; If `nh` was empty, returns `end()`. +
++
+Otherwise returns an iterator pointing to the newly inserted element.
+Throws:;; If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated. +
++
+In C++17 this can be used to insert a node extracted from a compatible `unordered_map`, but that is not supported yet.
 
 ---
 
@@ -870,15 +909,19 @@ Otherwise inserts the element owned by `nh`.
 
 `hint` is a suggestion to where the element should be inserted.
 
-Requires:: `nh` is empty or `nh.get_allocator()` is equal to the container's allocator.
-
-Returns:: If `nh` was empty, returns `end()`. +
+[horizontal]
+Requires:;; `nh` is empty or `nh.get_allocator()` is equal to the container's allocator.
+Returns:;; If `nh` was empty, returns `end()`. +
 +
 Otherwise returns an iterator pointing to the newly inserted element.
-
-Throws:: If an exception is thrown by an operation other than a call to hasher the function has no effect.
-
-Notes:: The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated. In C++17 this can be used to insert a node extracted from a compatible `unordered_map`, but that is not supported yet.
+Throws:;; If an exception is thrown by an operation other than a call to hasher the function has no effect.
+Notes:;; The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. +
++
+Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated. +
++
+In C++17 this can be used to insert a node extracted from a compatible `unordered_map`, but that is not supported yet.
 
 ---
 
@@ -891,11 +934,10 @@ iterator erase(const_iterator position);
 
 Erase the element pointed to by `position`.
 
-Returns:: The iterator following `position` before the erasure.
-
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
-
-Notes:: In older versions this could be inefficient because it had to search through several buckets to find the position of the returned iterator. The data structure has been changed so that this is no longer the case, and the alternative erase methods have been deprecated.
+[horizontal]
+Returns:;; The iterator following `position` before the erasure.
+Throws:;; Only throws an exception if it is thrown by `hasher` or `key_equal`.
+Notes:;; In older versions this could be inefficient because it had to search through several buckets to find the position of the returned iterator. The data structure has been changed so that this is no longer the case, and the alternative erase methods have been deprecated.
 
 ---
 
@@ -906,9 +948,9 @@ size_type erase(const key_type& k);
 
 Erase all elements with key equivalent to `k`.
 
-Returns:: The number of elements erased.
-
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
+[horizontal]
+Returns:;; The number of elements erased.
+Throws:;; Only throws an exception if it is thrown by `hasher` or `key_equal`.
 
 ---
 
@@ -921,9 +963,9 @@ Erase all elements with key equivalent to `k`.
 
 This overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs and neither `iterator` nor `const_iterator` are implicitly convertible from `K`. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
 
-Returns:: The number of elements erased.
-
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
+[horizontal]
+Returns:;; The number of elements erased.
+Throws:;; Only throws an exception if it is thrown by `hasher` or `key_equal`.
 
 ---
 
@@ -935,9 +977,11 @@ iterator erase(const_iterator first, const_iterator last);
 
 Erases the elements in the range from `first` to `last`.
 
-Returns:: The iterator following the erased elements - i.e. `last`.
-
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`. In this implementation, this overload doesn't call either function object's methods so it is no throw, but this might not be true in other implementations.
+[horizontal]
+Returns:;; The iterator following the erased elements - i.e. `last`.
+Throws:;; Only throws an exception if it is thrown by `hasher` or `key_equal`. +
++
+In this implementation, this overload doesn't call either function object's methods so it is no throw, but this might not be true in other implementations.
 
 ---
 
@@ -948,9 +992,11 @@ void quick_erase(const_iterator position);
 
 Erase the element pointed to by `position`.
 
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`. In this implementation, this overload doesn't call either function object's methods so it is no throw, but this might not be true in other implementations.
-
-Notes:: This method was implemented because returning an iterator to the next element from erase was expensive, but the container has been redesigned so that is no longer the case. So this method is now deprecated.
+[horizontal]
+Throws:;; Only throws an exception if it is thrown by `hasher` or `key_equal`. +
++
+In this implementation, this overload doesn't call either function object's methods so it is no throw, but this might not be true in other implementations.
+Notes:;; This method was implemented because returning an iterator to the next element from erase was expensive, but the container has been redesigned so that is no longer the case. So this method is now deprecated.
 
 ---
 
@@ -961,9 +1007,11 @@ void erase_return_void(const_iterator position);
 
 Erase the element pointed to by `position`.
 
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`. In this implementation, this overload doesn't call either function object's methods so it is no throw, but this might not be true in other implementations.
-
-Notes:: This method was implemented because returning an iterator to the next element from erase was expensive, but the container has been redesigned so that is no longer the case. So this method is now deprecated.
+[horizontal]
+Throws:;; Only throws an exception if it is thrown by `hasher` or `key_equal`. +
++
+In this implementation, this overload doesn't call either function object's methods so it is no throw, but this might not be true in other implementations.
+Notes:;; This method was implemented because returning an iterator to the next element from erase was expensive, but the container has been redesigned so that is no longer the case. So this method is now deprecated.
 
 ---
 
@@ -979,9 +1027,9 @@ Swaps the contents of the container with the parameter.
 
 If `Allocator::propagate_on_container_swap` is declared and `Allocator::propagate_on_container_swap::value` is `true` then the containers' allocators are swapped. Otherwise, swapping with unequal allocators results in undefined behavior.
 
-Throws:: Doesn't throw an exception unless it is thrown by the copy constructor or copy assignment operator of `key_equal` or `hasher`.
-
-Notes:: The exception specifications aren't quite the same as the C++11 standard, as the equality predicate and hash function are swapped using their copy constructors.
+[horizontal]
+Throws:;; Doesn't throw an exception unless it is thrown by the copy constructor or copy assignment operator of `key_equal` or `hasher`.
+Notes:;; The exception specifications aren't quite the same as the C++11 standard, as the equality predicate and hash function are swapped using their copy constructors.
 
 ---
 
@@ -992,9 +1040,9 @@ void clear() noexcept;
 
 Erases all elements in the container.
 
-Postconditions:: `size() == 0`
-
-Throws:: Never throws an exception.
+[horizontal]
+Postconditions:;; `size() == 0`
+Throws:;; Never throws an exception.
 
 ---
 
@@ -1004,7 +1052,8 @@ template<class H2, class P2>
   void merge(unordered_multimap<Key, T, H2, P2, Allocator>& source);
 ```
 
-Notes:: Does not support merging with a compatible `unordered_map` yet.
+[horizontal]
+Notes:;; Does not support merging with a compatible `unordered_map` yet.
 
 ---
 
@@ -1014,7 +1063,8 @@ template<class H2, class P2>
   void merge(unordered_multimap<Key, T, H2, P2, Allocator>&& source);
 ```
 
-Notes:: Does not support merging with a compatible `unordered_map` yet.
+[horizontal]
+Notes:;; Does not support merging with a compatible `unordered_map` yet.
 
 ---
 
@@ -1032,7 +1082,8 @@ allocator_type get_allocator() const;
 hasher hash_function() const;
 ```
 
-Returns:: The container's hash function.
+[horizontal]
+Returns:;; The container's hash function.
 
 ---
 
@@ -1041,7 +1092,8 @@ Returns:: The container's hash function.
 key_equal key_eq() const;
 ```
 
-Returns:: The container's key equality predicate
+[horizontal]
+Returns:;; The container's key equality predicate
 
 ---
 
@@ -1064,9 +1116,10 @@ template<typename CompatibleKey, typename CompatibleHash, typename CompatiblePre
 
 ```
 
-Returns:: An iterator pointing to an element with key equivalent to `k`, or `b.end()` if no such element exists.
-
-Notes:: The templated overloads containing `CompatibleKey`, `CompatibleHash` and `CompatiblePredicate` are non-standard extensions which allow you to use a compatible hash function and equality predicate for a key of a different type in order to avoid an expensive type cast. In general, its use is not encouraged and instead the `K` member function templates should be used. +
+[horizontal]
+Returns:;; An iterator pointing to an element with key equivalent to `k`, or `b.end()` if no such element exists.
+Notes:;; The templated overloads containing `CompatibleKey`, `CompatibleHash` and `CompatiblePredicate` are non-standard extensions which allow you to use a compatible hash function and equality predicate for a key of a different type in order to avoid an expensive type cast. In general, its use is not encouraged and instead the `K` member function templates should be used. +
++
 The `template <typename K>` overloads only participate in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
 
 ---
@@ -1078,9 +1131,9 @@ template<class K>
   size_type      count(const K& k) const;
 ```
 
-Returns:: The number of elements with key equivalent to `k`.
-
-Notes:: The `template <typename K>` overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
+[horizontal]
+Returns:;; The number of elements with key equivalent to `k`.
+Notes:;; The `template <typename K>` overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
 
 ---
 
@@ -1091,9 +1144,9 @@ template<class K>
   bool           contains(const K& k) const;
 ```
 
-Returns:: A boolean indicating whether or not there is an element with key equal to `key` in the container
-
-Notes:: The `template <typename K>` overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
+[horizontal]
+Returns:;; A boolean indicating whether or not there is an element with key equal to `key` in the container
+Notes:;; The `template <typename K>` overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
 
 ---
 
@@ -1107,9 +1160,9 @@ template<class K>
   pair<const_iterator, const_iterator> equal_range(const K& k) const;
 ```
 
-Returns:: A range containing all elements with key equivalent to `k`. If the container doesn't contain any such elements, returns `std::make_pair(b.end(), b.end())`.
-
-Notes:: The `template <typename K>` overloads only participate in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
+[horizontal]
+Returns:;; A range containing all elements with key equivalent to `k`. If the container doesn't contain any such elements, returns `std::make_pair(b.end(), b.end())`.
+Notes:;; The `template <typename K>` overloads only participate in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
 
 ---
 
@@ -1120,7 +1173,8 @@ Notes:: The `template <typename K>` overloads only participate in overload resol
 size_type bucket_count() const noexcept;
 ```
 
-Returns:: The number of buckets.
+[horizontal]
+Returns:;; The number of buckets.
 
 ---
 
@@ -1129,7 +1183,8 @@ Returns:: The number of buckets.
 size_type max_bucket_count() const noexcept;
 ```
 
-Returns:: An upper bound on the number of buckets.
+[horizontal]
+Returns:;; An upper bound on the number of buckets.
 
 ---
 
@@ -1138,9 +1193,9 @@ Returns:: An upper bound on the number of buckets.
 size_type bucket_size(size_type n) const;
 ```
 
-Requires:: `n < bucket_count()`
-
-Returns:: The number of elements in bucket `n`.
+[horizontal]
+Requires:;; `n < bucket_count()`
+Returns:;; The number of elements in bucket `n`.
 
 ---
 
@@ -1149,9 +1204,9 @@ Returns:: The number of elements in bucket `n`.
 size_type bucket(const key_type& k) const;
 ```
 
-Returns:: The index of the bucket which would contain an element with key `k`.
-
-Postconditions:: The return value is less than `bucket_count()`.
+[horizontal]
+Returns:;; The index of the bucket which would contain an element with key `k`.
+Postconditions:;; The return value is less than `bucket_count()`.
 
 ---
 
@@ -1162,9 +1217,9 @@ local_iterator begin(size_type n);
 const_local_iterator begin(size_type n) const;
 ```
 
-Requires:: `n` shall be in the range `[0, bucket_count())`.
-
-Returns:: A local iterator pointing the first element in the bucket with index `n`.
+[horizontal]
+Requires:;; `n` shall be in the range `[0, bucket_count())`.
+Returns:;; A local iterator pointing the first element in the bucket with index `n`.
 
 ---
 
@@ -1174,9 +1229,9 @@ local_iterator end(size_type n);
 const_local_iterator end(size_type n) const;
 ```
 
-Requires:: `n` shall be in the range `[0, bucket_count())`.
-
-Returns:: A local iterator pointing the 'one past the end' element in the bucket with index `n`.
+[horizontal]
+Requires:;; `n` shall be in the range `[0, bucket_count())`.
+Returns:;; A local iterator pointing the 'one past the end' element in the bucket with index `n`.
 
 ---
 
@@ -1185,9 +1240,9 @@ Returns:: A local iterator pointing the 'one past the end' element in the bucket
 const_local_iterator cbegin(size_type n) const;
 ```
 
-Requires:: `n` shall be in the range `[0, bucket_count())`.
-
-Returns:: A constant local iterator pointing the first element in the bucket with index `n`.
+[horizontal]
+Requires:;; `n` shall be in the range `[0, bucket_count())`.
+Returns:;; A constant local iterator pointing the first element in the bucket with index `n`.
 
 ---
 
@@ -1196,9 +1251,9 @@ Returns:: A constant local iterator pointing the first element in the bucket wit
 const_local_iterator cend(size_type n) const;
 ```
 
-Requires:: `n` shall be in the range `[0, bucket_count())`.
-
-Returns:: A constant local iterator pointing the 'one past the end' element in the bucket with index `n`.
+[horizontal]
+Requires:;; `n` shall be in the range `[0, bucket_count())`.
+Returns:;; A constant local iterator pointing the 'one past the end' element in the bucket with index `n`.
 
 ---
 
@@ -1209,7 +1264,8 @@ Returns:: A constant local iterator pointing the 'one past the end' element in t
 float load_factor() const noexcept;
 ```
 
-Returns:: The average number of elements per bucket.
+[horizontal]
+Returns:;; The average number of elements per bucket.
 
 ---
 
@@ -1219,7 +1275,8 @@ Returns:: The average number of elements per bucket.
 float max_load_factor() const noexcept;
 ```
 
-Returns:: Returns the current maximum load factor.
+[horizontal]
+Returns:;; Returns the current maximum load factor.
 
 ---
 
@@ -1228,7 +1285,8 @@ Returns:: Returns the current maximum load factor.
 void max_load_factor(float z);
 ```
 
-Effects:: Changes the container's maximum load factor, using `z` as a hint.
+[horizontal]
+Effects:;; Changes the container's maximum load factor, using `z` as a hint.
 
 ---
 
@@ -1242,7 +1300,8 @@ Changes the number of buckets so that there at least `n` buckets, and so that th
 
 Invalidates iterators, and changes the order of elements. Pointers and references to elements are not invalidated.
 
-Throws:: The function has no effect if an exception is thrown, unless it is thrown by the container's hash function or comparison function.
+[horizontal]
+Throws:;; The function has no effect if an exception is thrown, unless it is thrown by the container's hash function or comparison function.
 
 ---
 
@@ -1253,7 +1312,8 @@ void reserve(size_type n);
 
 Invalidates iterators, and changes the order of elements. Pointers and references to elements are not invalidated.
 
-Throws:: The function has no effect if an exception is thrown, unless it is thrown by the container's hash function or comparison function.
+[horizontal]
+Throws:;; The function has no effect if an exception is thrown, unless it is thrown by the container's hash function or comparison function.
 
 ---
 
@@ -1268,7 +1328,10 @@ template<class Key, class T, class Hash, class Pred, class Alloc>
 
 Return `true` if `x.size() == y.size()` and for every equivalent key group in `x`, there is a group in `y` for the same key, which is a permutation (using `operator==` to compare the value types).
 
-Notes:: The behavior of this function was changed to match the C++11 standard in Boost 1.48. Behavior is undefined if the two containers don't have equivalent equality predicates.
+[horizontal]
+Notes:;; The behavior of this function was changed to match the C++11 standard in Boost 1.48. +
++
+Behavior is undefined if the two containers don't have equivalent equality predicates.
 
 ---
 
@@ -1281,7 +1344,10 @@ template<class Key, class T, class Hash, class Pred, class Alloc>
 
 Return `false` if `x.size() == y.size()` and for every equivalent key group in `x`, there is a group in `y` for the same key, which is a permutation (using `operator==` to compare the value types).
 
-Notes:: The behavior of this function was changed to match the C++11 standard in Boost 1.48. Behavior is undefined if the two containers don't have equivalent equality predicates.
+[horizontal]
+Notes:;; The behavior of this function was changed to match the C++11 standard in Boost 1.48. +
++
+Behavior is undefined if the two containers don't have equivalent equality predicates.
 
 ---
 
@@ -1297,10 +1363,9 @@ Swaps the contents of `x` and `y`.
 
 If `Allocator::propagate_on_container_swap` is declared and `Allocator::propagate_on_container_swap::value` is `true` then the containers' allocators are swapped. Otherwise, swapping with unequal allocators results in undefined behavior.
 
-Effects:: `x.swap(y)`
-
-Throws:: Doesn't throw an exception unless it is thrown by the copy constructor or copy assignment operator of `key_equal` or `hasher`.
-
-Notes:: The exception specifications aren't quite the same as the C++11 standard, as the equality predicate and hash function are swapped using their copy constructors.
+[horizontal]
+Effects:;; `x.swap(y)`
+Throws:;; Doesn't throw an exception unless it is thrown by the copy constructor or copy assignment operator of `key_equal` or `hasher`.
+Notes:;; The exception specifications aren't quite the same as the C++11 standard, as the equality predicate and hash function are swapped using their copy constructors.
 
 

--- a/doc/unordered/unordered_multiset.adoc
+++ b/doc/unordered/unordered_multiset.adoc
@@ -326,8 +326,9 @@ Constructs an empty container using `hasher()` as the hash function,
 `key_equal()` as the key equality predicate, `allocator_type()` as the allocator
 and a maximum load factor of `1.0`.
 
-Postconditions:: `size() == 0`
-Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+[horizontal]
+Postconditions:;; `size() == 0`
+Requires:;; If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
 ---
 
@@ -343,9 +344,9 @@ Constructs an empty container with at least `n` buckets, using `hf` as the hash
 function, `eql` as the key equality predicate, `a` as the allocator and a maximum
 load factor of `1.0`.
 
-Postconditions:: `size() == 0`
-
-Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+[horizontal]
+Postconditions:;; `size() == 0`
+Requires:;; If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
 ---
 
@@ -362,7 +363,8 @@ template<class InputIterator>
 
 Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `eql` as the key equality predicate, `a` as the allocator and a maximum load factor of `1.0` and inserts the elements from `[f, l)` into it.
 
-Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+[horizontal]
+Requires:;; If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
 ---
 
@@ -375,7 +377,8 @@ The copy constructor. Copies the contained elements, hash function, predicate, m
 
 If `Allocator::select_on_container_copy_construction` exists and has the right signature, the allocator will be constructed from its result.
 
-Requires:: `value_type` is copy constructible
+[horizontal]
+Requires:;; `value_type` is copy constructible
 
 ---
 
@@ -386,9 +389,11 @@ unordered_multiset(unordered_multiset&& other);
 
 The move constructor.
 
-Notes:: This is implemented using Boost.Move.
-
-Requires:: `value_type` is move-constructible. On compilers without rvalue reference support the emulation does not support moving without calling `boost::move` if `value_type` is not copyable.
+[horizontal]
+Notes:;; This is implemented using Boost.Move.
+Requires:;; `value_type` is move-constructible. +
++
+On compilers without rvalue reference support the emulation does not support moving without calling `boost::move` if `value_type` is not copyable.
 So, for example, you can't return the container from a function.
 
 ---
@@ -418,8 +423,9 @@ unordered_multiset(unordered_multiset&& other, const Allocator& a);
 
 Construct a container moving ``other``'s contained elements, and having the hash function, predicate and maximum load factor, but using allocate `a`.
 
-Notes:: This is implemented using Boost.Move.
-Requires:: `value_type` is move insertable.
+[horizontal]
+Notes:;; This is implemented using Boost.Move.
+Requires:;; `value_type` is move insertable.
 
 ---
 
@@ -435,7 +441,8 @@ unordered_multiset(initializer_list<value_type> il,
 
 Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `eql` as the key equality predicate, `a` as the allocator and a maximum load factor of `1.0` and inserts the elements from `il` into it.
 
-Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+[horizontal]
+Requires:;; If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
 ---
 
@@ -446,8 +453,9 @@ unordered_multiset(size_type n, const allocator_type& a);
 
 Constructs an empty container with at least `n` buckets, using `hf` as the hash function, the default hash function and key equality predicate, `a` as the allocator and a maximum load factor of `1.0`.
 
-Postconditions:: `size() == 0`
-Requires:: `hasher` and `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+[horizontal]
+Postconditions:;; `size() == 0`
+Requires:;; `hasher` and `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
 ---
 
@@ -458,8 +466,9 @@ unordered_multiset(size_type n, const hasher& hf, const allocator_type& a);
 
 Constructs an empty container with at least `n` buckets, using `hf` as the hash function, the default key equality predicate, `a` as the allocator and a maximum load factor of `1.0`.
 
-Postconditions:: `size() == 0`
-Requires:: `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+[horizontal]
+Postconditions:;; `size() == 0`
+Requires:;; `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
 ---
 
@@ -472,7 +481,8 @@ template<class InputIterator>
 
 Constructs an empty container with at least `n` buckets, using `a` as the allocator, with the default hash function and key equality predicate and a maximum load factor of `1.0` and inserts the elements from `[f, l)` into it.
 
-Requires:: `hasher`, `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+[horizontal]
+Requires:;; `hasher`, `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
 ---
 
@@ -486,7 +496,8 @@ template<class InputIterator>
 
 Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `a` as the allocator, with the default key equality predicate and a maximum load factor of `1.0` and inserts the elements from `[f, l)` into it.
 
-Requires:: `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+[horizontal]
+Requires:;; `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
 ---
 
@@ -496,7 +507,8 @@ Requires:: `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/D
 ~unordered_multiset();
 ```
 
-Note:: The destructor is applied to every element, and all memory is deallocated
+[horizontal]
+Note:;; The destructor is applied to every element, and all memory is deallocated
 
 ---
 
@@ -512,7 +524,8 @@ The assignment operator. Copies the contained elements, hash function, predicate
 
 If `Alloc::propagate_on_container_copy_assignment` exists and `Alloc::propagate_on_container_copy_assignment::value` is `true`, the allocator is overwritten, if not the copied elements are created using the existing allocator.
 
-Requires:: `value_type` is copy constructible
+[horizontal]
+Requires:;; `value_type` is copy constructible
 
 ---
 
@@ -527,9 +540,9 @@ The move assignment operator.
 
 If `Alloc::propagate_on_container_move_assignment` exists and `Alloc::propagate_on_container_move_assignment::value` is `true`, the allocator is overwritten, if not the moved elements are created using the existing allocator.
 
-Notes:: On compilers without rvalue references, this is emulated using Boost.Move. Note that on some compilers the copy assignment operator may be used in some circumstances.
-
-Requires:: `value_type` is move constructible.
+[horizontal]
+Notes:;; On compilers without rvalue references, this is emulated using Boost.Move. Note that on some compilers the copy assignment operator may be used in some circumstances.
+Requires:;; `value_type` is move constructible.
 
 ---
 
@@ -540,7 +553,8 @@ unordered_multiset& operator=(initializer_list<value_type> il);
 
 Assign from values in initializer list. All existing elements are either overwritten by the new elements or destroyed.
 
-Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/CopyInsertable[CopyInsertable^] into the container and https://en.cppreference.com/w/cpp/named_req/CopyAssignable[CopyAssignable^].
+[horizontal]
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/CopyInsertable[CopyInsertable^] into the container and https://en.cppreference.com/w/cpp/named_req/CopyAssignable[CopyAssignable^].
 
 ---
 
@@ -552,7 +566,8 @@ iterator       begin() noexcept;
 const_iterator begin() const noexcept;
 ```
 
-Returns:: An iterator referring to the first element of the container, or if the container is empty the past-the-end value for the container.
+[horizontal]
+Returns:;; An iterator referring to the first element of the container, or if the container is empty the past-the-end value for the container.
 
 ---
 
@@ -562,7 +577,8 @@ iterator       end() noexcept;
 const_iterator end() const noexcept;
 ```
 
-Returns:: An iterator which refers to the past-the-end value for the container.
+[horizontal]
+Returns:;; An iterator which refers to the past-the-end value for the container.
 
 ---
 
@@ -570,7 +586,9 @@ Returns:: An iterator which refers to the past-the-end value for the container.
 ```c++
 const_iterator cbegin() const noexcept;
 ```
-Returns:: A `const_iterator` referring to the first element of the container, or if the container is empty the past-the-end value for the container.
+
+[horizontal]
+Returns:;; A `const_iterator` referring to the first element of the container, or if the container is empty the past-the-end value for the container.
 
 ---
 
@@ -579,7 +597,8 @@ Returns:: A `const_iterator` referring to the first element of the container, or
 const_iterator cend() const noexcept;
 ```
 
-Returns:: A `const_iterator` which refers to the past-the-end value for the container.
+[horizontal]
+Returns:;; A `const_iterator` which refers to the past-the-end value for the container.
 
 ---
 
@@ -591,7 +610,8 @@ Returns:: A `const_iterator` which refers to the past-the-end value for the cont
 bool empty() const noexcept;
 ```
 
-Returns:: `size() == 0`
+[horizontal]
+Returns:;; `size() == 0`
 
 ---
 
@@ -601,7 +621,8 @@ Returns:: `size() == 0`
 size_type size() const noexcept;
 ```
 
-Returns:: `std::distance(begin(), end())`
+[horizontal]
+Returns:;; `std::distance(begin(), end())`
 
 ---
 
@@ -611,7 +632,8 @@ Returns:: `std::distance(begin(), end())`
 size_type max_size() const noexcept;
 ```
 
-Returns:: `size()` of the largest possible container.
+[horizontal]
+Returns:;; `size()` of the largest possible container.
 
 ---
 
@@ -624,15 +646,16 @@ template<class... Args> iterator emplace(Args&&... args);
 
 Inserts an object, constructed with the arguments args, in the container.
 
-Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `args`.
-
-Returns:: An iterator pointing to the inserted element.
-
-Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-
-Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor.
-Pointers and references to elements are never invalidated.
-If the compiler doesn't support variadic template arguments or rvalue references, this is emulated for up to `10` arguments, with no support for rvalue references or move semantics.
+[horizontal]
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `args`.
+Returns:;; An iterator pointing to the inserted element.
+Throws:;; If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated. +
++
+If the compiler doesn't support variadic template arguments or rvalue references, this is emulated for up to `10` arguments, with no support for rvalue references or move semantics. +
++
 Since existing `std::pair` implementations don't support `std::piecewise_construct` this emulates it, but using `boost::unordered::piecewise_construct`.
 
 ---
@@ -646,16 +669,18 @@ Inserts an object, constructed with the arguments args, in the container.
 
 `hint` is a suggestion to where the element should be inserted.
 
-Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `args`.
-
-Returns:: An iterator pointing to the inserted element.
-
-Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-
-Notes:: The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key.
-Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor.
-Pointers and references to elements are never invalidated.
-If the compiler doesn't support variadic template arguments or rvalue references, this is emulated for up to 10 arguments, with no support for rvalue references or move semantics.
+[horizontal]
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `args`.
+Returns:;; An iterator pointing to the inserted element.
+Throws:;; If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. +
++
+Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated. +
++
+If the compiler doesn't support variadic template arguments or rvalue references, this is emulated for up to 10 arguments, with no support for rvalue references or move semantics. +
++
 Since existing `std::pair` implementations don't support `std::piecewise_construct` this emulates it, but using `boost::unordered::piecewise_construct`.
 
 ---
@@ -667,13 +692,13 @@ iterator insert(const value_type& obj);
 
 Inserts `obj` in the container.
 
-Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/CopyInsertable[CopyInsertable^].
-
-Returns:: An iterator pointing to the inserted element.
-
-Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-
-Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated.
+[horizontal]
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/CopyInsertable[CopyInsertable^].
+Returns:;; An iterator pointing to the inserted element.
+Throws:;; If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated.
 
 ---
 
@@ -684,13 +709,13 @@ iterator insert(value_type&& obj);
 
 Inserts `obj` in the container.
 
-Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/MoveInsertable[MoveInsertable^].
-
-Returns:: An iterator pointing to the inserted element.
-
-Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-
-Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated.
+[horizontal]
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/MoveInsertable[MoveInsertable^].
+Returns:;; An iterator pointing to the inserted element.
+Throws:;; If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated.
 
 ---
 
@@ -703,13 +728,15 @@ Inserts `obj` in the container.
 
 `hint` is a suggestion to where the element should be inserted.
 
-Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/CopyInsertable[CopyInsertable^].
-
-Returns:: An iterator pointing to the inserted element.
-
-Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-
-Notes:: The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated.
+[horizontal]
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/CopyInsertable[CopyInsertable^].
+Returns:;; An iterator pointing to the inserted element.
+Throws:;; If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. +
++
+Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated.
 
 ---
 
@@ -722,13 +749,15 @@ Inserts `obj` in the container.
 
 `hint` is a suggestion to where the element should be inserted.
 
-Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/MoveInsertable[MoveInsertable^].
-
-Returns:: An iterator pointing to the inserted element.
-
-Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-
-Notes:: The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated.
+[horizontal]
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/MoveInsertable[MoveInsertable^].
+Returns:;; An iterator pointing to the inserted element.
+Throws:;; If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. +
++
+Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated.
 
 ---
 
@@ -739,11 +768,12 @@ template<class InputIterator> void insert(InputIterator first, InputIterator las
 
 Inserts a range of elements into the container.
 
-Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `*first`.
-
-Throws:: When inserting a single element, if an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-
-Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated.
+[horizontal]
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `*first`.
+Throws:;; When inserting a single element, if an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated.
 
 ---
 
@@ -754,11 +784,12 @@ void insert(initializer_list<value_type> il);
 
 Inserts a range of elements into the container. Elements are inserted if and only if there is no element in the container with an equivalent key.
 
-Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `*first`.
-
-Throws:: When inserting a single element, if an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-
-Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated.
+[horizontal]
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `*first`.
+Throws:;; When inserting a single element, if an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated.
 
 ---
 
@@ -769,9 +800,9 @@ node_type extract(const_iterator position);
 
 Removes the element pointed to by `position`.
 
-Returns:: A `node_type` owning the element.
-
-Notes:: In C++17 a node extracted using this method can be inserted into a compatible `unordered_set`, but that is not supported yet.
+[horizontal]
+Returns:;; A `node_type` owning the element.
+Notes:;; In C++17 a node extracted using this method can be inserted into a compatible `unordered_set`, but that is not supported yet.
 
 ---
 
@@ -782,11 +813,10 @@ node_type extract(const key_type& k);
 
 Removes an element with key equivalent to `k`.
 
-Returns:: A `node_type` owning the element if found, otherwise an empty `node_type`.
-
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
-
-Notes:: In C++17 a node extracted using this method can be inserted into a compatible `unordered_set`, but that is not supported yet.
+[horizontal]
+Returns:;; A `node_type` owning the element if found, otherwise an empty `node_type`.
+Throws:;; Only throws an exception if it is thrown by `hasher` or `key_equal`.
+Notes:;; In C++17 a node extracted using this method can be inserted into a compatible `unordered_set`, but that is not supported yet.
 
 ---
 
@@ -799,11 +829,10 @@ Removes an element with key equivalent to `k`.
 
 This overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs and neither `iterator` nor `const_iterator` are implicitly convertible from `K`. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
 
-Returns:: A `node_type` owning the element if found, otherwise an empty `node_type`.
-
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
-
-Notes:: In C++17 a node extracted using this method can be inserted into a compatible `unordered_set`, but that is not supported yet.
+[horizontal]
+Returns:;; A `node_type` owning the element if found, otherwise an empty `node_type`.
+Throws:;; Only throws an exception if it is thrown by `hasher` or `key_equal`.[horizontal]
+Notes:;; In C++17 a node extracted using this method can be inserted into a compatible `unordered_set`, but that is not supported yet.
 
 ---
 
@@ -816,13 +845,15 @@ If `nh` is empty, has no effect.
 
 Otherwise inserts the element owned by `nh`.
 
-Requires:: `nh` is empty or `nh.get_allocator()` is equal to the container's allocator.
-
-Returns::  If `nh` was empty, returns `end()`. Otherwise returns an iterator pointing to the newly inserted element.
-
-Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-
-Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated. In C++17 this can be used to insert a node extracted from a compatible `unordered_set`, but that is not supported yet.
+[horizontal]
+Requires:;; `nh` is empty or `nh.get_allocator()` is equal to the container's allocator.
+Returns:;; If `nh` was empty, returns `end()`. +
++
+Otherwise returns an iterator pointing to the newly inserted element.
+Throws:;; If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated. In C++17 this can be used to insert a node extracted from a compatible `unordered_set`, but that is not supported yet.
 
 ---
 
@@ -837,15 +868,19 @@ Otherwise inserts the element owned by `nh`.
 
 `hint` is a suggestion to where the element should be inserted.
 
-Requires:: `nh` is empty or `nh.get_allocator()` is equal to the container's allocator.
-
-Returns:: If `nh` was empty, returns `end()`.
-
+[horizontal]
+Requires:;; `nh` is empty or `nh.get_allocator()` is equal to the container's allocator.
+Returns:;; If `nh` was empty, returns `end()`. +
++
 Otherwise returns an iterator pointing to the newly inserted element.
-
-Throws:: If an exception is thrown by an operation other than a call to hasher the function has no effect.
-
-Notes:: The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated. In C++17 this can be used to insert a node extracted from a compatible `unordered_set`, but that is not supported yet.
+Throws:;; If an exception is thrown by an operation other than a call to hasher the function has no effect.
+Notes:;; The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. +
++
+Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated. +
++
+In C++17 this can be used to insert a node extracted from a compatible `unordered_set`, but that is not supported yet.
 
 ---
 
@@ -858,11 +893,10 @@ iterator erase(const_iterator position);
 
 Erase the element pointed to by `position`.
 
-Returns:: The iterator following `position` before the erasure.
-
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
-
-Notes:: In older versions this could be inefficient because it had to search through several buckets to find the position of the returned iterator. The data structure has been changed so that this is no longer the case, and the alternative erase methods have been deprecated.
+[horizontal]
+Returns:;; The iterator following `position` before the erasure.
+Throws:;; Only throws an exception if it is thrown by `hasher` or `key_equal`.
+Notes:;; In older versions this could be inefficient because it had to search through several buckets to find the position of the returned iterator. The data structure has been changed so that this is no longer the case, and the alternative erase methods have been deprecated.
 
 ---
 
@@ -873,9 +907,9 @@ size_type erase(const key_type& k);
 
 Erase all elements with key equivalent to `k`.
 
-Returns:: The number of elements erased.
-
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
+[horizontal]
+Returns:;; The number of elements erased.
+Throws:;; Only throws an exception if it is thrown by `hasher` or `key_equal`.
 
 ---
 
@@ -888,9 +922,9 @@ Erase all elements with key equivalent to `k`.
 
 This overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs and neither `iterator` nor `const_iterator` are implicitly convertible from `K`. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
 
-Returns:: The number of elements erased.
-
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
+[horizontal]
+Returns:;; The number of elements erased.
+Throws:;; Only throws an exception if it is thrown by `hasher` or `key_equal`.
 
 ---
 
@@ -902,9 +936,11 @@ iterator erase(const_iterator first, const_iterator last);
 
 Erases the elements in the range from `first` to `last`.
 
-Returns:: The iterator following the erased elements - i.e. `last`.
-
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`. In this implementation, this overload doesn't call either function object's methods so it is no throw, but this might not be true in other implementations.
+[horizontal]
+Returns:;; The iterator following the erased elements - i.e. `last`.
+Throws:;; Only throws an exception if it is thrown by `hasher` or `key_equal`. +
++
+In this implementation, this overload doesn't call either function object's methods so it is no throw, but this might not be true in other implementations.
 
 ---
 
@@ -915,9 +951,11 @@ void quick_erase(const_iterator position);
 
 Erase the element pointed to by `position`.
 
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`. In this implementation, this overload doesn't call either function object's methods so it is no throw, but this might not be true in other implementations.
-
-Notes:: This method was implemented because returning an iterator to the next element from erase was expensive, but the container has been redesigned so that is no longer the case. So this method is now deprecated.
+[horizontal]
+Throws:;; Only throws an exception if it is thrown by `hasher` or `key_equal`. +
++
+In this implementation, this overload doesn't call either function object's methods so it is no throw, but this might not be true in other implementations.
+Notes:;; This method was implemented because returning an iterator to the next element from erase was expensive, but the container has been redesigned so that is no longer the case. So this method is now deprecated.
 
 ---
 
@@ -928,9 +966,11 @@ void erase_return_void(const_iterator position);
 
 Erase the element pointed to by `position`.
 
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`. In this implementation, this overload doesn't call either function object's methods so it is no throw, but this might not be true in other implementations.
-
-Notes:: This method was implemented because returning an iterator to the next element from erase was expensive, but the container has been redesigned so that is no longer the case. So this method is now deprecated.
+[horizontal]
+Throws:;; Only throws an exception if it is thrown by `hasher` or `key_equal`. +
++
+In this implementation, this overload doesn't call either function object's methods so it is no throw, but this might not be true in other implementations.
+Notes:;; This method was implemented because returning an iterator to the next element from erase was expensive, but the container has been redesigned so that is no longer the case. So this method is now deprecated.
 
 ---
 
@@ -946,9 +986,9 @@ Swaps the contents of the container with the parameter.
 
 If `Allocator::propagate_on_container_swap` is declared and `Allocator::propagate_on_container_swap::value` is `true` then the containers' allocators are swapped. Otherwise, swapping with unequal allocators results in undefined behavior.
 
-Throws:: Doesn't throw an exception unless it is thrown by the copy constructor or copy assignment operator of `key_equal` or `hasher`.
-
-Notes:: The exception specifications aren't quite the same as the C++11 standard, as the equality predicate and hash function are swapped using their copy constructors.
+[horizontal]
+Throws:;; Doesn't throw an exception unless it is thrown by the copy constructor or copy assignment operator of `key_equal` or `hasher`.
+Notes:;; The exception specifications aren't quite the same as the C++11 standard, as the equality predicate and hash function are swapped using their copy constructors.
 
 ---
 
@@ -959,9 +999,9 @@ void clear() noexcept;
 
 Erases all elements in the container.
 
-Postconditions:: `size() == 0`
-
-Throws:: Never throws an exception.
+[horizontal]
+Postconditions:;; `size() == 0`
+Throws:;; Never throws an exception.
 
 ---
 
@@ -971,7 +1011,8 @@ template<class H2, class P2>
   void merge(unordered_multiset<Key, H2, P2, Allocator>& source);
 ```
 
-Notes:: Does not support merging with a compatible `unordered_set` yet.
+[horizontal]
+Notes:;; Does not support merging with a compatible `unordered_set` yet.
 
 ---
 
@@ -981,7 +1022,8 @@ template<class H2, class P2>
   void merge(unordered_multiset<Key, H2, P2, Allocator>&& source);
 ```
 
-Notes:: Does not support merging with a compatible `unordered_set` yet.
+[horizontal]
+Notes:;; Does not support merging with a compatible `unordered_set` yet.
 
 ---
 
@@ -999,7 +1041,8 @@ allocator_type get_allocator() const noexcept;
 hasher hash_function() const;
 ```
 
-Returns:: The container's hash function.
+[horizontal]
+Returns:;; The container's hash function.
 
 ---
 
@@ -1009,7 +1052,8 @@ Returns:: The container's hash function.
 key_equal key_eq() const;
 ```
 
-Returns:: The container's key equality predicate
+[horizontal]
+Returns:;; The container's key equality predicate
 
 ---
 
@@ -1031,9 +1075,10 @@ template<typename CompatibleKey, typename CompatibleHash, typename CompatiblePre
                        CompatiblePredicate const&) const;
 ```
 
-Returns:: An iterator pointing to an element with key equivalent to `k`, or `b.end()` if no such element exists.
-
-Notes:: The templated overloads containing `CompatibleKey`, `CompatibleHash` and `CompatiblePredicate` are non-standard extensions which allow you to use a compatible hash function and equality predicate for a key of a different type in order to avoid an expensive type cast. In general, its use is not encouraged and instead the `K` member function templates should be used. +
+[horizontal]
+Returns:;; An iterator pointing to an element with key equivalent to `k`, or `b.end()` if no such element exists.
+Notes:;; The templated overloads containing `CompatibleKey`, `CompatibleHash` and `CompatiblePredicate` are non-standard extensions which allow you to use a compatible hash function and equality predicate for a key of a different type in order to avoid an expensive type cast. In general, its use is not encouraged and instead the `K` member function templates should be used. +
++
 The `template <typename K>` overloads only participate in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
 
 ---
@@ -1045,9 +1090,9 @@ template<class K>
   size_type      count(const K& k) const;
 ```
 
-Returns:: The number of elements with key equivalent to `k`.
-
-Notes:: The `template <typename K>` overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
+[horizontal]
+Returns:;; The number of elements with key equivalent to `k`.
+Notes:;; The `template <typename K>` overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
 
 ---
 
@@ -1058,9 +1103,9 @@ template<class K>
   bool           contains(const K& k) const;
 ```
 
-Returns:: A boolean indicating whether or not there is an element with key equal to `key` in the container
-
-Notes:: The `template <typename K>` overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
+[horizontal]
+Returns:;; A boolean indicating whether or not there is an element with key equal to `key` in the container
+Notes:;; The `template <typename K>` overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
 
 ---
 
@@ -1074,9 +1119,9 @@ template<class K>
   std::pair<const_iterator, const_iterator> equal_range(const K& k) const;
 ```
 
-Returns:: A range containing all elements with key equivalent to `k`. If the container doesn't contain any such elements, returns `std::make_pair(b.end(), b.end())`.
-
-Notes:: The `template <typename K>` overloads only participate in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
+[horizontal]
+Returns:;; A range containing all elements with key equivalent to `k`. If the container doesn't contain any such elements, returns `std::make_pair(b.end(), b.end())`.
+Notes:;; The `template <typename K>` overloads only participate in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
 
 ---
 
@@ -1087,7 +1132,8 @@ Notes:: The `template <typename K>` overloads only participate in overload resol
 size_type bucket_count() const noexcept;
 ```
 
-Returns:: The number of buckets.
+[horizontal]
+Returns:;; The number of buckets.
 
 ---
 
@@ -1096,7 +1142,8 @@ Returns:: The number of buckets.
 size_type max_bucket_count() const noexcept;
 ```
 
-Returns:: An upper bound on the number of buckets.
+[horizontal]
+Returns:;; An upper bound on the number of buckets.
 
 ---
 
@@ -1105,9 +1152,9 @@ Returns:: An upper bound on the number of buckets.
 size_type bucket_size(size_type n) const;
 ```
 
-Requires:: `n < bucket_count()`
-
-Returns:: The number of elements in bucket `n`.
+[horizontal]
+Requires:;; `n < bucket_count()`
+Returns:;; The number of elements in bucket `n`.
 
 ---
 
@@ -1116,9 +1163,9 @@ Returns:: The number of elements in bucket `n`.
 size_type bucket(const key_type& k) const;
 ```
 
-Returns:: The index of the bucket which would contain an element with key `k`.
-
-Postconditions:: The return value is less than `bucket_count()`.
+[horizontal]
+Returns:;; The index of the bucket which would contain an element with key `k`.
+Postconditions:;; The return value is less than `bucket_count()`.
 
 ---
 
@@ -1129,9 +1176,9 @@ local_iterator begin(size_type n);
 const_local_iterator begin(size_type n) const;
 ```
 
-Requires:: `n` shall be in the range `[0, bucket_count())`.
-
-Returns:: A local iterator pointing the first element in the bucket with index `n`.
+[horizontal]
+Requires:;; `n` shall be in the range `[0, bucket_count())`.
+Returns:;; A local iterator pointing the first element in the bucket with index `n`.
 
 ---
 
@@ -1141,9 +1188,9 @@ local_iterator end(size_type n);
 const_local_iterator end(size_type n) const;
 ```
 
-Requires:: `n` shall be in the range `[0, bucket_count())`.
-
-Returns:: A local iterator pointing the 'one past the end' element in the bucket with index `n`.
+[horizontal]
+Requires:;; `n` shall be in the range `[0, bucket_count())`.
+Returns:;; A local iterator pointing the 'one past the end' element in the bucket with index `n`.
 
 ---
 
@@ -1152,9 +1199,9 @@ Returns:: A local iterator pointing the 'one past the end' element in the bucket
 const_local_iterator cbegin(size_type n) const;
 ```
 
-Requires:: `n` shall be in the range `[0, bucket_count())`.
-
-Returns:: A constant local iterator pointing the first element in the bucket with index `n`.
+[horizontal]
+Requires:;; `n` shall be in the range `[0, bucket_count())`.
+Returns:;; A constant local iterator pointing the first element in the bucket with index `n`.
 
 ---
 
@@ -1163,9 +1210,9 @@ Returns:: A constant local iterator pointing the first element in the bucket wit
 const_local_iterator cend(size_type n) const;
 ```
 
-Requires:: `n` shall be in the range `[0, bucket_count())`.
-
-Returns:: A constant local iterator pointing the 'one past the end' element in the bucket with index `n`.
+[horizontal]
+Requires:;; `n` shall be in the range `[0, bucket_count())`.
+Returns:;; A constant local iterator pointing the 'one past the end' element in the bucket with index `n`.
 
 ---
 
@@ -1176,7 +1223,8 @@ Returns:: A constant local iterator pointing the 'one past the end' element in t
 float load_factor() const noexcept;
 ```
 
-Returns:: The average number of elements per bucket.
+[horizontal]
+Returns:;; The average number of elements per bucket.
 
 ---
 
@@ -1186,7 +1234,8 @@ Returns:: The average number of elements per bucket.
 float max_load_factor() const noexcept;
 ```
 
-Returns:: Returns the current maximum load factor.
+[horizontal]
+Returns:;; Returns the current maximum load factor.
 
 ---
 
@@ -1195,7 +1244,8 @@ Returns:: Returns the current maximum load factor.
 void max_load_factor(float z);
 ```
 
-Effects:: Changes the container's maximum load factor, using `z` as a hint.
+[horizontal]
+Effects:;; Changes the container's maximum load factor, using `z` as a hint.
 
 ---
 
@@ -1208,7 +1258,8 @@ Changes the number of buckets so that there at least `n` buckets, and so that th
 
 Invalidates iterators, and changes the order of elements. Pointers and references to elements are not invalidated.
 
-Throws:: The function has no effect if an exception is thrown, unless it is thrown by the container's hash function or comparison function.
+[horizontal]
+Throws:;; The function has no effect if an exception is thrown, unless it is thrown by the container's hash function or comparison function.
 
 ---
 
@@ -1219,7 +1270,8 @@ void reserve(size_type n);
 
 Invalidates iterators, and changes the order of elements. Pointers and references to elements are not invalidated.
 
-Throws:: The function has no effect if an exception is thrown, unless it is thrown by the container's hash function or comparison function.
+[horizontal]
+Throws:;; The function has no effect if an exception is thrown, unless it is thrown by the container's hash function or comparison function.
 
 ---
 
@@ -1234,7 +1286,10 @@ template<class Key, class Hash, class Pred, class Alloc>
 
 Return `true` if `x.size() == y.size()` and for every element in `x`, there is an element in `y` with the same key, with an equal value (using `operator==` to compare the value types).
 
-Notes:: The behavior of this function was changed to match the C++11 standard in Boost 1.48. Behavior is undefined if the two containers don't have equivalent equality predicates.
+[horizontal]
+Notes:;; The behavior of this function was changed to match the C++11 standard in Boost 1.48. +
++
+Behavior is undefined if the two containers don't have equivalent equality predicates.
 
 ---
 
@@ -1247,7 +1302,10 @@ template<class Key, class Hash, class Pred, class Alloc>
 
 Return `false` if `x.size() == y.size()` and for every element in `x`, there is an element in `y` with the same key, with an equal value (using `operator==` to compare the value types).
 
-Notes:: The behavior of this function was changed to match the C++11 standard in Boost 1.48. Behavior is undefined if the two containers don't have equivalent equality predicates.
+[horizontal]
+Notes:;; The behavior of this function was changed to match the C++11 standard in Boost 1.48. +
++
+Behavior is undefined if the two containers don't have equivalent equality predicates.
 
 ---
 
@@ -1263,10 +1321,9 @@ Swaps the contents of `x` and `y`.
 
 If `Allocator::propagate_on_container_swap` is declared and `Allocator::propagate_on_container_swap::value` is `true` then the containers' allocators are swapped. Otherwise, swapping with unequal allocators results in undefined behavior.
 
-Effects:: `x.swap(y)`
-
-Throws:: Doesn't throw an exception unless it is thrown by the copy constructor or copy assignment operator of `key_equal` or `hasher`.
-
-Notes:: The exception specifications aren't quite the same as the C++11 standard, as the equality predicate and hash function are swapped using their copy constructors.
+[horizontal]
+Effects:;; `x.swap(y)`
+Throws:;; Doesn't throw an exception unless it is thrown by the copy constructor or copy assignment operator of `key_equal` or `hasher`.
+Notes:;; The exception specifications aren't quite the same as the C++11 standard, as the equality predicate and hash function are swapped using their copy constructors.
 
 

--- a/doc/unordered/unordered_multiset.adoc
+++ b/doc/unordered/unordered_multiset.adoc
@@ -7,261 +7,186 @@
 
 === Synopsis
 
-[source,c++,subs=+quotes]
+[listing,subs="+macros,+quotes"]
 -----
 // #include <boost/unordered_set.hpp>
 
-template<
-  typename Value,
-  typename Hash = boost::hash<Value>,
-  typename Pred = std::equal_to<Value>,
-  typename Alloc = std::allocator<std::pair<Value const, Mapped>> >
-class unordered_multiset {
-public:
-  // types
-  typedef Value                                  key_type;
-  typedef Value                                  value_type;
-  typedef Hash                                   hasher;
-  typedef Pred                                   key_equal;
-  typedef Alloc                                  allocator_type;
-  typedef typename allocator_type::pointer       pointer;
-  typedef typename allocator_type::const_pointer const_pointer;
-  typedef value_type&                            reference;
-  typedef value_type const&                      const_reference;
-  typedef _implementation-defined_                 size_type;
-  typedef _implementation-defined_                 difference_type;
-  typedef _implementation-defined_                 iterator;
-  typedef _implementation-defined_                 const_iterator;
-  typedef _implementation-defined_                 local_iterator;
-  typedef _implementation-defined_                 const_local_iterator;
-  typedef _implementation-defined_                 node_type;
-  typedef _implementation-defined_                 insert_return_type;
+namespace boost {
+  template<class Key,
+           class Hash = boost::hash<Key>,
+           class Pred = std::equal_to<Key>,
+           class Allocator = std::allocator<Key>>
+  class unordered_multiset {
+  public:
+    // types
+    using key_type             = Key;
+    using value_type           = Key;
+    using hasher               = Hash;
+    using key_equal            = Pred;
+    using allocator_type       = Allocator;
+    using pointer              = typename boost::allocator_traits<Allocator>::pointer;
+    using const_pointer        = typename boost::allocator_traits<Allocator>::const_pointer;
+    using reference            = value_type&;
+    using const_reference      = const value_type&;
+    using size_type            = _implementation-defined_;
+    using difference_type      = _implementation-defined_;
 
-  // construct/copy/destruct
-  unordered_multiset();
+    using iterator             = _implementation-defined_;
+    using const_iterator       = _implementation-defined_;
+    using local_iterator       = _implementation-defined_;
+    using const_local_iterator = _implementation-defined_;
+    using node_type            = _implementation-defined_;
 
-  explicit unordered_multiset(size_type n,
-                              hasher const& hf = hasher(),
-                              key_equal const& eq = key_equal(),
-                              allocator_type const& a  = allocator_type());
+    // construct/copy/destroy
+    xref:#unordered_multiset_default_constructor[unordered_multiset]();
+    explicit xref:#unordered_multiset_bucket_count_constructor[unordered_multiset](size_type n,
+                                const hasher& hf = hasher(),
+                                const key_equal& eql = key_equal(),
+                                const allocator_type& a = allocator_type());
+    template<class InputIterator>
+      xref:#unordered_multiset_iterator_range_constructor[unordered_multiset](InputIterator f, InputIterator l,
+                         size_type n = _implementation-defined_,
+                         const hasher& hf = hasher(),
+                         const key_equal& eql = key_equal(),
+                         const allocator_type& a = allocator_type());
+    xref:#unordered_multiset_copy_constructor[unordered_multiset](const unordered_multiset& other);
+    xref:#unordered_multiset_move_constructor[unordered_multiset](unordered_multiset&& other);
+    explicit xref:#unordered_multiset_allocator_constructor[unordered_multiset](const Allocator& a);
+    xref:#unordered_multiset_copy_constructor_with_allocator[unordered_multiset](const unordered_multiset& other, const Allocator& a);
+    xref:#unordered_multiset_move_constructor_with_allocator[unordered_multiset](unordered_multiset&& other, const Allocator& a);
+    xref:#unordered_multiset_initializer_list_constructor[unordered_multiset](initializer_list<value_type> il,
+                       size_type n = _implementation-defined_,
+                       const hasher& hf = hasher(),
+                       const key_equal& eql = key_equal(),
+                       const allocator_type& a = allocator_type());
+    xref:#unordered_multiset_bucket_count_constructor_with_allocator[unordered_multiset](size_type n, const allocator_type& a);
+    xref:#unordered_multiset_bucket_count_constructor_with_hasher_and_allocator[unordered_multiset](size_type n, const hasher& hf, const allocator_type& a);
+    template<class InputIterator>
+      xref:#unordered_multiset_iterator_range_constructor_with_bucket_count_and_allocator[unordered_multiset](InputIterator f, InputIterator l, size_type n, const allocator_type& a);
+    template<class InputIterator>
+      xref:#unordered_multiset_iterator_range_constructor_with_bucket_count_and_hasher[unordered_multiset](InputIterator f, InputIterator l, size_type n, const hasher& hf,
+                         const allocator_type& a);
+    xref:#unordered_multiset_destructor[~unordered_multiset()];
+    unordered_multiset& xref:#unordered_multiset_copy_assignment[operator++=++](const unordered_multiset& other);
+    unordered_multiset& xref:#unordered_multiset_move_assignment[operator++=++](unordered_multiset&& other)
+      noexcept(boost::allocator_traits<Allocator>::is_always_equal::value &&
+               boost::is_nothrow_move_assignable_v<Hash> &&
+               boost::is_nothrow_move_assignable_v<Pred>);
+    unordered_multiset& xref:#unordered_multiset_initializer_list_assignment[operator++=++](initializer_list<value_type> il);
+    allocator_type xref:#unordered_multiset_get_allocator[get_allocator]() const noexcept;
 
-  unordered_multiset(unordered_multiset const& other);
-  unordered_multiset(unordered_multiset&& other);
+    // iterators
+    iterator       xref:#unordered_multiset_begin[begin]() noexcept;
+    const_iterator xref:#unordered_multiset_begin[begin]() const noexcept;
+    iterator       xref:#unordered_multiset_end[end]() noexcept;
+    const_iterator xref:#unordered_multiset_end[end]() const noexcept;
+    const_iterator xref:#unordered_multiset_cbegin[cbegin]() const noexcept;
+    const_iterator xref:#unordered_multiset_cend[cend]() const noexcept;
 
-  explicit unordered_multiset(Allocator const& a);
-  unordered_multiset(unordered_multiset const& other, Allocator const& a);
-  unordered_multiset(unordered_multiset&& other, Allocator const& a);
+    // capacity
+    bool xref:#unordered_multiset_empty[empty]() const noexcept;
+    size_type xref:#unordered_multiset_size[size]() const noexcept;
+    size_type xref:#unordered_multiset_max_size[max_size]() const noexcept;
 
-  unordered_multiset(size_type n, allocator_type const& a);
-  unordered_multiset(size_type n, hasher const& hf, allocator_type const& a);
+    // modifiers
+    template<class... Args> iterator xref:#unordered_multiset_emplace[emplace](Args&&... args);
+    template<class... Args> iterator xref:#unordered_multiset_emplace_hint[emplace_hint](const_iterator position, Args&&... args);
+    iterator xref:#unordered_multiset_copy_insert[insert](const value_type& obj);
+    iterator xref:#unordered_multiset_move_insert[insert](value_type&& obj);
+    iterator xref:#unordered_multiset_copy_insert_with_hint[insert](const_iterator hint, const value_type& obj);
+    iterator xref:#unordered_multiset_move_insert_with_hint[insert](const_iterator hint, value_type&& obj);
+    template<class InputIterator> void xref:#unordered_multiset_insert_iterator_range[insert](InputIterator first, InputIterator last);
+    void xref:#unordered_multiset_insert_initializer_list[insert](initializer_list<value_type> il);
 
-  unordered_multiset(initializer_list<value_type> il,
-                     size_type n = _implementation-defined_,
-                     hasher const& hf = hasher(),
-                     key_equal const& eq = key_equal(),
-                     allocator_type const& a = allocator_type());
+    node_type xref:#unordered_multiset_extract_by_iterator[extract](const_iterator position);
+    node_type xref:#unordered_multiset_extract_by_value[extract](const key_type& k);
+    template<class K> node_type xref:#unordered_multiset_transparent_extract_by_value[extract](K&& k);
+    iterator xref:#unordered_multiset_insert_with_node_handle[insert](node_type&& nh);
+    iterator xref:#unordered_multiset_insert_with_hint_and_node_handle[insert](const_iterator hint, node_type&& nh);
 
-  template<typename InputIterator>
-  unordered_multiset(InputIterator f,
-                     InputIterator l,
-                     size_type n = _implementation-defined_,
-                     hasher const& hf = hasher(),
-                     key_equal const& eq = key_equal(),
-                     allocator_type const& a  = allocator_type());
+    iterator  xref:#unordered_multiset_erase_by_position[erase](iterator position);
+    iterator  xref:#unordered_multiset_erase_by_position[erase](const_iterator position);
+    size_type xref:#unordered_multiset_erase_by_value[erase](const key_type& k);
+    template<class K> size_type xref:#unordered_multiset_transparent_erase_by_value[erase](K&& x);
+    iterator  xref:#unordered_multiset_erase_range[erase](const_iterator first, const_iterator last);
+    void      xref:#unordered_multiset_quick_erase[quick_erase](const_iterator position);
+    void      xref:#unordered_multiset_erase_return_void[erase_return_void](const_iterator position);
+    void      xref:#unordered_multiset_swap[swap](unordered_multiset&)
+      noexcept(boost::allocator_traits<Allocator>::is_always_equal::value &&
+               boost::is_nothrow_swappable_v<Hash> &&
+               boost::is_nothrow_swappable_v<Pred>);
+    void      xref:#unordered_multiset_clear[clear]() noexcept;
 
-  template<typename InputIterator>
-  unordered_multiset(InputIterator f,
-                    InputIterator l,
-                    size_type n,
-                    allocator_type const& a);
+    template<class H2, class P2>
+      void xref:#unordered_multiset_merge[merge](unordered_multiset<Key, H2, P2, Allocator>& source);
+    template<class H2, class P2>
+      void xref:#unordered_multiset_merge_rvalue_reference[merge](unordered_multiset<Key, H2, P2, Allocator>&& source);
 
-  template<typename InputIterator>
-  unordered_multiset(InputIterator f,
-                     InputIterator l,
-                     size_type n,
-                     hasher const& hf,
-                     allocator_type const& a);
+    // observers
+    hasher xref:#unordered_multiset_hash_function[hash_function]() const;
+    key_equal xref:#unordered_multiset_key_eq[key_eq]() const;
 
-  ~unordered_multiset();
+    // set operations
+    iterator         xref:#unordered_multiset_find[find](const key_type& k);
+    const_iterator   xref:#unordered_multiset_find[find](const key_type& k) const;
+    template<class K>
+      iterator       xref:#unordered_multiset_find[find](const K& k);
+    template<class K>
+      const_iterator xref:#unordered_multiset_find[find](const K& k) const;
+    template<typename CompatibleKey, typename CompatibleHash, typename CompatiblePredicate> 
+      iterator       xref:#unordered_multiset_find[find](CompatibleKey const&, CompatibleHash const&, 
+                          CompatiblePredicate const&);
+    template<typename CompatibleKey, typename CompatibleHash, typename CompatiblePredicate> 
+      const_iterator  xref:#unordered_multiset_find[find](CompatibleKey const&, CompatibleHash const&, 
+                           CompatiblePredicate const&) const;
+    size_type        xref:#unordered_multiset_count[count](const key_type& k) const;
+    template<class K>
+      size_type      xref:#unordered_multiset_count[count](const K& k) const;
+    bool             xref:#unordered_multiset_contains[contains](const key_type& k) const;
+    template<class K>
+      bool           xref:#unordered_multiset_contains[contains](const K& k) const;
+    std::pair<iterator, iterator>               xref:#unordered_multiset_equal_range[equal_range](const key_type& k);
+    std::pair<const_iterator, const_iterator>   xref:#unordered_multiset_equal_range[equal_range](const key_type& k) const;
+    template<class K>
+      std::pair<iterator, iterator>             xref:#unordered_multiset_equal_range[equal_range](const K& k);
+    template<class K>
+      std::pair<const_iterator, const_iterator> xref:#unordered_multiset_equal_range[equal_range](const K& k) const;
 
-  unordered_multiset& operator=(unordered_multiset const& other);
-  unordered_multiset& operator=(unordered_multiset&& other);
-  unordered_multiset& operator=(initializer_list<value_type> il);
+    // bucket interface
+    size_type xref:#unordered_multiset_bucket_count[bucket_count]() const noexcept;
+    size_type xref:#unordered_multiset_max_bucket_count[max_bucket_count]() const noexcept;
+    size_type xref:#unordered_multiset_bucket_size[bucket_size](size_type n) const;
+    size_type xref:#unordered_multiset_bucket[bucket](const key_type& k) const;
+    local_iterator xref:#unordered_multiset_begin_2[begin](size_type n);
+    const_local_iterator xref:#unordered_multiset_begin_2[begin](size_type n) const;
+    local_iterator xref:#unordered_multiset_end_2[end](size_type n);
+    const_local_iterator xref:#unordered_multiset_end_2[end](size_type n) const;
+    const_local_iterator xref:#unordered_multiset_cbegin_2[cbegin](size_type n) const;
+    const_local_iterator xref:#unordered_multiset_cend_2[cend](size_type n) const;
 
-  // size and capacity
-  bool empty() const;
-  size_type size() const;
-  size_type max_size() const;
-
-  // iterators
-  iterator begin();
-  const_iterator begin() const;
-
-  iterator end();
-  const_iterator end() const;
-
-  const_iterator cbegin() const;
-  const_iterator cend() const;
-
-  // modifiers
-  template<typename... Args>
-  iterator
-  emplace(Args&&... args);
-
-  template<typename... Args>
-  iterator
-  emplace_hint(const_iterator hint, Args&&... args);
-
-  iterator
-  insert(value_type const& obj);
-
-  iterator
-  insert(value_type&& obj);
-
-  iterator insert(node_type&& nh);
-
-  iterator insert(const_iterator hint, value_type const& obj);
-  iterator insert(const_iterator hint, value_type&& obj);
-  iterator insert(const_iterator hint, node_type&& nh);
-
-  template<typename InputIterator>
-  void insert(InputIterator first, InputIterator last);
-
-  void insert(initializer_list<value_type> il);
-
-  node_type extract(const_iterator position);
-  node_type extract(key_type const& k);
-
-  template<typename K>
-  node_type extract(K&& k);
-
-  iterator erase(const_iterator position);
-  iterator erase(const_iterator first, const_iterator last);
-  size_type erase(key_type const& k);
-
-  template<typename K>
-  size_type erase(K&& k);
-
-  void quick_erase(const_iterator position);
-  void erase_return_void(const_iterator position);
-
-  void clear();
-  void swap(unordered_multiset& other);
-
-  template<typename H2, typename P2>
-  void merge(unordered_multiset<Value, Mapped, H2, P2, Alloc>& source);
-
-  template<typename H2, typename P2>
-  void merge(unordered_multiset<Value, Mapped, H2, P2, Alloc>&& source);
-
-  // observers
-  allocator_type get_allocator() const;
-  hasher hash_function() const;
-  key_equal key_eq() const;
-
-  // lookup
-  iterator find(key_type const& k);
-  const_iterator find(key_type const& k) const;
-
-  template<typename K>
-  iterator
-  find(K const& k);
-
-  template<typename K>
-  const_iterator
-  find(K const& k) const;
-
-  template<
-    typename CompatibleValue,
-    typename CompatibleHash,
-    typename CompatiblePredicate>
-  iterator
-  find(CompatibleValue const& k,
-       CompatibleHash const& hash,
-       CompatiblePredicate const&) eq;
-
-  template<
-    typename CompatibleValue,
-    typename CompatibleHash,
-    typename CompatiblePredicate>
-  const_iterator
-  find(CompatibleValue const& k,
-       CompatibleHash const& hash,
-       CompatiblePredicate const& eq) const;
-
-  bool contains(key_type const& key) const;
-
-  template<typename K>
-  bool contains(K const& key);
-
-  size_type count(key_type const& k) const;
-
-  template<typename K>
-  size_type count(K const& k) const;
-
-  std::pair<iterator, iterator>
-  equal_range(key_type const& k);
-
-  std::pair<const_iterator, const_iterator>
-  equal_range(key_type const& k) const;
-
-  template<typename K>
-  std::pair<iterator, iterator>
-  equal_range(K const& k);
-
-  template<typename K>
-  std::pair<const_iterator, const_iterator>
-  equal_range(K const& k) const;
-
-  // bucket interface
-  size_type bucket_count() const;
-  size_type max_bucket_count() const;
-  size_type bucket_size(size_type n) const;
-  size_type bucket(key_type const& k) const;
-
-  local_iterator begin(size_type n);
-  const_local_iterator begin(size_type n) const;
-
-  local_iterator end(size_type n);
-  const_local_iterator end(size_type n) const;
-
-  const_local_iterator cbegin(size_type n) const;
-  const_local_iterator cend(size_type n) const;
-
-  // hash policy
-  float load_factor() const;
-  float max_load_factor() const;
-
-  void max_load_factor(float z);
-
-  void rehash(size_type n);
-  void reserve(size_type n);
-};
+    // hash policy
+    float xref:#unordered_multiset_load_factor[load_factor]() const noexcept;
+    float xref:#unordered_multiset_max_load_factor[max_load_factor]() const noexcept;
+    void xref:#unordered_multiset_set_max_load_factor[max_load_factor](float z);
+    void xref:#unordered_multiset_rehash[rehash](size_type n);
+    void xref:#unordered_multiset_reserve[reserve](size_type n);
+  };
+}
 
 // Equality Comparisons
-template<
-  typename Value,
-  typename Mapped,
-  typename Hash,
-  typename Pred,
-  typename Alloc>
-bool operator==(unordered_multiset<Value, Mapped, Hash, Pred, Alloc> const& x,
-                unordered_multiset<Value, Mapped, Hash, Pred, Alloc> const& y);
+template<class Key, class Hash, class Pred, class Alloc>
+  bool xref:#unordered_multiset_operator[operator++==++](const unordered_multiset<Key, Hash, Pred, Alloc>& x,
+                  const unordered_multiset<Key, Hash, Pred, Alloc>& y);
 
-template<
-  typename Value,
-  typename Mapped,
-  typename Hash,
-  typename Pred,
-  typename Alloc>
-bool operator!=(unordered_multiset<Value, Mapped, Hash, Pred, Alloc> const& x,
-                unordered_multiset<Value, Mapped, Hash, Pred, Alloc> const& y);
+template<class Key, class Hash, class Pred, class Alloc>
+  bool xref:#unordered_multiset_operator_2[operator!=](const unordered_multiset<Key, Hash, Pred, Alloc>& x,
+                  const unordered_multiset<Key, Hash, Pred, Alloc>& y);
 
 // swap
-template<typename Value, typename Mapped, typename Hash, typename Pred,
-         typename Alloc>
-void swap(unordered_multiset<Value, Mapped, Hash, Pred, Alloc>& x,
-          unordered_multiset<Value, Mapped, Hash, Pred, Alloc>& y);
+template<class Key, class Hash, class Pred, class Alloc>
+  void xref:#unordered_multiset_swap_2[swap](unordered_multiset<Key, Hash, Pred, Alloc>& x,
+            unordered_multiset<Key, Hash, Pred, Alloc>& y)
+    noexcept(noexcept(x.swap(y)));
 -----
 
 ---

--- a/doc/unordered/unordered_multiset.adoc
+++ b/doc/unordered/unordered_multiset.adoc
@@ -198,21 +198,21 @@ template<class Key, class Hash, class Pred, class Alloc>
 [cols="1,1"]
 |===
 
-|_Value_
-|`Value` must be https://en.cppreference.com/w/cpp/named_req/Erasable[Erasable^] from the container (i.e. `allocator_traits` can destroy it).
+|_Key_
+|`Key` must be https://en.cppreference.com/w/cpp/named_req/Erasable[Erasable^] from the container (i.e. `allocator_traits` can destroy it).
 
 |_Hash_
-|A unary function object type that acts a hash function for a `Value`. It takes a single argument of type `Value` and returns a value of type `std::size_t`.
+|A unary function object type that acts a hash function for a `Key`. It takes a single argument of type `Key` and returns a value of type `std::size_t`.
 
 |_Pred_
-|A binary function object that implements an equivalence relation on values of type `Value`. A binary function object that induces an equivalence relation on values of type `Value`. It takes two arguments of type `Value` and returns a value of type bool.
+|A binary function object that implements an equivalence relation on values of type `Key`. A binary function object that induces an equivalence relation on values of type `Key`. It takes two arguments of type `Key` and returns a value of type bool.
 
-|_Alloc_
+|_Allocator_
 |An allocator whose value type is the same as the container's value type.
 
 |===
 
-The elements are organized into buckets. Keys with the same hash code are stored in the same bucket.
+The elements are organized into buckets. Keys with the same hash code are stored in the same bucket and elements with equivalent keys are stored next to each other.
 
 The number of buckets can be automatically increased by a call to insert, or as the result of calling rehash.
 
@@ -315,15 +315,6 @@ See node_handle_set for details.
 
 ---
 
-[source,c++,subs=+quotes]
-----
-typedef _implementation-defined_ insert_return_type;
-----
-
-Structure returned by inserting node_type.
-
----
-
 === Constructors
 
 ==== Default Constructor
@@ -343,13 +334,13 @@ Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` 
 ==== Bucket Count Constructor
 ```c++
 explicit unordered_multiset(size_type n,
-                            hasher const& hf = hasher(),
-                            key_equal const& eq = key_equal(),
-                            allocator_type const& a = allocator_type());
+                            const hasher& hf = hasher(),
+                            const key_equal& eql = key_equal(),
+                            const allocator_type& a = allocator_type());
 ```
 
 Constructs an empty container with at least `n` buckets, using `hf` as the hash
-function, `eq` as the key equality predicate, `a` as the allocator and a maximum
+function, `eql` as the key equality predicate, `a` as the allocator and a maximum
 load factor of `1.0`.
 
 Postconditions:: `size() == 0`
@@ -358,9 +349,26 @@ Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` 
 
 ---
 
+==== Iterator Range Constructor
+[source,c++,subs="+quotes"]
+----
+template<class InputIterator>
+  unordered_multiset(InputIterator f, InputIterator l,
+                     size_type n = _implementation-defined_,
+                     const hasher& hf = hasher(),
+                     const key_equal& eql = key_equal(),
+                     const allocator_type& a = allocator_type());
+----
+
+Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `eql` as the key equality predicate, `a` as the allocator and a maximum load factor of `1.0` and inserts the elements from `[f, l)` into it.
+
+Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
 ==== Copy Constructor
 ```c++
-unordered_multiset(unordered_multiset const& other);
+unordered_multiset(const unordered_multiset& other);
 ```
 
 The copy constructor. Copies the contained elements, hash function, predicate, maximum load factor and allocator.
@@ -387,7 +395,7 @@ So, for example, you can't return the container from a function.
 
 ==== Allocator Constructor
 ```c++
-explicit unordered_multiset(Allocator const& a);
+explicit unordered_multiset(const Allocator& a);
 ```
 
 Constructs an empty container, using allocator `a`.
@@ -396,7 +404,7 @@ Constructs an empty container, using allocator `a`.
 
 ==== Copy Constructor with Allocator
 ```c++
-unordered_multiset(unordered_multiset const& other, Allocator const& a);
+unordered_multiset(const unordered_multiset& other, const Allocator& a);
 ```
 
 Constructs an container, copying ``other``'s contained elements, hash function, predicate, maximum load factor, but using allocator `a`.
@@ -405,7 +413,7 @@ Constructs an container, copying ``other``'s contained elements, hash function, 
 
 ==== Move Constructor with Allocator
 ```c++
-unordered_multiset(unordered_multiset&& other, Allocator const& a);
+unordered_multiset(unordered_multiset&& other, const Allocator& a);
 ```
 
 Construct a container moving ``other``'s contained elements, and having the hash function, predicate and maximum load factor, but using allocate `a`.
@@ -415,9 +423,25 @@ Requires:: `value_type` is move insertable.
 
 ---
 
+==== Initializer List Constructor
+[source,c++,subs="+quotes"]
+----
+unordered_multiset(initializer_list<value_type> il,
+                   size_type n = _implementation-defined_,
+                   const hasher& hf = hasher(),
+                   const key_equal& eql = key_equal(),
+                   const allocator_type& a = allocator_type());
+----
+
+Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `eql` as the key equality predicate, `a` as the allocator and a maximum load factor of `1.0` and inserts the elements from `il` into it.
+
+Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
 ==== Bucket Count Constructor with Allocator
 ```c++
-unordered_multiset(size_type n, allocator_type const& a);
+unordered_multiset(size_type n, const allocator_type& a);
 ```
 
 Constructs an empty container with at least `n` buckets, using `hf` as the hash function, the default hash function and key equality predicate, `a` as the allocator and a maximum load factor of `1.0`.
@@ -429,7 +453,7 @@ Requires:: `hasher` and `key_equal` need to be https://en.cppreference.com/w/cpp
 
 ==== Bucket Count Constructor with Hasher and Allocator
 ```c++
-unordered_multiset(size_type n, hasher const& hf, allocator_type const& a);
+unordered_multiset(size_type n, const hasher& hf, const allocator_type& a);
 ```
 
 Constructs an empty container with at least `n` buckets, using `hf` as the hash function, the default key equality predicate, `a` as the allocator and a maximum load factor of `1.0`.
@@ -439,63 +463,25 @@ Requires:: `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/D
 
 ---
 
-==== Initializer List Constructor
-[source,c++,subs="quotes,macros"]
-----
-unordered_multiset(initializer_list++<++value_type++>++ il,
-                   size_type n = _implementation-defined_,
-                   hasher const& hf = hasher(),
-                   key_equal const& eq = key_equal(),
-                   allocator_type const& a = allocator_type());
-----
-
-Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `eq` as the key equality predicate, `a` as the allocator and a maximum load factor of `1.0` and inserts the elements from `il` into it.
-
-Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
-
----
-
-==== Iterator Range Constructor
-[source,c++,subs="quotes,macros"]
-----
-template++<++typename InputIterator++>++
-unordered_multiset(InputIterator f,
-                   InputIterator l,
-                   size_type n = _implementation-defined_,
-                   hasher const& hf = hasher(),
-                   key_equal const& eq = key_equal(),
-                   allocator_type const& a = allocator_type());
-----
-
-Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `eq` as the key equality predicate, `a` as the allocator and a maximum load factor of `1.0` and inserts the elements from `[f, l)` into it.
-
-Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
-
----
-
 ==== Iterator Range Constructor with Bucket Count and Allocator
-[source,c++,subs="quotes,macros"]
+[source,c++,subs="+quotes"]
 ----
-template++<++typename InputIterator++>++
-unordered_multiset(InputIterator f,
-                   InputIterator l,
-                   size_type n,
-                   allocator_type const& a);
+template<class InputIterator>
+  unordered_multiset(InputIterator f, InputIterator l, size_type n, const allocator_type& a);
 ----
 
 Constructs an empty container with at least `n` buckets, using `a` as the allocator, with the default hash function and key equality predicate and a maximum load factor of `1.0` and inserts the elements from `[f, l)` into it.
 
 Requires:: `hasher`, `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
+---
+
 ==== Iterator Range Constructor with Bucket Count and Hasher
-[source,c++,subs="quotes,macros"]
+[source,c++,subs="+quotes"]
 ----
-template++<++typename InputIterator++>++
-unordered_multiset(InputIterator f,
-                   InputIterator l,
-                   size_type n,
-                   hasher const& hf,
-                   allocator_type const& a);
+template<class InputIterator>
+  unordered_multiset(InputIterator f, InputIterator l, size_type n, const hasher& hf,
+                     const allocator_type& a);
 ----
 
 Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `a` as the allocator, with the default key equality predicate and a maximum load factor of `1.0` and inserts the elements from `[f, l)` into it.
@@ -509,6 +495,7 @@ Requires:: `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/D
 ```c++
 ~unordered_multiset();
 ```
+
 Note:: The destructor is applied to every element, and all memory is deallocated
 
 ---
@@ -518,7 +505,7 @@ Note:: The destructor is applied to every element, and all memory is deallocated
 ==== Copy Assignment
 
 ```c++
-unordered_multiset& operator=(unordered_multiset const& other);
+unordered_multiset& operator=(const unordered_multiset& other);
 ```
 
 The assignment operator. Copies the contained elements, hash function, predicate and maximum load factor but not the allocator.
@@ -531,7 +518,10 @@ Requires:: `value_type` is copy constructible
 
 ==== Move Assignment
 ```c++
-unordered_multiset& operator=(unordered_multiset&& other);
+unordered_multiset& operator=(unordered_multiset&& other)
+  noexcept(boost::allocator_traits<Allocator>::is_always_equal::value &&
+           boost::is_nothrow_move_assignable_v<Hash> &&
+           boost::is_nothrow_move_assignable_v<Pred>);
 ```
 The move assignment operator.
 
@@ -552,12 +542,53 @@ Assign from values in initializer list. All existing elements are either overwri
 
 Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/CopyInsertable[CopyInsertable^] into the container and https://en.cppreference.com/w/cpp/named_req/CopyAssignable[CopyAssignable^].
 
+---
+
+=== Iterators
+
+==== begin
+```c++
+iterator       begin() noexcept;
+const_iterator begin() const noexcept;
+```
+
+Returns:: An iterator referring to the first element of the container, or if the container is empty the past-the-end value for the container.
+
+---
+
+==== end
+```c++
+iterator       end() noexcept;
+const_iterator end() const noexcept;
+```
+
+Returns:: An iterator which refers to the past-the-end value for the container.
+
+---
+
+==== cbegin
+```c++
+const_iterator cbegin() const noexcept;
+```
+Returns:: A `const_iterator` referring to the first element of the container, or if the container is empty the past-the-end value for the container.
+
+---
+
+==== cend
+```c++
+const_iterator cend() const noexcept;
+```
+
+Returns:: A `const_iterator` which refers to the past-the-end value for the container.
+
+---
+
 === Size and Capacity
 
 ==== empty
 
 ```c++
-bool empty() const;
+bool empty() const noexcept;
 ```
 
 Returns:: `size() == 0`
@@ -567,7 +598,7 @@ Returns:: `size() == 0`
 ==== size
 
 ```c++
-size_type size() const;
+size_type size() const noexcept;
 ```
 
 Returns:: `std::distance(begin(), end())`
@@ -577,49 +608,10 @@ Returns:: `std::distance(begin(), end())`
 ==== max_size
 
 ```c++
-size_type max_size() const;
+size_type max_size() const noexcept;
 ```
 
 Returns:: `size()` of the largest possible container.
-
----
-
-=== Iterators
-
-==== begin
-```c++
-iterator begin();
-const_iterator begin() const;
-```
-
-Returns:: An iterator referring to the first element of the container, or if the container is empty the past-the-end value for the container.
-
----
-
-==== end
-```c++
-iterator end();
-const_iterator end() const;
-```
-
-Returns:: An iterator which refers to the past-the-end value for the container.
-
----
-
-==== cbegin
-```c++
-const_iterator cbegin() const;
-```
-Returns:: A `const_iterator` referring to the first element of the container, or if the container is empty the past-the-end value for the container.
-
----
-
-==== cend
-```c++
-const_iterator cend() const;
-```
-
-Returns:: A `const_iterator` which refers to the past-the-end value for the container.
 
 ---
 
@@ -627,9 +619,7 @@ Returns:: A `const_iterator` which refers to the past-the-end value for the cont
 
 ==== emplace
 ```c++
-template<typename... Args>
-iterator
-emplace(Args&&... args);
+template<class... Args> iterator emplace(Args&&... args);
 ```
 
 Inserts an object, constructed with the arguments args, in the container.
@@ -649,9 +639,7 @@ Since existing `std::pair` implementations don't support `std::piecewise_constru
 
 ==== emplace_hint
 ```c++
-template<typename... Args>
-iterator
-emplace_hint(const_iterator hint, Args&&... args);
+template<class... Args> iterator emplace_hint(const_iterator position, Args&&... args);
 ```
 
 Inserts an object, constructed with the arguments args, in the container.
@@ -674,8 +662,7 @@ Since existing `std::pair` implementations don't support `std::piecewise_constru
 
 ==== Copy Insert
 ```c++
-iterator
-insert(value_type const& obj);
+iterator insert(const value_type& obj);
 ```
 
 Inserts `obj` in the container.
@@ -692,8 +679,7 @@ Notes:: Can invalidate iterators, but only if the insert causes the load factor 
 
 ==== Move Insert
 ```c++
-iterator
-insert(value_type&& obj);
+iterator insert(value_type&& obj);
 ```
 
 Inserts `obj` in the container.
@@ -708,29 +694,9 @@ Notes:: Can invalidate iterators, but only if the insert causes the load factor 
 
 ---
 
-==== Insert with `node_handle`
-```c++
-iterator
-insert(node_type&& nh);
-```
-
-If `nh` is empty, has no effect.
-
-Otherwise inserts the element owned by `nh`.
-
-Requires:: `nh` is empty or `nh.get_allocator()` is equal to the container's allocator.
-
-Returns::  If `nh` was empty, returns `end()`. Otherwise returns an iterator pointing to the newly inserted element.
-
-Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-
-Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated. In C++17 this can be used to insert a node extracted from a compatible `unordered_set`, but that is not supported yet.
-
----
-
 ==== Copy Insert with Hint
 ```c++
-iterator insert(const_iterator hint, value_type const& obj);
+iterator insert(const_iterator hint, const value_type& obj);
 ```
 
 Inserts `obj` in the container.
@@ -766,33 +732,9 @@ Notes:: The standard is fairly vague on the meaning of the hint. But the only pr
 
 ---
 
-==== Insert with Hint and `node_handle`
-```c++
-iterator insert(const_iterator hint, node_type&& nh);
-```
-
-If `nh` is empty, has no effect.
-
-Otherwise inserts the element owned by `nh`.
-
-`hint` is a suggestion to where the element should be inserted.
-
-Requires:: `nh` is empty or `nh.get_allocator()` is equal to the container's allocator.
-
-Returns:: If `nh` was empty, returns `end()`.
-
-Otherwise returns an iterator pointing to the newly inserted element.
-
-Throws:: If an exception is thrown by an operation other than a call to hasher the function has no effect.
-
-Notes:: The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated. In C++17 this can be used to insert a node extracted from a compatible `unordered_set`, but that is not supported yet.
-
----
-
 ==== Insert Iterator Range
 ```c++
-template<typename InputIterator>
-void insert(InputIterator first, InputIterator last);
+template<class InputIterator> void insert(InputIterator first, InputIterator last);
 ```
 
 Inserts a range of elements into the container.
@@ -833,15 +775,12 @@ Notes:: In C++17 a node extracted using this method can be inserted into a compa
 
 ---
 
-==== Transparent Extract by Value
+==== Extract by Value
 ```c++
-template<typename K>
-node_type extract(K&& k);
+node_type extract(const key_type& k);
 ```
 
 Removes an element with key equivalent to `k`.
-
-This overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs and neither `iterator` nor `const_iterator` are implicitly convertible from `K`. The library assumes that `Hash` is callable with both `K` and `Value` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Value` type.
 
 Returns:: A `node_type` owning the element if found, otherwise an empty `node_type`.
 
@@ -851,12 +790,14 @@ Notes:: In C++17 a node extracted using this method can be inserted into a compa
 
 ---
 
-==== Extract by Value
+==== Transparent Extract by Value
 ```c++
-node_type extract(key_type const& k);
+template<class K> node_type extract(K&& k);
 ```
 
 Removes an element with key equivalent to `k`.
+
+This overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs and neither `iterator` nor `const_iterator` are implicitly convertible from `K`. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
 
 Returns:: A `node_type` owning the element if found, otherwise an empty `node_type`.
 
@@ -864,9 +805,54 @@ Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
 
 Notes:: In C++17 a node extracted using this method can be inserted into a compatible `unordered_set`, but that is not supported yet.
 
+---
+
+==== Insert with `node_handle`
+```c++
+iterator insert(node_type&& nh);
+```
+
+If `nh` is empty, has no effect.
+
+Otherwise inserts the element owned by `nh`.
+
+Requires:: `nh` is empty or `nh.get_allocator()` is equal to the container's allocator.
+
+Returns::  If `nh` was empty, returns `end()`. Otherwise returns an iterator pointing to the newly inserted element.
+
+Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+
+Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated. In C++17 this can be used to insert a node extracted from a compatible `unordered_set`, but that is not supported yet.
+
+---
+
+==== Insert with Hint and `node_handle`
+```c++
+iterator insert(const_iterator hint, node_type&& nh);
+```
+
+If `nh` is empty, has no effect.
+
+Otherwise inserts the element owned by `nh`.
+
+`hint` is a suggestion to where the element should be inserted.
+
+Requires:: `nh` is empty or `nh.get_allocator()` is equal to the container's allocator.
+
+Returns:: If `nh` was empty, returns `end()`.
+
+Otherwise returns an iterator pointing to the newly inserted element.
+
+Throws:: If an exception is thrown by an operation other than a call to hasher the function has no effect.
+
+Notes:: The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated. In C++17 this can be used to insert a node extracted from a compatible `unordered_set`, but that is not supported yet.
+
+---
+
 ==== Erase by Position
 
 ```c++
+iterator erase(iterator position);
 iterator erase(const_iterator position);
 ```
 
@@ -877,6 +863,34 @@ Returns:: The iterator following `position` before the erasure.
 Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
 
 Notes:: In older versions this could be inefficient because it had to search through several buckets to find the position of the returned iterator. The data structure has been changed so that this is no longer the case, and the alternative erase methods have been deprecated.
+
+---
+
+==== Erase by Value
+```c++
+size_type erase(const key_type& k);
+```
+
+Erase all elements with key equivalent to `k`.
+
+Returns:: The number of elements erased.
+
+Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
+
+---
+
+==== Transparent Erase by Value
+```c++
+template<class K> size_type erase(K&& x);
+```
+
+Erase all elements with key equivalent to `k`.
+
+This overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs and neither `iterator` nor `const_iterator` are implicitly convertible from `K`. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
+
+Returns:: The number of elements erased.
+
+Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
 
 ---
 
@@ -891,35 +905,6 @@ Erases the elements in the range from `first` to `last`.
 Returns:: The iterator following the erased elements - i.e. `last`.
 
 Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`. In this implementation, this overload doesn't call either function object's methods so it is no throw, but this might not be true in other implementations.
-
----
-
-==== Transparent Erase by Value
-```c++
-template<typename K>
-size_type erase(K&& k);
-```
-
-Erase all elements with key equivalent to `k`.
-
-This overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs and neither `iterator` nor `const_iterator` are implicitly convertible from `K`. The library assumes that `Hash` is callable with both `K` and `Value` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Value` type.
-
-Returns:: The number of elements erased.
-
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
-
----
-
-==== Erase by Value
-```c++
-size_type erase(key_type const& k);
-```
-
-Erase all elements with key equivalent to `k`.
-
-Returns:: The number of elements erased.
-
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
 
 ---
 
@@ -949,22 +934,12 @@ Notes:: This method was implemented because returning an iterator to the next el
 
 ---
 
-==== clear
-```c++
-void clear();
-```
-
-Erases all elements in the container.
-
-Postconditions:: `size() == 0`
-
-Throws:: Never throws an exception.
-
----
-
 ==== swap
 ```c++
-void swap(unordered_multiset& other);
+void swap(unordered_multiset&)
+  noexcept(boost::allocator_traits<Allocator>::is_always_equal::value &&
+           boost::is_nothrow_swappable_v<Hash> &&
+           boost::is_nothrow_swappable_v<Pred>);
 ```
 
 Swaps the contents of the container with the parameter.
@@ -977,10 +952,23 @@ Notes:: The exception specifications aren't quite the same as the C++11 standard
 
 ---
 
+==== clear
+```c++
+void clear() noexcept;
+```
+
+Erases all elements in the container.
+
+Postconditions:: `size() == 0`
+
+Throws:: Never throws an exception.
+
+---
+
 ==== merge
 ```c++
-template<typename H2, typename P2>
-void merge(unordered_multiset<Value, Mapped, H2, P2, Alloc>& source);
+template<class H2, class P2>
+  void merge(unordered_multiset<Key, H2, P2, Allocator>& source);
 ```
 
 Notes:: Does not support merging with a compatible `unordered_set` yet.
@@ -989,8 +977,8 @@ Notes:: Does not support merging with a compatible `unordered_set` yet.
 
 ==== merge (rvalue reference)
 ```c++
-template<typename H2, typename P2>
-void merge(unordered_multiset<Value, Mapped, H2, P2, Alloc>&& source);
+template<class H2, class P2>
+  void merge(unordered_multiset<Key, H2, P2, Allocator>&& source);
 ```
 
 Notes:: Does not support merging with a compatible `unordered_set` yet.
@@ -1001,8 +989,10 @@ Notes:: Does not support merging with a compatible `unordered_set` yet.
 
 ==== get_allocator
 ```
-allocator_type get_allocator() const;
+allocator_type get_allocator() const noexcept;
 ```
+
+---
 
 ==== hash_function
 ```
@@ -1012,6 +1002,8 @@ hasher hash_function() const;
 Returns:: The container's hash function.
 
 ---
+
+==== key_eq
 
 ```
 key_equal key_eq() const;
@@ -1025,90 +1017,66 @@ Returns:: The container's key equality predicate
 
 ==== find
 ```c++
-iterator find(key_type const& k);
-const_iterator find(key_type const& k) const;
-
-template<typename K>
-iterator
-find(K const& k);
-
-template<typename K>
-const_iterator
-find(K const& k) const;
-
-template<
-  typename CompatibleValue,
-  typename CompatibleHash,
-  typename CompatiblePredicate>
-iterator
-find(CompatibleValue const& k,
-     CompatibleHash const& hash,
-     CompatiblePredicate const& eq);
-
-template<
-  typename CompatibleValue,
-  typename CompatibleHash,
-  typename CompatiblePredicate>
-const_iterator
-find(CompatibleValue const& k,
-      CompatibleHash const& hash,
-      CompatiblePredicate const& eq) const;
-
+iterator         find(const key_type& k);
+const_iterator   find(const key_type& k) const;
+template<class K>
+  iterator       find(const K& k);
+template<class K>
+  const_iterator find(const K& k) const;
+template<typename CompatibleKey, typename CompatibleHash, typename CompatiblePredicate> 
+  iterator       find(CompatibleKey const&, CompatibleHash const&, 
+                      CompatiblePredicate const&);
+template<typename CompatibleKey, typename CompatibleHash, typename CompatiblePredicate> 
+  const_iterator  find(CompatibleKey const&, CompatibleHash const&, 
+                       CompatiblePredicate const&) const;
 ```
 
 Returns:: An iterator pointing to an element with key equivalent to `k`, or `b.end()` if no such element exists.
 
-Notes:: The templated overloads containing `CompatibleValue`, `CompatibleHash` and `CompatiblePredicate` are non-standard extensions which allow you to use a compatible hash function and equality predicate for a key of a different type in order to avoid an expensive type cast. In general, its use is not encouraged and instead the `K` member function templates should be used. +
-The `template <typename K>` overloads only participate in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Value` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Value` type.
-
----
-
-==== contains
-```c++
-template<typename K>
-bool contains(K const& key);
-bool contains(key_type const& key) const;
-```
-
-Returns:: A boolean indicating whether or not there is an element with key equal to `key` in the container
-
-Notes:: The `template <typename K>` overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Value` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Value` type.
+Notes:: The templated overloads containing `CompatibleKey`, `CompatibleHash` and `CompatiblePredicate` are non-standard extensions which allow you to use a compatible hash function and equality predicate for a key of a different type in order to avoid an expensive type cast. In general, its use is not encouraged and instead the `K` member function templates should be used. +
+The `template <typename K>` overloads only participate in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
 
 ---
 
 ==== count
 ```c++
-template<typename K>
-size_type count(K const& k) const;
-size_type count(key_type const& k) const;
+size_type        count(const key_type& k) const;
+template<class K>
+  size_type      count(const K& k) const;
 ```
 
 Returns:: The number of elements with key equivalent to `k`.
 
-Notes:: The `template <typename K>` overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Value` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Value` type.
+Notes:: The `template <typename K>` overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
+
+---
+
+==== contains
+```c++
+bool             contains(const key_type& k) const;
+template<class K>
+  bool           contains(const K& k) const;
+```
+
+Returns:: A boolean indicating whether or not there is an element with key equal to `key` in the container
+
+Notes:: The `template <typename K>` overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
 
 ---
 
 ==== equal_range
 ```c++
-std::pair<iterator, iterator>
-equal_range(key_type const& k);
-
-std::pair<const_iterator, const_iterator>
-equal_range(key_type const& k) const;
-
-template<typename K>
-std::pair<iterator, iterator>
-equal_range(K const& k);
-
-template<typename K>
-std::pair<const_iterator, const_iterator>
-equal_range(K const& k) const;
+std::pair<iterator, iterator>               equal_range(const key_type& k);
+std::pair<const_iterator, const_iterator>   equal_range(const key_type& k) const;
+template<class K>
+  std::pair<iterator, iterator>             equal_range(const K& k);
+template<class K>
+  std::pair<const_iterator, const_iterator> equal_range(const K& k) const;
 ```
 
 Returns:: A range containing all elements with key equivalent to `k`. If the container doesn't contain any such elements, returns `std::make_pair(b.end(), b.end())`.
 
-Notes:: The `template <typename K>` overloads only participate in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Value` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Value` type.
+Notes:: The `template <typename K>` overloads only participate in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
 
 ---
 
@@ -1116,7 +1084,7 @@ Notes:: The `template <typename K>` overloads only participate in overload resol
 
 ==== bucket_count
 ```c++
-size_type bucket_count() const;
+size_type bucket_count() const noexcept;
 ```
 
 Returns:: The number of buckets.
@@ -1125,7 +1093,7 @@ Returns:: The number of buckets.
 
 ==== max_bucket_count
 ```c++
-size_type max_bucket_count() const;
+size_type max_bucket_count() const noexcept;
 ```
 
 Returns:: An upper bound on the number of buckets.
@@ -1145,7 +1113,7 @@ Returns:: The number of elements in bucket `n`.
 
 ==== bucket
 ```c++
-size_type bucket(key_type const& k) const;
+size_type bucket(const key_type& k) const;
 ```
 
 Returns:: The index of the bucket which would contain an element with key `k`.
@@ -1205,7 +1173,7 @@ Returns:: A constant local iterator pointing the 'one past the end' element in t
 
 ==== load_factor
 ```c++
-float load_factor() const;
+float load_factor() const noexcept;
 ```
 
 Returns:: The average number of elements per bucket.
@@ -1215,7 +1183,7 @@ Returns:: The average number of elements per bucket.
 ==== max_load_factor
 
 ```c++
-float max_load_factor() const;
+float max_load_factor() const noexcept;
 ```
 
 Returns:: Returns the current maximum load factor.
@@ -1230,7 +1198,6 @@ void max_load_factor(float z);
 Effects:: Changes the container's maximum load factor, using `z` as a hint.
 
 ---
-
 
 ==== rehash
 ```c++
@@ -1254,18 +1221,15 @@ Invalidates iterators, and changes the order of elements. Pointers and reference
 
 Throws:: The function has no effect if an exception is thrown, unless it is thrown by the container's hash function or comparison function.
 
+---
+
 === Equality Comparisons
 
 ==== operator==
 ```c++
-template<
-  typename Value,
-  typename Mapped,
-  typename Hash,
-  typename Pred,
-  typename Alloc>
-bool operator==(unordered_multiset<Value, Mapped, Hash, Pred, Alloc> const& x,
-                unordered_multiset<Value, Mapped, Hash, Pred, Alloc> const& y);
+template<class Key, class Hash, class Pred, class Alloc>
+  bool operator==(const unordered_multiset<Key, Hash, Pred, Alloc>& x,
+                  const unordered_multiset<Key, Hash, Pred, Alloc>& y);
 ```
 
 Return `true` if `x.size() == y.size()` and for every element in `x`, there is an element in `y` with the same key, with an equal value (using `operator==` to compare the value types).
@@ -1276,26 +1240,23 @@ Notes:: The behavior of this function was changed to match the C++11 standard in
 
 ==== operator!=
 ```c++
-template<
-  typename Value,
-  typename Mapped,
-  typename Hash,
-  typename Pred,
-  typename Alloc>
-bool operator!=(unordered_multiset<Value, Mapped, Hash, Pred, Alloc> const& x,
-                unordered_multiset<Value, Mapped, Hash, Pred, Alloc> const& y);
+template<class Key, class Hash, class Pred, class Alloc>
+  bool operator!=(const unordered_multiset<Key, Hash, Pred, Alloc>& x,
+                  const unordered_multiset<Key, Hash, Pred, Alloc>& y);
 ```
 
 Return `false` if `x.size() == y.size()` and for every element in `x`, there is an element in `y` with the same key, with an equal value (using `operator==` to compare the value types).
 
 Notes:: The behavior of this function was changed to match the C++11 standard in Boost 1.48. Behavior is undefined if the two containers don't have equivalent equality predicates.
 
+---
+
 === Swap
 ```c++
-template<typename Value, typename Mapped, typename Hash, typename Pred,
-         typename Alloc>
-void swap(unordered_multiset<Value, Mapped, Hash, Pred, Alloc>& x,
-          unordered_multiset<Value, Mapped, Hash, Pred, Alloc>& y);
+template<class Key, class Hash, class Pred, class Alloc>
+  void swap(unordered_multiset<Key, Hash, Pred, Alloc>& x,
+            unordered_multiset<Key, Hash, Pred, Alloc>& y)
+    noexcept(noexcept(x.swap(y)));
 ```
 
 Swaps the contents of `x` and `y`.

--- a/doc/unordered/unordered_set.adoc
+++ b/doc/unordered/unordered_set.adoc
@@ -7,261 +7,187 @@
 
 === Synopsis
 
-[source,c++,subs=+quotes]
+[listing,subs="+macros,+quotes"]
 -----
 // #include <boost/unordered_set.hpp>
 
-template<
-  typename Value,
-  typename Hash = boost::hash<Value>,
-  typename Pred = std::equal_to<Value>,
-  typename Alloc = std::allocator<std::pair<Value const, Mapped>> >
-class unordered_set {
-public:
-  // types
-  typedef Value                                  key_type;
-  typedef Value                                  value_type;
-  typedef Hash                                   hasher;
-  typedef Pred                                   key_equal;
-  typedef Alloc                                  allocator_type;
-  typedef typename allocator_type::pointer       pointer;
-  typedef typename allocator_type::const_pointer const_pointer;
-  typedef value_type&                            reference;
-  typedef value_type const&                      const_reference;
-  typedef _implementation-defined_                 size_type;
-  typedef _implementation-defined_                 difference_type;
-  typedef _implementation-defined_                 iterator;
-  typedef _implementation-defined_                 const_iterator;
-  typedef _implementation-defined_                 local_iterator;
-  typedef _implementation-defined_                 const_local_iterator;
-  typedef _implementation-defined_                 node_type;
-  typedef _implementation-defined_                 insert_return_type;
+namespace boost {
+  template<class Key,
+           class Hash = boost::hash<Key>,
+           class Pred = std::equal_to<Key>,
+           class Allocator = std::allocator<Key>>
+  class unordered_set {
+  public:
+    // types
+    using key_type             = Key;
+    using value_type           = Key;
+    using hasher               = Hash;
+    using key_equal            = Pred;
+    using allocator_type       = Allocator;
+    using pointer              = typename boost::allocator_traits<Allocator>::pointer;
+    using const_pointer        = typename boost::allocator_traits<Allocator>::const_pointer;
+    using reference            = value_type&;
+    using const_reference      = const value_type&;
+    using size_type            = _implementation-defined_;
+    using difference_type      = _implementation-defined_;
 
-  // construct/copy/destruct
-  unordered_set();
+    using iterator             = _implementation-defined_;
+    using const_iterator       = _implementation-defined_;
+    using local_iterator       = _implementation-defined_;
+    using const_local_iterator = _implementation-defined_;
+    using node_type            = _implementation-defined_;
+    using insert_return_type   = _implementation-defined_;
 
-  explicit unordered_set(size_type n,
-                         hasher const& hf = hasher(),
-                         key_equal const& eq = key_equal(),
-                         allocator_type const& a  = allocator_type());
+    // construct/copy/destroy
+    xref:#unordered_set_default_constructor[unordered_set]();
+    explicit xref:#unordered_set_bucket_count_constructor[unordered_set](size_type n,
+                           const hasher& hf = hasher(),
+                           const key_equal& eql = key_equal(),
+                           const allocator_type& a = allocator_type());
+    template<class InputIterator>
+      xref:#unordered_set_iterator_range_constructor[unordered_set](InputIterator f, InputIterator l,
+                    size_type n = _implementation-defined_,
+                    const hasher& hf = hasher(),
+                    const key_equal& eql = key_equal(),
+                    const allocator_type& a = allocator_type());
+    xref:#unordered_set_copy_constructor[unordered_set](const unordered_set& other);
+    xref:#unordered_set_move_constructor[unordered_set](unordered_set&& other);
+    explicit xref:#unordered_set_allocator_constructor[unordered_set](const Allocator& a);
+    xref:#unordered_set_copy_constructor_with_allocator[unordered_set](const unordered_set& other, const Allocator& a);
+    xref:#unordered_set_move_constructor_with_allocator[unordered_set](unordered_set&& other, const Allocator& a);
+    xref:#unordered_set_initializer_list_constructor[unordered_set](initializer_list<value_type> il,
+                  size_type n = _implementation-defined_,
+                  const hasher& hf = hasher(),
+                  const key_equal& eql = key_equal(),
+                  const allocator_type& a = allocator_type());
+    xref:#unordered_set_bucket_count_constructor_with_allocator[unordered_set](size_type n, const allocator_type& a);
+    xref:#unordered_set_bucket_count_constructor_with_hasher_and_allocator[unordered_set](size_type n, const hasher& hf, const allocator_type& a);
+    template<class InputIterator>
+      xref:#unordered_set_iterator_range_constructor_with_bucket_count_and_allocator[unordered_set](InputIterator f, InputIterator l, size_type n, const allocator_type& a);
+    template<class InputIterator>
+      xref:#unordered_set_iterator_range_constructor_with_bucket_count_and_hasher[unordered_set](InputIterator f, InputIterator l, size_type n, const hasher& hf,
+                    const allocator_type& a);
+    xref:#unordered_set_destructor[~unordered_set]();
+    unordered_set& xref:#unordered_set_copy_assignment[operator++=++](const unordered_set& other);
+    unordered_set& xref:#unordered_set_move_assignment[operator++=++](unordered_set&& other)
+      noexcept(boost::allocator_traits<Allocator>::is_always_equal::value &&
+               boost::is_nothrow_move_assignable_v<Hash> &&
+               boost::is_nothrow_move_assignable_v<Pred>);
+    unordered_set& xref:#unordered_set_initializer_list_assignment[operator++=++](initializer_list<value_type> il);
+    allocator_type xref:#unordered_set_get_allocator[get_allocator]() const noexcept;
 
-  unordered_set(unordered_set const& other);
-  unordered_set(unordered_set&& other);
+    // iterators
+    iterator       xref:#unordered_set_begin[begin]() noexcept;
+    const_iterator xref:#unordered_set_begin[begin]() const noexcept;
+    iterator       xref:#unordered_set_end[end]() noexcept;
+    const_iterator xref:#unordered_set_end[end]() const noexcept;
+    const_iterator xref:#unordered_set_cbegin[cbegin]() const noexcept;
+    const_iterator xref:#unordered_set_cend[cend]() const noexcept;
 
-  explicit unordered_set(Allocator const& a);
-  unordered_set(unordered_set const& other, Allocator const& a);
-  unordered_set(unordered_set&& other, Allocator const& a);
+    // capacity
+    bool xref:#unordered_set_empty[empty]() const noexcept;
+    size_type xref:#unordered_set_size[size]() const noexcept;
+    size_type xref:#unordered_set_max_size[max_size]() const noexcept;
 
-  unordered_set(size_type n, allocator_type const& a);
-  unordered_set(size_type n, hasher const& hf, allocator_type const& a);
+    // modifiers
+    template<class... Args> std::pair<iterator, bool> xref:#unordered_set_emplace[emplace](Args&&... args);
+    template<class... Args> iterator xref:#unordered_set_emplace_hint[emplace_hint](const_iterator position, Args&&... args);
+    std::pair<iterator, bool> xref:#unordered_set_copy_insert[insert](const value_type& obj);
+    std::pair<iterator, bool> xref:#unordered_set_move_insert[insert](value_type&& obj);
+    iterator xref:#unordered_set_copy_insert_with_hint[insert](const_iterator hint, const value_type& obj);
+    iterator xref:#unordered_set_move_insert_with_hint[insert](const_iterator hint, value_type&& obj);
+    template<class InputIterator> void xref:#unordered_set_insert_iterator_range[insert](InputIterator first, InputIterator last);
+    void xref:#unordered_set_insert_initializer_list[insert](initializer_list<value_type>);
 
-  unordered_set(initializer_list<value_type> il,
-                size_type n = _implementation-defined_,
-                hasher const& hf = hasher(),
-                key_equal const& eq = key_equal(),
-                allocator_type const& a = allocator_type());
+    node_type xref:#unordered_set_extract_by_iterator[extract](const_iterator position);
+    node_type xref:#unordered_set_extract_by_value[extract](const key_type& k);
+    template<class K> node_type xref:#unordered_set_transparent_extract_by_value[extract](K&& k);
+    insert_return_type xref:#unordered_set_insert_with_node_handle[insert](node_type&& nh);
+    iterator           xref:#unordered_set_insert_with_hint_and_node_handle[insert](const_iterator hint, node_type&& nh);
 
-  template<typename InputIterator>
-  unordered_set(InputIterator f,
-                InputIterator l,
-                size_type n = _implementation-defined_,
-                hasher const& hf = hasher(),
-                key_equal const& eq = key_equal(),
-                allocator_type const& a  = allocator_type());
+    iterator  xref:#unordered_set_erase_by_position[erase](iterator position);
+    iterator  xref:#unordered_set_erase_by_position[erase](const_iterator position);
+    size_type xref:#unordered_set_erase_by_value[erase](const key_type& k);
+    template<class K> size_type xref:#unordered_set_transparent_erase_by_value[erase](K&& k);
+    iterator  xref:#unordered_set_erase_range[erase](const_iterator first, const_iterator last);
+    void      xref:#unordered_set_quick_erase[quick_erase](const_iterator position);
+    void      xref:#unordered_set_erase_return_void[erase_return_void](const_iterator position);
+    void      xref:#unordered_set_swap[swap](unordered_set& other)
+      noexcept(boost::allocator_traits<Allocator>::is_always_equal::value &&
+               boost::is_nothrow_swappable_v<Hash> &&
+               boost::is_nothrow_swappable_v<Pred>);
+    void      xref:#unordered_set_clear[clear]() noexcept;
 
-  template<typename InputIterator>
-  unordered_set(InputIterator f,
-                InputIterator l,
-                size_type n,
-                allocator_type const& a);
+    template<class H2, class P2>
+      void xref:#unordered_set_merge[merge](unordered_set<Key, H2, P2, Allocator>& source);
+    template<class H2, class P2>
+      void xref:#unordered_set_merge_rvalue_reference[merge](unordered_set<Key, H2, P2, Allocator>&& source);
 
-  template<typename InputIterator>
-  unordered_set(InputIterator f,
-                InputIterator l,
-                size_type n,
-                hasher const& hf,
-                allocator_type const& a);
+    // observers
+    hasher xref:#unordered_set_hash_function[hash_function]() const;
+    key_equal xref:#unordered_set_key_eq[key_eq]() const;
 
-  ~unordered_set();
+    // set operations
+    iterator         xref:#unordered_set_find[find](const key_type& k);
+    const_iterator   xref:#unordered_set_find[find](const key_type& k) const;
+    template<class K>
+      iterator       xref:#unordered_set_find[find](const K& k);
+    template<class K>
+      const_iterator xref:#unordered_set_find[find](const K& k) const;
+    template<typename CompatibleKey, typename CompatibleHash, typename CompatiblePredicate>
+      iterator       xref:#unordered_set_find[find](CompatibleKey const& k, CompatibleHash const& hash,
+                          CompatiblePredicate const& eq);
+    template<typename CompatibleKey, typename CompatibleHash, typename CompatiblePredicate>
+      const_iterator xref:#unordered_set_find[find](CompatibleKey const& k, CompatibleHash const& hash,
+                          CompatiblePredicate const& eq) const;
+    size_type        xref:#unordered_set_count[count](const key_type& k) const;
+    template<class K>
+      size_type      xref:#unordered_set_count[count](const K& k) const;
+    bool             xref:#unordered_set_contains[contains](const key_type& k) const;
+    template<class K>
+      bool           xref:#unordered_set_contains[contains](const K& k) const;
+    pair<iterator, iterator>               xref:#unordered_set_equal_range[equal_range](const key_type& k);
+    pair<const_iterator, const_iterator>   xref:#unordered_set_equal_range[equal_range](const key_type& k) const;
+    template<class K>
+      pair<iterator, iterator>             xref:#unordered_set_equal_range[equal_range](const K& k);
+    template<class K>
+      pair<const_iterator, const_iterator> xref:#unordered_set_equal_range[equal_range](const K& k) const;
 
-  unordered_set& operator=(unordered_set const& other);
-  unordered_set& operator=(unordered_set&& other);
-  unordered_set& operator=(initializer_list<value_type> il);
+    // bucket interface
+    size_type xref:#unordered_set_bucket_count[bucket_count]() const noexcept;
+    size_type xref:#unordered_set_max_bucket_count[max_bucket_count]() const noexcept;
+    size_type xref:#unordered_set_bucket_size[bucket_size](size_type n) const;
+    size_type xref:#unordered_set_bucket[bucket](const key_type& k) const;
+    local_iterator xref:#unordered_set_begin_2[begin](size_type n);
+    const_local_iterator xref:#unordered_set_begin_2[begin](size_type n) const;
+    local_iterator xref:#unordered_set_end_2[end](size_type n);
+    const_local_iterator xref:#unordered_set_end_2[end](size_type n) const;
+    const_local_iterator xref:#unordered_set_cbegin_2[cbegin](size_type n) const;
+    const_local_iterator xref:#unordered_set_cend_2[cend](size_type n) const;
 
-  // size and capacity
-  bool empty() const;
-  size_type size() const;
-  size_type max_size() const;
-
-  // iterators
-  iterator begin();
-  const_iterator begin() const;
-
-  iterator end();
-  const_iterator end() const;
-
-  const_iterator cbegin() const;
-  const_iterator cend() const;
-
-  // modifiers
-  template<typename... Args>
-  std::pair<iterator, bool>
-  emplace(Args&&... args);
-
-  template<typename... Args>
-  iterator
-  emplace_hint(const_iterator hint, Args&&... args);
-
-  std::pair<iterator, bool>
-  insert(value_type const& obj);
-
-  std::pair<iterator, bool>
-  insert(value_type&& obj);
-
-  insert_return_type insert(node_type&& nh);
-
-  iterator insert(const_iterator hint, value_type const& obj);
-  iterator insert(const_iterator hint, value_type&& obj);
-  iterator insert(const_iterator hint, node_type&& nh);
-
-  template<typename InputIterator>
-  void insert(InputIterator first, InputIterator last);
-
-  void insert(initializer_list<value_type> il);
-
-  node_type extract(const_iterator position);
-  node_type extract(key_type const& k);
-
-  template<typename K>
-  node_type extract(K&& k);
-
-  iterator erase(const_iterator position);
-  iterator erase(const_iterator first, const_iterator last);
-  size_type erase(key_type const& k);
-
-  template<typename K>
-  size_type erase(K&& k);
-
-  void quick_erase(const_iterator position);
-  void erase_return_void(const_iterator position);
-
-  void clear();
-  void swap(unordered_set& other);
-
-  template<typename H2, typename P2>
-  void merge(unordered_set<Value, Mapped, H2, P2, Alloc>& source);
-
-  template<typename H2, typename P2>
-  void merge(unordered_set<Value, Mapped, H2, P2, Alloc>&& source);
-
-  // observers
-  allocator_type get_allocator() const;
-  hasher hash_function() const;
-  key_equal key_eq() const;
-
-  // lookup
-  iterator find(key_type const& k);
-  const_iterator find(key_type const& k) const;
-
-  template<typename K>
-  iterator
-  find(K const& k);
-
-  template<typename K>
-  const_iterator
-  find(K const& k) const;
-
-  template<
-    typename CompatibleValue,
-    typename CompatibleHash,
-    typename CompatiblePredicate>
-  iterator
-  find(CompatibleValue const& k,
-       CompatibleHash const& hash,
-       CompatiblePredicate const&) eq;
-
-  template<
-    typename CompatibleValue,
-    typename CompatibleHash,
-    typename CompatiblePredicate>
-  const_iterator
-  find(CompatibleValue const& k,
-       CompatibleHash const& hash,
-       CompatiblePredicate const& eq) const;
-
-  bool contains(key_type const& key) const;
-
-  template<typename K>
-  bool contains(K const& key);
-
-  size_type count(key_type const& k) const;
-
-  template<typename K>
-  size_type count(K const& k) const;
-
-  std::pair<iterator, iterator>
-  equal_range(key_type const& k);
-
-  std::pair<const_iterator, const_iterator>
-  equal_range(key_type const& k) const;
-
-  template<typename K>
-  std::pair<iterator, iterator>
-  equal_range(K const& k);
-
-  template<typename K>
-  std::pair<const_iterator, const_iterator>
-  equal_range(K const& k) const;
-
-  // bucket interface
-  size_type bucket_count() const;
-  size_type max_bucket_count() const;
-  size_type bucket_size(size_type n) const;
-  size_type bucket(key_type const& k) const;
-
-  local_iterator begin(size_type n);
-  const_local_iterator begin(size_type n) const;
-
-  local_iterator end(size_type n);
-  const_local_iterator end(size_type n) const;
-
-  const_local_iterator cbegin(size_type n) const;
-  const_local_iterator cend(size_type n) const;
-
-  // hash policy
-  float load_factor() const;
-  float max_load_factor() const;
-
-  void max_load_factor(float z);
-
-  void rehash(size_type n);
-  void reserve(size_type n);
-};
+    // hash policy
+    float xref:#unordered_set_load_factor[load_factor]() const noexcept;
+    float xref:#unordered_set_max_load_factor[max_load_factor]() const noexcept;
+    void xref:#unordered_set_set_max_load_factor[max_load_factor](float z);
+    void xref:#unordered_set_rehash[rehash](size_type n);
+    void xref:#unordered_set_reserve[reserve](size_type n);
+  };
+}
 
 // Equality Comparisons
-template<
-  typename Value,
-  typename Mapped,
-  typename Hash,
-  typename Pred,
-  typename Alloc>
-bool operator==(unordered_set<Value, Mapped, Hash, Pred, Alloc> const& x,
-                unordered_set<Value, Mapped, Hash, Pred, Alloc> const& y);
+template<class Key, class Hash, class Pred, class Alloc>
+  bool xref:#unordered_set_operator[operator++==++](const unordered_set<Key, Hash, Pred, Alloc>& x,
+                  const unordered_set<Key, Hash, Pred, Alloc>& y);
 
-template<
-  typename Value,
-  typename Mapped,
-  typename Hash,
-  typename Pred,
-  typename Alloc>
-bool operator!=(unordered_set<Value, Mapped, Hash, Pred, Alloc> const& x,
-                unordered_set<Value, Mapped, Hash, Pred, Alloc> const& y);
+template<class Key, class Hash, class Pred, class Alloc>
+  bool xref:#unordered_set_operator_2[operator!=](const unordered_set<Key, Hash, Pred, Alloc>& x,
+                  const unordered_set<Key, Hash, Pred, Alloc>& y);
 
 // swap
-template<typename Value, typename Mapped, typename Hash, typename Pred,
-         typename Alloc>
-void swap(unordered_set<Value, Mapped, Hash, Pred, Alloc>& x,
-          unordered_set<Value, Mapped, Hash, Pred, Alloc>& y);
+template<class Key, class Hash, class Pred, class Alloc>
+  void xref:#unordered_set_swap_2[swap](unordered_set<Key, Hash, Pred, Alloc>& x,
+            unordered_set<Key, Hash, Pred, Alloc>& y)
+    noexcept(noexcept(x.swap(y)));
 -----
 
 ---

--- a/doc/unordered/unordered_set.adoc
+++ b/doc/unordered/unordered_set.adoc
@@ -337,8 +337,9 @@ Constructs an empty container using `hasher()` as the hash function,
 `key_equal()` as the key equality predicate, `allocator_type()` as the allocator
 and a maximum load factor of `1.0`.
 
-Postconditions:: `size() == 0`
-Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+[horizontal]
+Postconditions:;; `size() == 0`
+Requires:;; If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
 ---
 
@@ -354,9 +355,9 @@ Constructs an empty container with at least `n` buckets, using `hf` as the hash
 function, `eql` as the key equality predicate, `a` as the allocator and a maximum
 load factor of `1.0`.
 
-Postconditions:: `size() == 0`
-
-Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+[horizontal]
+Postconditions:;; `size() == 0`
+Requires:;; If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
 ---
 
@@ -373,7 +374,8 @@ template<class InputIterator>
 
 Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `eql` as the key equality predicate, `a` as the allocator and a maximum load factor of `1.0` and inserts the elements from `[f, l)` into it.
 
-Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+[horizontal]
+Requires:;; If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
 ---
 
@@ -386,7 +388,8 @@ The copy constructor. Copies the contained elements, hash function, predicate, m
 
 If `Allocator::select_on_container_copy_construction` exists and has the right signature, the allocator will be constructed from its result.
 
-Requires:: `value_type` is copy constructible
+[horizontal]
+Requires:;; `value_type` is copy constructible
 
 ---
 
@@ -397,9 +400,11 @@ unordered_set(unordered_set&& other);
 
 The move constructor.
 
-Notes:: This is implemented using Boost.Move.
-
-Requires:: `value_type` is move-constructible. On compilers without rvalue reference support the emulation does not support moving without calling `boost::move` if `value_type` is not copyable.
+[horizontal]
+Notes:;; This is implemented using Boost.Move.
+Requires:;; `value_type` is move-constructible. +
++
+On compilers without rvalue reference support the emulation does not support moving without calling `boost::move` if `value_type` is not copyable.
 So, for example, you can't return the container from a function.
 
 ---
@@ -429,8 +434,9 @@ unordered_set(unordered_set&& other, const Allocator& a);
 
 Construct a container moving ``other``'s contained elements, and having the hash function, predicate and maximum load factor, but using allocate `a`.
 
-Notes:: This is implemented using Boost.Move.
-Requires:: `value_type` is move insertable.
+[horizontal]
+Notes:;; This is implemented using Boost.Move.
+Requires:;; `value_type` is move insertable.
 
 ---
 
@@ -446,7 +452,8 @@ unordered_set(initializer_list<value_type> il,
 
 Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `eql` as the key equality predicate, `a` as the allocator and a maximum load factor of `1.0` and inserts the elements from `il` into it.
 
-Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+[horizontal]
+Requires:;; If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
 ---
 
@@ -457,8 +464,9 @@ unordered_set(size_type n, const allocator_type& a);
 
 Constructs an empty container with at least `n` buckets, using `hf` as the hash function, the default hash function and key equality predicate, `a` as the allocator and a maximum load factor of `1.0`.
 
-Postconditions:: `size() == 0`
-Requires:: `hasher` and `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+[horizontal]
+Postconditions:;; `size() == 0`
+Requires:;; `hasher` and `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
 ---
 
@@ -469,8 +477,9 @@ unordered_set(size_type n, const hasher& hf, const allocator_type& a);
 
 Constructs an empty container with at least `n` buckets, using `hf` as the hash function, the default key equality predicate, `a` as the allocator and a maximum load factor of `1.0`.
 
-Postconditions:: `size() == 0`
-Requires:: `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+[horizontal]
+Postconditions:;; `size() == 0`
+Requires:;; `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
 ---
 
@@ -483,7 +492,10 @@ template<class InputIterator>
 
 Constructs an empty container with at least `n` buckets, using `a` as the allocator, with the default hash function and key equality predicate and a maximum load factor of `1.0` and inserts the elements from `[f, l)` into it.
 
-Requires:: `hasher`, `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+[horizontal]
+Requires:;; `hasher`, `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
 
 ==== Iterator Range Constructor with Bucket Count and Hasher
 [source,c++,subs="+quotes"]
@@ -495,7 +507,8 @@ template<class InputIterator>
 
 Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `a` as the allocator, with the default key equality predicate and a maximum load factor of `1.0` and inserts the elements from `[f, l)` into it.
 
-Requires:: `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+[horizontal]
+Requires:;; `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
 ---
 
@@ -504,7 +517,9 @@ Requires:: `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/D
 ```c++
 ~unordered_set();
 ```
-Note:: The destructor is applied to every element, and all memory is deallocated
+
+[horizontal]
+Note:;; The destructor is applied to every element, and all memory is deallocated
 
 ---
 
@@ -520,7 +535,8 @@ The assignment operator. Copies the contained elements, hash function, predicate
 
 If `Alloc::propagate_on_container_copy_assignment` exists and `Alloc::propagate_on_container_copy_assignment::value` is `true`, the allocator is overwritten, if not the copied elements are created using the existing allocator.
 
-Requires:: `value_type` is copy constructible
+[horizontal]
+Requires:;; `value_type` is copy constructible
 
 ---
 
@@ -535,9 +551,9 @@ The move assignment operator.
 
 If `Alloc::propagate_on_container_move_assignment` exists and `Alloc::propagate_on_container_move_assignment::value` is `true`, the allocator is overwritten, if not the moved elements are created using the existing allocator.
 
-Notes:: On compilers without rvalue references, this is emulated using Boost.Move. Note that on some compilers the copy assignment operator may be used in some circumstances.
-
-Requires:: `value_type` is move constructible.
+[horizontal]
+Notes:;; On compilers without rvalue references, this is emulated using Boost.Move. Note that on some compilers the copy assignment operator may be used in some circumstances.
+Requires:;; `value_type` is move constructible.
 
 ---
 
@@ -548,7 +564,8 @@ unordered_set& operator=(initializer_list<value_type> il);
 
 Assign from values in initializer list. All existing elements are either overwritten by the new elements or destroyed.
 
-Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/CopyInsertable[CopyInsertable^] into the container and https://en.cppreference.com/w/cpp/named_req/CopyAssignable[CopyAssignable^].
+[horizontal]
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/CopyInsertable[CopyInsertable^] into the container and https://en.cppreference.com/w/cpp/named_req/CopyAssignable[CopyAssignable^].
 
 ---
 
@@ -560,7 +577,8 @@ iterator       begin() noexcept;
 const_iterator begin() const noexcept;
 ```
 
-Returns:: An iterator referring to the first element of the container, or if the container is empty the past-the-end value for the container.
+[horizontal]
+Returns:;; An iterator referring to the first element of the container, or if the container is empty the past-the-end value for the container.
 
 ---
 
@@ -570,7 +588,8 @@ iterator       end() noexcept;
 const_iterator end() const noexcept;
 ```
 
-Returns:: An iterator which refers to the past-the-end value for the container.
+[horizontal]
+Returns:;; An iterator which refers to the past-the-end value for the container.
 
 ---
 
@@ -578,7 +597,9 @@ Returns:: An iterator which refers to the past-the-end value for the container.
 ```c++
 const_iterator cbegin() const noexcept;
 ```
-Returns:: A `const_iterator` referring to the first element of the container, or if the container is empty the past-the-end value for the container.
+
+[horizontal]
+Returns:;; A `const_iterator` referring to the first element of the container, or if the container is empty the past-the-end value for the container.
 
 ---
 
@@ -587,7 +608,8 @@ Returns:: A `const_iterator` referring to the first element of the container, or
 const_iterator cend() const noexcept;
 ```
 
-Returns:: A `const_iterator` which refers to the past-the-end value for the container.
+[horizontal]
+Returns:;; A `const_iterator` which refers to the past-the-end value for the container.
 
 ---
 
@@ -599,7 +621,8 @@ Returns:: A `const_iterator` which refers to the past-the-end value for the cont
 bool empty() const noexcept;
 ```
 
-Returns:: `size() == 0`
+[horizontal]
+Returns:;; `size() == 0`
 
 ---
 
@@ -609,7 +632,8 @@ Returns:: `size() == 0`
 size_type size() const noexcept;
 ```
 
-Returns:: `std::distance(begin(), end())`
+[horizontal]
+Returns:;; `std::distance(begin(), end())`
 
 ---
 
@@ -619,7 +643,8 @@ Returns:: `std::distance(begin(), end())`
 size_type max_size() const noexcept;
 ```
 
-Returns:: `size()` of the largest possible container.
+[horizontal]
+Returns:;; `size()` of the largest possible container.
 
 ---
 
@@ -632,16 +657,18 @@ template<class... Args> pair<iterator, bool> emplace(Args&&... args);
 
 Inserts an object, constructed with the arguments `args`, in the container if and only if there is no element in the container with an equivalent value.
 
-Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `args`.
-
-Returns:: The bool component of the return type is true if an insert took place. +
+[horizontal]
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `args`.
+Returns:;; The bool component of the return type is true if an insert took place. +
++
 If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent value.
-
-Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-
-Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor.
-Pointers and references to elements are never invalidated.
-If the compiler doesn't support variadic template arguments or rvalue references, this is emulated for up to `10` arguments, with no support for rvalue references or move semantics.
+Throws:;; If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated. +
++
+If the compiler doesn't support variadic template arguments or rvalue references, this is emulated for up to `10` arguments, with no support for rvalue references or move semantics. +
++
 Since existing `std::pair` implementations don't support `std::piecewise_construct` this emulates it, but using `boost::unordered::piecewise_construct`.
 
 ---
@@ -655,16 +682,18 @@ Inserts an object, constructed with the arguments `args`, in the container if an
 
 `position` is a suggestion to where the element should be inserted.
 
-Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `args`.
-
-Returns:: If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
-
-Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-
-Notes:: The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key.
-Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor.
-Pointers and references to elements are never invalidated.
-If the compiler doesn't support variadic template arguments or rvalue references, this is emulated for up to 10 arguments, with no support for rvalue references or move semantics.
+[horizontal]
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `args`.
+Returns:;; If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
+Throws:;; If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. +
++
+Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated. +
++
+If the compiler doesn't support variadic template arguments or rvalue references, this is emulated for up to 10 arguments, with no support for rvalue references or move semantics. +
++
 Since existing `std::pair` implementations don't support `std::piecewise_construct` this emulates it, but using `boost::unordered::piecewise_construct`.
 
 ---
@@ -676,13 +705,15 @@ std::pair<iterator, bool> insert(const value_type& obj);
 
 Inserts `obj` in the container if and only if there is no element in the container with an equivalent key.
 
-Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/CopyInsertable[CopyInsertable^].
-
-Returns:: The bool component of the return type is true if an insert took place. If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
-
-Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-
-Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated.
+[horizontal]
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/CopyInsertable[CopyInsertable^].
+Returns:;; The bool component of the return type is true if an insert took place. +
++
+If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
+Throws:;; If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated.
 
 ---
 
@@ -693,13 +724,15 @@ std::pair<iterator, bool> insert(value_type&& obj);
 
 Inserts `obj` in the container if and only if there is no element in the container with an equivalent key.
 
-Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/MoveInsertable[MoveInsertable^].
-
-Returns:: The bool component of the return type is true if an insert took place. If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
-
-Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-
-Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated.
+[horizontal]
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/MoveInsertable[MoveInsertable^].
+Returns:;; The bool component of the return type is true if an insert took place. +
++
+If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
+Throws:;; If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated.
 
 ---
 
@@ -711,13 +744,15 @@ Inserts `obj` in the container if and only if there is no element in the contain
 
 `hint` is a suggestion to where the element should be inserted.
 
-Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/CopyInsertable[CopyInsertable^].
-
-Returns:: If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
-
-Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-
-Notes:: The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated.
+[horizontal]
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/CopyInsertable[CopyInsertable^].
+Returns:;; If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
+Throws:;; If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. +
++
+Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated.
 
 ---
 
@@ -730,13 +765,15 @@ Inserts `obj` in the container if and only if there is no element in the contain
 
 `hint` is a suggestion to where the element should be inserted.
 
-Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/MoveInsertable[MoveInsertable^].
-
-Returns:: If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
-
-Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-
-Notes:: The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated.
+[horizontal]
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/MoveInsertable[MoveInsertable^].
+Returns:;; If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
+Throws:;; If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. +
++
+Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated.
 
 ---
 
@@ -747,11 +784,12 @@ template<class InputIterator> void insert(InputIterator first, InputIterator las
 
 Inserts a range of elements into the container. Elements are inserted if and only if there is no element in the container with an equivalent key.
 
-Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `*first`.
-
-Throws:: When inserting a single element, if an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-
-Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated.
+[horizontal]
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `*first`.
+Throws:;; When inserting a single element, if an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated.
 
 ---
 
@@ -762,11 +800,12 @@ void insert(initializer_list<value_type>);
 
 Inserts a range of elements into the container. Elements are inserted if and only if there is no element in the container with an equivalent key.
 
-Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `*first`.
-
-Throws:: When inserting a single element, if an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-
-Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated.
+[horizontal]
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `*first`.
+Throws:;; When inserting a single element, if an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated.
 
 ---
 
@@ -777,9 +816,9 @@ node_type extract(const_iterator position);
 
 Removes the element pointed to by `position`.
 
-Returns:: A `node_type` owning the element.
-
-Notes:: In C++17 a node extracted using this method can be inserted into a compatible `unordered_multiset`, but that is not supported yet.
+[horizontal]
+Returns:;; A `node_type` owning the element.
+Notes:;; In C++17 a node extracted using this method can be inserted into a compatible `unordered_multiset`, but that is not supported yet.
 
 ---
 
@@ -790,11 +829,10 @@ node_type extract(const key_type& k);
 
 Removes an element with key equivalent to `k`.
 
-Returns:: A `node_type` owning the element if found, otherwise an empty `node_type`.
-
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
-
-Notes:: In C++17 a node extracted using this method can be inserted into a compatible `unordered_multiset`, but that is not supported yet.
+[horizontal]
+Returns:;; A `node_type` owning the element if found, otherwise an empty `node_type`.
+Throws:;; Only throws an exception if it is thrown by `hasher` or `key_equal`.
+Notes:;; In C++17 a node extracted using this method can be inserted into a compatible `unordered_multiset`, but that is not supported yet.
 
 ---
 
@@ -807,11 +845,10 @@ Removes an element with key equivalent to `k`.
 
 This overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs and neither `iterator` nor `const_iterator` are implicitly convertible from `K`. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
 
-Returns:: A `node_type` owning the element if found, otherwise an empty `node_type`.
-
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
-
-Notes:: In C++17 a node extracted using this method can be inserted into a compatible `unordered_multiset`, but that is not supported yet.
+[horizontal]
+Returns:;; A `node_type` owning the element if found, otherwise an empty `node_type`.
+Throws:;; Only throws an exception if it is thrown by `hasher` or `key_equal`.
+Notes:;; In C++17 a node extracted using this method can be inserted into a compatible `unordered_multiset`, but that is not supported yet.
 
 ---
 
@@ -824,13 +861,19 @@ If `nh` is empty, has no effect.
 
 Otherwise inserts the element owned by `nh` if and only if there is no element in the container with an equivalent key.
 
-Requires:: `nh` is empty or `nh.get_allocator()` is equal to the container's allocator.
-
-Returns:: If `nh` was empty, returns an `insert_return_type` with: `inserted` equal to `false`, `position` equal to `end()` and `node` empty. Otherwise if there was already an element with an equivalent key, returns an `insert_return_type` with: `inserted` equal to `false`, `position` pointing to a matching element and `node` contains the node from `nh`. Otherwise if the insertion succeeded, returns an `insert_return_type` with: `inserted` equal to `true`, `position` pointing to the newly inserted element and `node` empty.
-
-Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-
-Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated. In C++17 this can be used to insert a node extracted from a compatible `unordered_multiset`, but that is not supported yet.
+[horizontal]
+Requires:;; `nh` is empty or `nh.get_allocator()` is equal to the container's allocator.
+Returns:;; If `nh` was empty, returns an `insert_return_type` with: `inserted` equal to `false`, `position` equal to `end()` and `node` empty. +
++
+Otherwise if there was already an element with an equivalent key, returns an `insert_return_type` with: `inserted` equal to `false`, `position` pointing to a matching element and `node` contains the node from `nh`. +
++
+Otherwise if the insertion succeeded, returns an `insert_return_type` with: `inserted` equal to `true`, `position` pointing to the newly inserted element and `node` empty.
+Throws:;; If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated. +
++
+In C++17 this can be used to insert a node extracted from a compatible `unordered_multiset`, but that is not supported yet.
 
 ---
 
@@ -847,13 +890,21 @@ If there is already an element in the container with an equivalent key has no ef
 
 `hint` is a suggestion to where the element should be inserted.
 
-Requires:: `nh` is empty or `nh.get_allocator()` is equal to the container's allocator.
-
-Returns:: If `nh` was empty returns `end()`. If there was already an element in the container with an equivalent key returns an iterator pointing to that. Otherwise returns an iterator pointing to the newly inserted element.
-
-Throws:: If an exception is thrown by an operation other than a call to hasher the function has no effect.
-
-Notes:: The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated. In C++17 this can be used to insert a node extracted from a compatible `unordered_multiset`, but that is not supported yet.
+[horizontal]
+Requires:;; `nh` is empty or `nh.get_allocator()` is equal to the container's allocator.
+Returns:;; If `nh` was empty returns `end()`. +
++
+If there was already an element in the container with an equivalent key returns an iterator pointing to that. +
++
+Otherwise returns an iterator pointing to the newly inserted element.
+Throws:;; If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. +
++
+Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated. +
++
+In C++17 this can be used to insert a node extracted from a compatible `unordered_multiset`, but that is not supported yet.
 
 ---
 
@@ -866,11 +917,10 @@ iterator erase(const_iterator position);
 
 Erase the element pointed to by `position`.
 
-Returns:: The iterator following `position` before the erasure.
-
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
-
-Notes:: In older versions this could be inefficient because it had to search through several buckets to find the position of the returned iterator. The data structure has been changed so that this is no longer the case, and the alternative erase methods have been deprecated.
+[horizontal]
+Returns:;; The iterator following `position` before the erasure.
+Throws:;; Only throws an exception if it is thrown by `hasher` or `key_equal`.
+Notes:;; In older versions this could be inefficient because it had to search through several buckets to find the position of the returned iterator. The data structure has been changed so that this is no longer the case, and the alternative erase methods have been deprecated.
 
 ---
 
@@ -881,9 +931,9 @@ size_type erase(const key_type& k);
 
 Erase all elements with key equivalent to `k`.
 
-Returns:: The number of elements erased.
-
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
+[horizontal]
+Returns:;; The number of elements erased.
+Throws:;; Only throws an exception if it is thrown by `hasher` or `key_equal`.
 
 ---
 
@@ -896,9 +946,9 @@ Erase all elements with key equivalent to `k`.
 
 This overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs and neither `iterator` nor `const_iterator` are implicitly convertible from `K`. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
 
-Returns:: The number of elements erased.
-
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
+[horizontal]
+Returns:;; The number of elements erased.
+Throws:;; Only throws an exception if it is thrown by `hasher` or `key_equal`.
 
 ---
 
@@ -910,9 +960,11 @@ iterator erase(const_iterator first, const_iterator last);
 
 Erases the elements in the range from `first` to `last`.
 
-Returns:: The iterator following the erased elements - i.e. `last`.
-
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`. In this implementation, this overload doesn't call either function object's methods so it is no throw, but this might not be true in other implementations.
+[horizontal]
+Returns:;; The iterator following the erased elements - i.e. `last`.
+Throws:;; Only throws an exception if it is thrown by `hasher` or `key_equal`. +
++
+In this implementation, this overload doesn't call either function object's methods so it is no throw, but this might not be true in other implementations.
 
 ---
 
@@ -923,9 +975,11 @@ void quick_erase(const_iterator position);
 
 Erase the element pointed to by `position`.
 
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`. In this implementation, this overload doesn't call either function object's methods so it is no throw, but this might not be true in other implementations.
-
-Notes:: This method was implemented because returning an iterator to the next element from erase was expensive, but the container has been redesigned so that is no longer the case. So this method is now deprecated.
+[horizontal]
+Throws:;; Only throws an exception if it is thrown by `hasher` or `key_equal`. +
++
+In this implementation, this overload doesn't call either function object's methods so it is no throw, but this might not be true in other implementations.
+Notes:;; This method was implemented because returning an iterator to the next element from erase was expensive, but the container has been redesigned so that is no longer the case. So this method is now deprecated.
 
 ---
 
@@ -936,9 +990,11 @@ void erase_return_void(const_iterator position);
 
 Erase the element pointed to by `position`.
 
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`. In this implementation, this overload doesn't call either function object's methods so it is no throw, but this might not be true in other implementations.
-
-Notes:: This method was implemented because returning an iterator to the next element from erase was expensive, but the container has been redesigned so that is no longer the case. So this method is now deprecated.
+[horizontal]
+Throws:;; Only throws an exception if it is thrown by `hasher` or `key_equal`. +
++
+In this implementation, this overload doesn't call either function object's methods so it is no throw, but this might not be true in other implementations.
+Notes:;; This method was implemented because returning an iterator to the next element from erase was expensive, but the container has been redesigned so that is no longer the case. So this method is now deprecated.
 
 ---
 
@@ -954,9 +1010,9 @@ Swaps the contents of the container with the parameter.
 
 If `Allocator::propagate_on_container_swap` is declared and `Allocator::propagate_on_container_swap::value` is `true` then the containers' allocators are swapped. Otherwise, swapping with unequal allocators results in undefined behavior.
 
-Throws:: Doesn't throw an exception unless it is thrown by the copy constructor or copy assignment operator of `key_equal` or `hasher`.
-
-Notes:: The exception specifications aren't quite the same as the C++11 standard, as the equality predicate and hash function are swapped using their copy constructors.
+[horizontal]
+Throws:;; Doesn't throw an exception unless it is thrown by the copy constructor or copy assignment operator of `key_equal` or `hasher`.
+Notes:;; The exception specifications aren't quite the same as the C++11 standard, as the equality predicate and hash function are swapped using their copy constructors.
 
 ---
 
@@ -967,9 +1023,9 @@ void clear() noexcept;
 
 Erases all elements in the container.
 
-Postconditions:: `size() == 0`
-
-Throws:: Never throws an exception.
+[horizontal]
+Postconditions:;; `size() == 0`
+Throws:;; Never throws an exception.
 
 ---
 
@@ -979,7 +1035,8 @@ template<class H2, class P2>
   void merge(unordered_set<Key, H2, P2, Allocator>& source);
 ```
 
-Notes:: Does not support merging with a compatible `unordered_multiset` yet.
+[horizontal]
+Notes:;; Does not support merging with a compatible `unordered_multiset` yet.
 
 ---
 
@@ -989,7 +1046,8 @@ template<class H2, class P2>
   void merge(unordered_set<Key, H2, P2, Allocator>&& source);
 ```
 
-Notes:: Does not support merging with a compatible `unordered_multiset` yet.
+[horizontal]
+Notes:;; Does not support merging with a compatible `unordered_multiset` yet.
 
 ---
 
@@ -1007,7 +1065,8 @@ allocator_type get_allocator() const;
 hasher hash_function() const;
 ```
 
-Returns:: The container's hash function.
+[horizontal]
+Returns:;; The container's hash function.
 
 ---
 
@@ -1017,7 +1076,8 @@ Returns:: The container's hash function.
 key_equal key_eq() const;
 ```
 
-Returns:: The container's key equality predicate
+[horizontal]
+Returns:;; The container's key equality predicate
 
 ---
 
@@ -1039,9 +1099,10 @@ template<typename CompatibleKey, typename CompatibleHash, typename CompatiblePre
                       CompatiblePredicate const& eq) const;
 ```
 
-Returns:: An iterator pointing to an element with key equivalent to `k`, or `b.end()` if no such element exists.
-
-Notes:: The templated overloads containing `CompatibleKey`, `CompatibleHash` and `CompatiblePredicate` are non-standard extensions which allow you to use a compatible hash function and equality predicate for a key of a different type in order to avoid an expensive type cast. In general, its use is not encouraged and instead the `K` member function templates should be used. +
+[horizontal]
+Returns:;; An iterator pointing to an element with key equivalent to `k`, or `b.end()` if no such element exists.
+Notes:;; The templated overloads containing `CompatibleKey`, `CompatibleHash` and `CompatiblePredicate` are non-standard extensions which allow you to use a compatible hash function and equality predicate for a key of a different type in order to avoid an expensive type cast. In general, its use is not encouraged and instead the `K` member function templates should be used. +
++
 The `template <typename K>` overloads only participate in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
 
 ---
@@ -1053,9 +1114,9 @@ template<class K>
   size_type      count(const K& k) const;
 ```
 
-Returns:: The number of elements with key equivalent to `k`.
-
-Notes:: The `template <typename K>` overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
+[horizontal]
+Returns:;; The number of elements with key equivalent to `k`.
+Notes:;; The `template <typename K>` overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
 
 ---
 
@@ -1066,9 +1127,9 @@ template<class K>
   bool           contains(const K& k) const;
 ```
 
-Returns:: A boolean indicating whether or not there is an element with key equal to `key` in the container
-
-Notes:: The `template <typename K>` overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
+[horizontal]
+Returns:;; A boolean indicating whether or not there is an element with key equal to `key` in the container
+Notes:;; The `template <typename K>` overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
 
 ---
 
@@ -1082,9 +1143,9 @@ template<class K>
   pair<const_iterator, const_iterator> equal_range(const K& k) const;
 ```
 
-Returns:: A range containing all elements with key equivalent to `k`. If the container doesn't contain any such elements, returns `std::make_pair(b.end(), b.end())`.
-
-Notes:: The `template <typename K>` overloads only participate in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
+[horizontal]
+Returns:;; A range containing all elements with key equivalent to `k`. If the container doesn't contain any such elements, returns `std::make_pair(b.end(), b.end())`.
+Notes:;; The `template <typename K>` overloads only participate in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
 
 ---
 
@@ -1095,7 +1156,8 @@ Notes:: The `template <typename K>` overloads only participate in overload resol
 size_type bucket_count() const noexcept;
 ```
 
-Returns:: The number of buckets.
+[horizontal]
+Returns:;; The number of buckets.
 
 ---
 
@@ -1104,7 +1166,8 @@ Returns:: The number of buckets.
 size_type max_bucket_count() const noexcept;
 ```
 
-Returns:: An upper bound on the number of buckets.
+[horizontal]
+Returns:;; An upper bound on the number of buckets.
 
 ---
 
@@ -1113,9 +1176,9 @@ Returns:: An upper bound on the number of buckets.
 size_type bucket_size(size_type n) const;
 ```
 
-Requires:: `n < bucket_count()`
-
-Returns:: The number of elements in bucket `n`.
+[horizontal]
+Requires:;; `n < bucket_count()`
+Returns:;; The number of elements in bucket `n`.
 
 ---
 
@@ -1124,9 +1187,9 @@ Returns:: The number of elements in bucket `n`.
 size_type bucket(const key_type& k) const;
 ```
 
-Returns:: The index of the bucket which would contain an element with key `k`.
-
-Postconditions:: The return value is less than `bucket_count()`.
+[horizontal]
+Returns:;; The index of the bucket which would contain an element with key `k`.
+Postconditions:;; The return value is less than `bucket_count()`.
 
 ---
 
@@ -1137,9 +1200,9 @@ local_iterator begin(size_type n);
 const_local_iterator begin(size_type n) const;
 ```
 
-Requires:: `n` shall be in the range `[0, bucket_count())`.
-
-Returns:: A local iterator pointing the first element in the bucket with index `n`.
+[horizontal]
+Requires:;; `n` shall be in the range `[0, bucket_count())`.
+Returns:;; A local iterator pointing the first element in the bucket with index `n`.
 
 ---
 
@@ -1149,9 +1212,9 @@ local_iterator end(size_type n);
 const_local_iterator end(size_type n) const;
 ```
 
-Requires:: `n` shall be in the range `[0, bucket_count())`.
-
-Returns:: A local iterator pointing the 'one past the end' element in the bucket with index `n`.
+[horizontal]
+Requires:;; `n` shall be in the range `[0, bucket_count())`.
+Returns:;; A local iterator pointing the 'one past the end' element in the bucket with index `n`.
 
 ---
 
@@ -1160,9 +1223,9 @@ Returns:: A local iterator pointing the 'one past the end' element in the bucket
 const_local_iterator cbegin(size_type n) const;
 ```
 
-Requires:: `n` shall be in the range `[0, bucket_count())`.
-
-Returns:: A constant local iterator pointing the first element in the bucket with index `n`.
+[horizontal]
+Requires:;; `n` shall be in the range `[0, bucket_count())`.
+Returns:;; A constant local iterator pointing the first element in the bucket with index `n`.
 
 ---
 
@@ -1171,9 +1234,9 @@ Returns:: A constant local iterator pointing the first element in the bucket wit
 const_local_iterator cend(size_type n) const;
 ```
 
-Requires:: `n` shall be in the range `[0, bucket_count())`.
-
-Returns:: A constant local iterator pointing the 'one past the end' element in the bucket with index `n`.
+[horizontal]
+Requires:;; `n` shall be in the range `[0, bucket_count())`.
+Returns:;; A constant local iterator pointing the 'one past the end' element in the bucket with index `n`.
 
 ---
 
@@ -1184,7 +1247,8 @@ Returns:: A constant local iterator pointing the 'one past the end' element in t
 float load_factor() const noexcept;
 ```
 
-Returns:: The average number of elements per bucket.
+[horizontal]
+Returns:;; The average number of elements per bucket.
 
 ---
 
@@ -1194,7 +1258,8 @@ Returns:: The average number of elements per bucket.
 float max_load_factor() const noexcept;
 ```
 
-Returns:: Returns the current maximum load factor.
+[horizontal]
+Returns:;; Returns the current maximum load factor.
 
 ---
 
@@ -1203,7 +1268,8 @@ Returns:: Returns the current maximum load factor.
 void max_load_factor(float z);
 ```
 
-Effects:: Changes the container's maximum load factor, using `z` as a hint.
+[horizontal]
+Effects:;; Changes the container's maximum load factor, using `z` as a hint.
 
 ---
 
@@ -1216,7 +1282,8 @@ Changes the number of buckets so that there at least `n` buckets, and so that th
 
 Invalidates iterators, and changes the order of elements. Pointers and references to elements are not invalidated.
 
-Throws:: The function has no effect if an exception is thrown, unless it is thrown by the container's hash function or comparison function.
+[horizontal]
+Throws:;; The function has no effect if an exception is thrown, unless it is thrown by the container's hash function or comparison function.
 
 ---
 
@@ -1227,7 +1294,8 @@ void reserve(size_type n);
 
 Invalidates iterators, and changes the order of elements. Pointers and references to elements are not invalidated.
 
-Throws:: The function has no effect if an exception is thrown, unless it is thrown by the container's hash function or comparison function.
+[horizontal]
+Throws:;; The function has no effect if an exception is thrown, unless it is thrown by the container's hash function or comparison function.
 
 === Equality Comparisons
 
@@ -1240,7 +1308,10 @@ template<class Key, class Hash, class Pred, class Alloc>
 
 Return `true` if `x.size() == y.size()` and for every element in `x`, there is an element in `y` with the same key, with an equal value (using `operator==` to compare the value types).
 
-Notes:: The behavior of this function was changed to match the C++11 standard in Boost 1.48. Behavior is undefined if the two containers don't have equivalent equality predicates.
+[horizontal]
+Notes:;; The behavior of this function was changed to match the C++11 standard in Boost 1.48. +
++
+Behavior is undefined if the two containers don't have equivalent equality predicates.
 
 ---
 
@@ -1253,7 +1324,10 @@ template<class Key, class Hash, class Pred, class Alloc>
 
 Return `false` if `x.size() == y.size()` and for every element in `x`, there is an element in `y` with the same key, with an equal value (using `operator==` to compare the value types).
 
-Notes:: The behavior of this function was changed to match the C++11 standard in Boost 1.48. Behavior is undefined if the two containers don't have equivalent equality predicates.
+[horizontal]
+Notes:;; The behavior of this function was changed to match the C++11 standard in Boost 1.48. +
++
+Behavior is undefined if the two containers don't have equivalent equality predicates.
 
 ---
 
@@ -1269,10 +1343,9 @@ Swaps the contents of `x` and `y`.
 
 If `Allocator::propagate_on_container_swap` is declared and `Allocator::propagate_on_container_swap::value` is `true` then the containers' allocators are swapped. Otherwise, swapping with unequal allocators results in undefined behavior.
 
-Effects:: `x.swap(y)`
+[horizontal]
+Effects:;; `x.swap(y)`
+Throws:;; Doesn't throw an exception unless it is thrown by the copy constructor or copy assignment operator of `key_equal` or `hasher`.
+Notes:;; The exception specifications aren't quite the same as the C++11 standard, as the equality predicate and hash function are swapped using their copy constructors.
 
-Throws:: Doesn't throw an exception unless it is thrown by the copy constructor or copy assignment operator of `key_equal` or `hasher`.
-
-Notes:: The exception specifications aren't quite the same as the C++11 standard, as the equality predicate and hash function are swapped using their copy constructors.
-
-
+---

--- a/doc/unordered/unordered_set.adoc
+++ b/doc/unordered/unordered_set.adoc
@@ -199,16 +199,16 @@ template<class Key, class Hash, class Pred, class Alloc>
 [cols="1,1"]
 |===
 
-|_Value_
-|`Value` must be https://en.cppreference.com/w/cpp/named_req/Erasable[Erasable^] from the container (i.e. `allocator_traits` can destroy it).
+|_Key_
+|`Key` must be https://en.cppreference.com/w/cpp/named_req/Erasable[Erasable^] from the container (i.e. `allocator_traits` can destroy it).
 
 |_Hash_
-|A unary function object type that acts a hash function for a `Value`. It takes a single argument of type `Value` and returns a value of type `std::size_t`.
+|A unary function object type that acts a hash function for a `Key`. It takes a single argument of type `Key` and returns a value of type `std::size_t`.
 
 |_Pred_
-|A binary function object that implements an equivalence relation on values of type `Value`. A binary function object that induces an equivalence relation on values of type `Value`. It takes two arguments of type `Value` and returns a value of type bool.
+|A binary function object that implements an equivalence relation on values of type `Key`. A binary function object that induces an equivalence relation on values of type `Key`. It takes two arguments of type `Key` and returns a value of type bool.
 
-|_Alloc_
+|_Allocator_
 |An allocator whose value type is the same as the container's value type.
 
 |===
@@ -345,13 +345,13 @@ Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` 
 ==== Bucket Count Constructor
 ```c++
 explicit unordered_set(size_type n,
-                       hasher const& hf = hasher(),
-                       key_equal const& eq = key_equal(),
-                       allocator_type const& a = allocator_type());
+                       const hasher& hf = hasher(),
+                       const key_equal& eql = key_equal(),
+                       const allocator_type& a = allocator_type());
 ```
 
 Constructs an empty container with at least `n` buckets, using `hf` as the hash
-function, `eq` as the key equality predicate, `a` as the allocator and a maximum
+function, `eql` as the key equality predicate, `a` as the allocator and a maximum
 load factor of `1.0`.
 
 Postconditions:: `size() == 0`
@@ -360,9 +360,26 @@ Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` 
 
 ---
 
+==== Iterator Range Constructor
+[source,c++,subs="+quotes"]
+----
+template<class InputIterator>
+  unordered_set(InputIterator f, InputIterator l,
+                size_type n = _implementation-defined_,
+                const hasher& hf = hasher(),
+                const key_equal& eql = key_equal(),
+                const allocator_type& a = allocator_type());
+----
+
+Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `eql` as the key equality predicate, `a` as the allocator and a maximum load factor of `1.0` and inserts the elements from `[f, l)` into it.
+
+Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
 ==== Copy Constructor
 ```c++
-unordered_set(unordered_set const& other);
+unordered_set(const unordered_set& other);
 ```
 
 The copy constructor. Copies the contained elements, hash function, predicate, maximum load factor and allocator.
@@ -389,7 +406,7 @@ So, for example, you can't return the container from a function.
 
 ==== Allocator Constructor
 ```c++
-explicit unordered_set(Allocator const& a);
+explicit unordered_set(const Allocator& a);
 ```
 
 Constructs an empty container, using allocator `a`.
@@ -398,7 +415,7 @@ Constructs an empty container, using allocator `a`.
 
 ==== Copy Constructor with Allocator
 ```c++
-unordered_set(unordered_set const& other, Allocator const& a);
+unordered_set(const unordered_set& other, const Allocator& a);
 ```
 
 Constructs an container, copying ``other``'s contained elements, hash function, predicate, maximum load factor, but using allocator `a`.
@@ -407,7 +424,7 @@ Constructs an container, copying ``other``'s contained elements, hash function, 
 
 ==== Move Constructor with Allocator
 ```c++
-unordered_set(unordered_set&& other, Allocator const& a);
+unordered_set(unordered_set&& other, const Allocator& a);
 ```
 
 Construct a container moving ``other``'s contained elements, and having the hash function, predicate and maximum load factor, but using allocate `a`.
@@ -417,9 +434,25 @@ Requires:: `value_type` is move insertable.
 
 ---
 
+==== Initializer List Constructor
+[source,c++,subs="+quotes"]
+----
+unordered_set(initializer_list<value_type> il,
+              size_type n = _implementation-defined_,
+              const hasher& hf = hasher(),
+              const key_equal& eql = key_equal(),
+              const allocator_type& a = allocator_type());
+----
+
+Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `eql` as the key equality predicate, `a` as the allocator and a maximum load factor of `1.0` and inserts the elements from `il` into it.
+
+Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
 ==== Bucket Count Constructor with Allocator
 ```c++
-unordered_set(size_type n, allocator_type const& a);
+unordered_set(size_type n, const allocator_type& a);
 ```
 
 Constructs an empty container with at least `n` buckets, using `hf` as the hash function, the default hash function and key equality predicate, `a` as the allocator and a maximum load factor of `1.0`.
@@ -431,7 +464,7 @@ Requires:: `hasher` and `key_equal` need to be https://en.cppreference.com/w/cpp
 
 ==== Bucket Count Constructor with Hasher and Allocator
 ```c++
-unordered_set(size_type n, hasher const& hf, allocator_type const& a);
+unordered_set(size_type n, const hasher& hf, const allocator_type& a);
 ```
 
 Constructs an empty container with at least `n` buckets, using `hf` as the hash function, the default key equality predicate, `a` as the allocator and a maximum load factor of `1.0`.
@@ -441,48 +474,11 @@ Requires:: `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/D
 
 ---
 
-==== Initializer List Constructor
-[source,c++,subs="quotes,macros"]
-----
-unordered_set(initializer_list++<++value_type++>++ il,
-              size_type n = _implementation-defined_,
-              hasher const& hf = hasher(),
-              key_equal const& eq = key_equal(),
-              allocator_type const& a = allocator_type());
-----
-
-Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `eq` as the key equality predicate, `a` as the allocator and a maximum load factor of `1.0` and inserts the elements from `il` into it.
-
-Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
-
----
-
-==== Iterator Range Constructor
-[source,c++,subs="quotes,macros"]
-----
-template++<++typename InputIterator++>++
-unordered_set(InputIterator f,
-              InputIterator l,
-              size_type n = _implementation-defined_,
-              hasher const& hf = hasher(),
-              key_equal const& eq = key_equal(),
-              allocator_type const& a = allocator_type());
-----
-
-Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `eq` as the key equality predicate, `a` as the allocator and a maximum load factor of `1.0` and inserts the elements from `[f, l)` into it.
-
-Requires:: If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
-
----
-
 ==== Iterator Range Constructor with Bucket Count and Allocator
-[source,c++,subs="quotes,macros"]
+[source,c++,subs="+quotes"]
 ----
-template++<++typename InputIterator++>++
-unordered_set(InputIterator f,
-              InputIterator l,
-              size_type n,
-              allocator_type const& a);
+template<class InputIterator>
+  unordered_set(InputIterator f, InputIterator l, size_type n, const allocator_type& a);
 ----
 
 Constructs an empty container with at least `n` buckets, using `a` as the allocator, with the default hash function and key equality predicate and a maximum load factor of `1.0` and inserts the elements from `[f, l)` into it.
@@ -490,14 +486,11 @@ Constructs an empty container with at least `n` buckets, using `a` as the alloca
 Requires:: `hasher`, `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
 
 ==== Iterator Range Constructor with Bucket Count and Hasher
-[source,c++,subs="quotes,macros"]
+[source,c++,subs="+quotes"]
 ----
-template++<++typename InputIterator++>++
-unordered_set(InputIterator f,
-              InputIterator l,
-              size_type n,
-              hasher const& hf,
-              allocator_type const& a);
+template<class InputIterator>
+  unordered_set(InputIterator f, InputIterator l, size_type n, const hasher& hf,
+                const allocator_type& a);
 ----
 
 Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `a` as the allocator, with the default key equality predicate and a maximum load factor of `1.0` and inserts the elements from `[f, l)` into it.
@@ -520,7 +513,7 @@ Note:: The destructor is applied to every element, and all memory is deallocated
 ==== Copy Assignment
 
 ```c++
-unordered_set& operator=(unordered_set const& other);
+unordered_set& operator=(const unordered_set& other);
 ```
 
 The assignment operator. Copies the contained elements, hash function, predicate and maximum load factor but not the allocator.
@@ -533,7 +526,10 @@ Requires:: `value_type` is copy constructible
 
 ==== Move Assignment
 ```c++
-unordered_set& operator=(unordered_set&& other);
+unordered_set& operator=(unordered_set&& other)
+  noexcept(boost::allocator_traits<Allocator>::is_always_equal::value &&
+           boost::is_nothrow_move_assignable_v<Hash> &&
+           boost::is_nothrow_move_assignable_v<Pred>);
 ```
 The move assignment operator.
 
@@ -554,12 +550,53 @@ Assign from values in initializer list. All existing elements are either overwri
 
 Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/CopyInsertable[CopyInsertable^] into the container and https://en.cppreference.com/w/cpp/named_req/CopyAssignable[CopyAssignable^].
 
+---
+
+=== Iterators
+
+==== begin
+```c++
+iterator       begin() noexcept;
+const_iterator begin() const noexcept;
+```
+
+Returns:: An iterator referring to the first element of the container, or if the container is empty the past-the-end value for the container.
+
+---
+
+==== end
+```c++
+iterator       end() noexcept;
+const_iterator end() const noexcept;
+```
+
+Returns:: An iterator which refers to the past-the-end value for the container.
+
+---
+
+==== cbegin
+```c++
+const_iterator cbegin() const noexcept;
+```
+Returns:: A `const_iterator` referring to the first element of the container, or if the container is empty the past-the-end value for the container.
+
+---
+
+==== cend
+```c++
+const_iterator cend() const noexcept;
+```
+
+Returns:: A `const_iterator` which refers to the past-the-end value for the container.
+
+---
+
 === Size and Capacity
 
 ==== empty
 
 ```c++
-bool empty() const;
+bool empty() const noexcept;
 ```
 
 Returns:: `size() == 0`
@@ -569,7 +606,7 @@ Returns:: `size() == 0`
 ==== size
 
 ```c++
-size_type size() const;
+size_type size() const noexcept;
 ```
 
 Returns:: `std::distance(begin(), end())`
@@ -579,49 +616,10 @@ Returns:: `std::distance(begin(), end())`
 ==== max_size
 
 ```c++
-size_type max_size() const;
+size_type max_size() const noexcept;
 ```
 
 Returns:: `size()` of the largest possible container.
-
----
-
-=== Iterators
-
-==== begin
-```c++
-iterator begin();
-const_iterator begin() const;
-```
-
-Returns:: An iterator referring to the first element of the container, or if the container is empty the past-the-end value for the container.
-
----
-
-==== end
-```c++
-iterator end();
-const_iterator end() const;
-```
-
-Returns:: An iterator which refers to the past-the-end value for the container.
-
----
-
-==== cbegin
-```c++
-const_iterator cbegin() const;
-```
-Returns:: A `const_iterator` referring to the first element of the container, or if the container is empty the past-the-end value for the container.
-
----
-
-==== cend
-```c++
-const_iterator cend() const;
-```
-
-Returns:: A `const_iterator` which refers to the past-the-end value for the container.
 
 ---
 
@@ -629,9 +627,7 @@ Returns:: A `const_iterator` which refers to the past-the-end value for the cont
 
 ==== emplace
 ```c++
-template<typename... Args>
-std::pair<iterator, bool>
-emplace(Args&&... args);
+template<class... Args> pair<iterator, bool> emplace(Args&&... args);
 ```
 
 Inserts an object, constructed with the arguments `args`, in the container if and only if there is no element in the container with an equivalent value.
@@ -652,14 +648,12 @@ Since existing `std::pair` implementations don't support `std::piecewise_constru
 
 ==== emplace_hint
 ```c++
-template<typename... Args>
-iterator
-emplace_hint(const_iterator hint, Args&&... args);
+template<class... Args> iterator emplace_hint(const_iterator position, Args&&... args);
 ```
 
 Inserts an object, constructed with the arguments `args`, in the container if and only if there is no element in the container with an equivalent value.
 
-`hint` is a suggestion to where the element should be inserted.
+`position` is a suggestion to where the element should be inserted.
 
 Requires:: `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `args`.
 
@@ -677,8 +671,7 @@ Since existing `std::pair` implementations don't support `std::piecewise_constru
 
 ==== Copy Insert
 ```c++
-std::pair<iterator, bool>
-insert(value_type const& obj);
+std::pair<iterator, bool> insert(const value_type& obj);
 ```
 
 Inserts `obj` in the container if and only if there is no element in the container with an equivalent key.
@@ -695,8 +688,7 @@ Notes:: Can invalidate iterators, but only if the insert causes the load factor 
 
 ==== Move Insert
 ```c++
-std::pair<iterator, bool>
-insert(value_type&& obj);
+std::pair<iterator, bool> insert(value_type&& obj);
 ```
 
 Inserts `obj` in the container if and only if there is no element in the container with an equivalent key.
@@ -711,29 +703,9 @@ Notes:: Can invalidate iterators, but only if the insert causes the load factor 
 
 ---
 
-==== Insert with `node_handle`
-```c++
-insert_return_type
-insert(node_type&& nh);
-```
-
-If `nh` is empty, has no effect.
-
-Otherwise inserts the element owned by `nh` if and only if there is no element in the container with an equivalent key.
-
-Requires:: `nh` is empty or `nh.get_allocator()` is equal to the container's allocator.
-
-Returns:: If `nh` was empty, returns an `insert_return_type` with: `inserted` equal to `false`, `position` equal to `end()` and `node` empty. Otherwise if there was already an element with an equivalent key, returns an `insert_return_type` with: `inserted` equal to `false`, `position` pointing to a matching element and `node` contains the node from `nh`. Otherwise if the insertion succeeded, returns an `insert_return_type` with: `inserted` equal to `true`, `position` pointing to the newly inserted element and `node` empty.
-
-Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
-
-Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated. In C++17 this can be used to insert a node extracted from a compatible `unordered_multiset`, but that is not supported yet.
-
----
-
 ==== Copy Insert with Hint
 ```c++
-iterator insert(const_iterator hint, value_type const& obj);
+iterator insert(const_iterator hint, const value_type& obj);
 ```
 Inserts `obj` in the container if and only if there is no element in the container with an equivalent key.
 
@@ -768,33 +740,9 @@ Notes:: The standard is fairly vague on the meaning of the hint. But the only pr
 
 ---
 
-==== Insert with Hint and `node_handle`
-```c++
-iterator insert(const_iterator hint, node_type&& nh);
-```
-
-If `nh` is empty, has no effect.
-
-Otherwise inserts the element owned by `nh` if and only if there is no element in the container with an equivalent key.
-
-If there is already an element in the container with an equivalent key has no effect on `nh` (i.e. `nh` still contains the node.)
-
-`hint` is a suggestion to where the element should be inserted.
-
-Requires:: `nh` is empty or `nh.get_allocator()` is equal to the container's allocator.
-
-Returns:: If `nh` was empty returns `end()`. If there was already an element in the container with an equivalent key returns an iterator pointing to that. Otherwise returns an iterator pointing to the newly inserted element.
-
-Throws:: If an exception is thrown by an operation other than a call to hasher the function has no effect.
-
-Notes:: The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated. In C++17 this can be used to insert a node extracted from a compatible `unordered_multiset`, but that is not supported yet.
-
----
-
 ==== Insert Iterator Range
 ```c++
-template<typename InputIterator>
-void insert(InputIterator first, InputIterator last);
+template<class InputIterator> void insert(InputIterator first, InputIterator last);
 ```
 
 Inserts a range of elements into the container. Elements are inserted if and only if there is no element in the container with an equivalent key.
@@ -809,7 +757,7 @@ Notes:: Can invalidate iterators, but only if the insert causes the load factor 
 
 ==== Insert Initializer List
 ```c++
-void insert(initializer_list<value_type> il);
+void insert(initializer_list<value_type>);
 ```
 
 Inserts a range of elements into the container. Elements are inserted if and only if there is no element in the container with an equivalent key.
@@ -835,15 +783,12 @@ Notes:: In C++17 a node extracted using this method can be inserted into a compa
 
 ---
 
-==== Transparent Extract by Value
+==== Extract by Value
 ```c++
-template<typename K>
-node_type extract(K&& k);
+node_type extract(const key_type& k);
 ```
 
 Removes an element with key equivalent to `k`.
-
-This overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs and neither `iterator` nor `const_iterator` are implicitly convertible from `K`. The library assumes that `Hash` is callable with both `K` and `Value` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Value` type.
 
 Returns:: A `node_type` owning the element if found, otherwise an empty `node_type`.
 
@@ -853,12 +798,14 @@ Notes:: In C++17 a node extracted using this method can be inserted into a compa
 
 ---
 
-==== Extract by Value
+==== Transparent Extract by Value
 ```c++
-node_type extract(key_type const& k);
+template<class K> node_type extract(K&& k);
 ```
 
 Removes an element with key equivalent to `k`.
+
+This overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs and neither `iterator` nor `const_iterator` are implicitly convertible from `K`. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
 
 Returns:: A `node_type` owning the element if found, otherwise an empty `node_type`.
 
@@ -866,9 +813,54 @@ Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
 
 Notes:: In C++17 a node extracted using this method can be inserted into a compatible `unordered_multiset`, but that is not supported yet.
 
+---
+
+==== Insert with `node_handle`
+```c++
+insert_return_type insert(node_type&& nh);
+```
+
+If `nh` is empty, has no effect.
+
+Otherwise inserts the element owned by `nh` if and only if there is no element in the container with an equivalent key.
+
+Requires:: `nh` is empty or `nh.get_allocator()` is equal to the container's allocator.
+
+Returns:: If `nh` was empty, returns an `insert_return_type` with: `inserted` equal to `false`, `position` equal to `end()` and `node` empty. Otherwise if there was already an element with an equivalent key, returns an `insert_return_type` with: `inserted` equal to `false`, `position` pointing to a matching element and `node` contains the node from `nh`. Otherwise if the insertion succeeded, returns an `insert_return_type` with: `inserted` equal to `true`, `position` pointing to the newly inserted element and `node` empty.
+
+Throws:: If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+
+Notes:: Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated. In C++17 this can be used to insert a node extracted from a compatible `unordered_multiset`, but that is not supported yet.
+
+---
+
+==== Insert with Hint and `node_handle`
+```c++
+iterator insert(const_iterator hint, node_type&& nh);
+```
+
+If `nh` is empty, has no effect.
+
+Otherwise inserts the element owned by `nh` if and only if there is no element in the container with an equivalent key.
+
+If there is already an element in the container with an equivalent key has no effect on `nh` (i.e. `nh` still contains the node.)
+
+`hint` is a suggestion to where the element should be inserted.
+
+Requires:: `nh` is empty or `nh.get_allocator()` is equal to the container's allocator.
+
+Returns:: If `nh` was empty returns `end()`. If there was already an element in the container with an equivalent key returns an iterator pointing to that. Otherwise returns an iterator pointing to the newly inserted element.
+
+Throws:: If an exception is thrown by an operation other than a call to hasher the function has no effect.
+
+Notes:: The standard is fairly vague on the meaning of the hint. But the only practical way to use it, and the only way that Boost.Unordered supports is to point to an existing element with the same key. Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. Pointers and references to elements are never invalidated. In C++17 this can be used to insert a node extracted from a compatible `unordered_multiset`, but that is not supported yet.
+
+---
+
 ==== Erase by Position
 
 ```c++
+iterator erase(iterator position);
 iterator erase(const_iterator position);
 ```
 
@@ -879,6 +871,34 @@ Returns:: The iterator following `position` before the erasure.
 Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
 
 Notes:: In older versions this could be inefficient because it had to search through several buckets to find the position of the returned iterator. The data structure has been changed so that this is no longer the case, and the alternative erase methods have been deprecated.
+
+---
+
+==== Erase by Value
+```c++
+size_type erase(const key_type& k);
+```
+
+Erase all elements with key equivalent to `k`.
+
+Returns:: The number of elements erased.
+
+Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
+
+---
+
+==== Transparent Erase by Value
+```c++
+template<class K> size_type erase(K&& k);
+```
+
+Erase all elements with key equivalent to `k`.
+
+This overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs and neither `iterator` nor `const_iterator` are implicitly convertible from `K`. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
+
+Returns:: The number of elements erased.
+
+Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
 
 ---
 
@@ -893,35 +913,6 @@ Erases the elements in the range from `first` to `last`.
 Returns:: The iterator following the erased elements - i.e. `last`.
 
 Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`. In this implementation, this overload doesn't call either function object's methods so it is no throw, but this might not be true in other implementations.
-
----
-
-==== Transparent Erase by Value
-```c++
-template<typename K>
-size_type erase(K&& k);
-```
-
-Erase all elements with key equivalent to `k`.
-
-This overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs and neither `iterator` nor `const_iterator` are implicitly convertible from `K`. The library assumes that `Hash` is callable with both `K` and `Value` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Value` type.
-
-Returns:: The number of elements erased.
-
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
-
----
-
-==== Erase by Value
-```c++
-size_type erase(key_type const& k);
-```
-
-Erase all elements with key equivalent to `k`.
-
-Returns:: The number of elements erased.
-
-Throws:: Only throws an exception if it is thrown by `hasher` or `key_equal`.
 
 ---
 
@@ -951,22 +942,12 @@ Notes:: This method was implemented because returning an iterator to the next el
 
 ---
 
-==== clear
-```c++
-void clear();
-```
-
-Erases all elements in the container.
-
-Postconditions:: `size() == 0`
-
-Throws:: Never throws an exception.
-
----
-
 ==== swap
 ```c++
-void swap(unordered_set& other);
+void swap(unordered_set& other)
+  noexcept(boost::allocator_traits<Allocator>::is_always_equal::value &&
+           boost::is_nothrow_swappable_v<Hash> &&
+           boost::is_nothrow_swappable_v<Pred>);
 ```
 
 Swaps the contents of the container with the parameter.
@@ -979,10 +960,23 @@ Notes:: The exception specifications aren't quite the same as the C++11 standard
 
 ---
 
+==== clear
+```c++
+void clear() noexcept;
+```
+
+Erases all elements in the container.
+
+Postconditions:: `size() == 0`
+
+Throws:: Never throws an exception.
+
+---
+
 ==== merge
 ```c++
-template<typename H2, typename P2>
-void merge(unordered_set<Value, Mapped, H2, P2, Alloc>& source);
+template<class H2, class P2>
+  void merge(unordered_set<Key, H2, P2, Allocator>& source);
 ```
 
 Notes:: Does not support merging with a compatible `unordered_multiset` yet.
@@ -991,8 +985,8 @@ Notes:: Does not support merging with a compatible `unordered_multiset` yet.
 
 ==== merge (rvalue reference)
 ```c++
-template<typename H2, typename P2>
-void merge(unordered_set<Value, Mapped, H2, P2, Alloc>&& source);
+template<class H2, class P2>
+  void merge(unordered_set<Key, H2, P2, Allocator>&& source);
 ```
 
 Notes:: Does not support merging with a compatible `unordered_multiset` yet.
@@ -1006,6 +1000,8 @@ Notes:: Does not support merging with a compatible `unordered_multiset` yet.
 allocator_type get_allocator() const;
 ```
 
+---
+
 ==== hash_function
 ```
 hasher hash_function() const;
@@ -1014,6 +1010,8 @@ hasher hash_function() const;
 Returns:: The container's hash function.
 
 ---
+
+==== key_eq
 
 ```
 key_equal key_eq() const;
@@ -1027,90 +1025,66 @@ Returns:: The container's key equality predicate
 
 ==== find
 ```c++
-iterator find(key_type const& k);
-const_iterator find(key_type const& k) const;
-
-template<typename K>
-iterator
-find(K const& k);
-
-template<typename K>
-const_iterator
-find(K const& k) const;
-
-template<
-  typename CompatibleValue,
-  typename CompatibleHash,
-  typename CompatiblePredicate>
-iterator
-find(CompatibleValue const& k,
-     CompatibleHash const& hash,
-     CompatiblePredicate const& eq);
-
-template<
-  typename CompatibleValue,
-  typename CompatibleHash,
-  typename CompatiblePredicate>
-const_iterator
-find(CompatibleValue const& k,
-      CompatibleHash const& hash,
-      CompatiblePredicate const& eq) const;
-
+iterator         find(const key_type& k);
+const_iterator   find(const key_type& k) const;
+template<class K>
+  iterator       find(const K& k);
+template<class K>
+  const_iterator find(const K& k) const;
+template<typename CompatibleKey, typename CompatibleHash, typename CompatiblePredicate>
+  iterator       find(CompatibleKey const& k, CompatibleHash const& hash,
+                      CompatiblePredicate const& eq);
+template<typename CompatibleKey, typename CompatibleHash, typename CompatiblePredicate>
+  const_iterator find(CompatibleKey const& k, CompatibleHash const& hash,
+                      CompatiblePredicate const& eq) const;
 ```
 
 Returns:: An iterator pointing to an element with key equivalent to `k`, or `b.end()` if no such element exists.
 
-Notes:: The templated overloads containing `CompatibleValue`, `CompatibleHash` and `CompatiblePredicate` are non-standard extensions which allow you to use a compatible hash function and equality predicate for a key of a different type in order to avoid an expensive type cast. In general, its use is not encouraged and instead the `K` member function templates should be used. +
-The `template <typename K>` overloads only participate in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Value` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Value` type.
-
----
-
-==== contains
-```c++
-template<typename K>
-bool contains(K const& key);
-bool contains(key_type const& key) const;
-```
-
-Returns:: A boolean indicating whether or not there is an element with key equal to `key` in the container
-
-Notes:: The `template <typename K>` overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Value` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Value` type.
+Notes:: The templated overloads containing `CompatibleKey`, `CompatibleHash` and `CompatiblePredicate` are non-standard extensions which allow you to use a compatible hash function and equality predicate for a key of a different type in order to avoid an expensive type cast. In general, its use is not encouraged and instead the `K` member function templates should be used. +
+The `template <typename K>` overloads only participate in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
 
 ---
 
 ==== count
 ```c++
-template<typename K>
-size_type count(K const& k) const;
-size_type count(key_type const& k) const;
+size_type        count(const key_type& k) const;
+template<class K>
+  size_type      count(const K& k) const;
 ```
 
 Returns:: The number of elements with key equivalent to `k`.
 
-Notes:: The `template <typename K>` overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Value` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Value` type.
+Notes:: The `template <typename K>` overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
+
+---
+
+==== contains
+```c++
+bool             contains(const key_type& k) const;
+template<class K>
+  bool           contains(const K& k) const;
+```
+
+Returns:: A boolean indicating whether or not there is an element with key equal to `key` in the container
+
+Notes:: The `template <typename K>` overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
 
 ---
 
 ==== equal_range
 ```c++
-std::pair<iterator, iterator>
-equal_range(key_type const& k);
-
-std::pair<const_iterator, const_iterator>
-equal_range(key_type const& k) const;
-
-template<typename K>
-std::pair<iterator, iterator>
-equal_range(K const& k);
-
-template<typename K>
-std::pair<const_iterator, const_iterator>
-equal_range(K const& k) const;
+pair<iterator, iterator>               equal_range(const key_type& k);
+pair<const_iterator, const_iterator>   equal_range(const key_type& k) const;
+template<class K>
+  pair<iterator, iterator>             equal_range(const K& k);
+template<class K>
+  pair<const_iterator, const_iterator> equal_range(const K& k) const;
 ```
 
 Returns:: A range containing all elements with key equivalent to `k`. If the container doesn't contain any such elements, returns `std::make_pair(b.end(), b.end())`.
 
-Notes:: The `template <typename K>` overloads only participate in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Value` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Value` type.
+Notes:: The `template <typename K>` overloads only participate in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
 
 ---
 
@@ -1118,7 +1092,7 @@ Notes:: The `template <typename K>` overloads only participate in overload resol
 
 ==== bucket_count
 ```c++
-size_type bucket_count() const;
+size_type bucket_count() const noexcept;
 ```
 
 Returns:: The number of buckets.
@@ -1127,7 +1101,7 @@ Returns:: The number of buckets.
 
 ==== max_bucket_count
 ```c++
-size_type max_bucket_count() const;
+size_type max_bucket_count() const noexcept;
 ```
 
 Returns:: An upper bound on the number of buckets.
@@ -1147,7 +1121,7 @@ Returns:: The number of elements in bucket `n`.
 
 ==== bucket
 ```c++
-size_type bucket(key_type const& k) const;
+size_type bucket(const key_type& k) const;
 ```
 
 Returns:: The index of the bucket which would contain an element with key `k`.
@@ -1207,7 +1181,7 @@ Returns:: A constant local iterator pointing the 'one past the end' element in t
 
 ==== load_factor
 ```c++
-float load_factor() const;
+float load_factor() const noexcept;
 ```
 
 Returns:: The average number of elements per bucket.
@@ -1217,7 +1191,7 @@ Returns:: The average number of elements per bucket.
 ==== max_load_factor
 
 ```c++
-float max_load_factor() const;
+float max_load_factor() const noexcept;
 ```
 
 Returns:: Returns the current maximum load factor.
@@ -1232,7 +1206,6 @@ void max_load_factor(float z);
 Effects:: Changes the container's maximum load factor, using `z` as a hint.
 
 ---
-
 
 ==== rehash
 ```c++
@@ -1260,14 +1233,9 @@ Throws:: The function has no effect if an exception is thrown, unless it is thro
 
 ==== operator==
 ```c++
-template<
-  typename Value,
-  typename Mapped,
-  typename Hash,
-  typename Pred,
-  typename Alloc>
-bool operator==(unordered_set<Value, Mapped, Hash, Pred, Alloc> const& x,
-                unordered_set<Value, Mapped, Hash, Pred, Alloc> const& y);
+template<class Key, class Hash, class Pred, class Alloc>
+  bool operator==(const unordered_set<Key, Hash, Pred, Alloc>& x,
+                  const unordered_set<Key, Hash, Pred, Alloc>& y);
 ```
 
 Return `true` if `x.size() == y.size()` and for every element in `x`, there is an element in `y` with the same key, with an equal value (using `operator==` to compare the value types).
@@ -1278,26 +1246,23 @@ Notes:: The behavior of this function was changed to match the C++11 standard in
 
 ==== operator!=
 ```c++
-template<
-  typename Value,
-  typename Mapped,
-  typename Hash,
-  typename Pred,
-  typename Alloc>
-bool operator!=(unordered_set<Value, Mapped, Hash, Pred, Alloc> const& x,
-                unordered_set<Value, Mapped, Hash, Pred, Alloc> const& y);
+template<class Key, class Hash, class Pred, class Alloc>
+  bool operator!=(const unordered_set<Key, Hash, Pred, Alloc>& x,
+                  const unordered_set<Key, Hash, Pred, Alloc>& y);
 ```
 
 Return `false` if `x.size() == y.size()` and for every element in `x`, there is an element in `y` with the same key, with an equal value (using `operator==` to compare the value types).
 
 Notes:: The behavior of this function was changed to match the C++11 standard in Boost 1.48. Behavior is undefined if the two containers don't have equivalent equality predicates.
 
+---
+
 === Swap
 ```c++
-template<typename Value, typename Mapped, typename Hash, typename Pred,
-         typename Alloc>
-void swap(unordered_set<Value, Mapped, Hash, Pred, Alloc>& x,
-          unordered_set<Value, Mapped, Hash, Pred, Alloc>& y);
+template<class Key, class Hash, class Pred, class Alloc>
+  void swap(unordered_set<Key, Hash, Pred, Alloc>& x,
+            unordered_set<Key, Hash, Pred, Alloc>& y)
+    noexcept(noexcept(x.swap(y)));
 ```
 
 Swaps the contents of `x` and `y`.


### PR DESCRIPTION
- update the synopsis for each container to be modelled after the stdlib
- the synopsis now links to the appropriate member functions
- add missing `noexcept` and `noexcept(...)` to relevant functiosn
- update description lists to be horizontally formatted
- description lists now include colons in the first item to better follow standard conventions