### PR TITLE
Correct reference docs for `merge()`

### DIFF
--- a/doc/unordered/unordered_map.adoc
+++ b/doc/unordered/unordered_map.adoc
@@ -125,7 +125,11 @@ namespace boost {
     template<class H2, class P2>
       void xref:#unordered_map_merge[merge](unordered_map<Key, T, H2, P2, Allocator>& source);
     template<class H2, class P2>
-      void xref:#unordered_map_merge_rvalue_reference[merge](unordered_map<Key, T, H2, P2, Allocator>&& source);
+      void xref:#unordered_map_merge[merge](unordered_map<Key, T, H2, P2, Allocator>&& source);
+    template<class H2, class P2>
+      void xref:#unordered_map_merge[merge](unordered_multimap<Key, T, H2, P2, Allocator>& source);
+    template<class H2, class P2>
+      void xref:#unordered_map_merge[merge](unordered_multimap<Key, T, H2, P2, Allocator>&& source);
 
     // observers
     hasher xref:#unordered_map_hash_function[hash_function]() const;
@@ -1084,23 +1088,36 @@ Throws:;; Never throws an exception.
 
 ==== merge
 ```c++
-template<typename H2, typename P2>
-void merge(unordered_map<Key, T, H2, P2, Alloc>& source);
+template<class H2, class P2>
+  void merge(unordered_map<Key, T, H2, P2, Allocator>& source);
+template<class H2, class P2>
+  void merge(unordered_map<Key, T, H2, P2, Allocator>&& source);
+template<class H2, class P2>
+  void merge(unordered_multimap<Key, T, H2, P2, Allocator>& source);
+template<class H2, class P2>
+  void merge(unordered_multimap<Key, T, H2, P2, Allocator>&& source);
 ```
 
+Attempt to "merge" two containers by iterating `source` and extracting any node in `source` that is not contained
+in `*this` and then inserting it into `*this`.
+
+Because `source` can have a different hash function and key equality predicate, the key of each node in
+`source` is rehashed using `this\->hash_function()` and then, if required, compared using `this\->key_eq()`.
+
+The behavior of this function is undefined if `this\->get_allocator() != source.get_allocator()`.
+
+This function does not copy or move any elements and instead simply relocates the nodes from `source`
+into `*this`.
+
 [horizontal]
-Notes:;; Does not support merging with a compatible `unordered_multimap` yet.
-
----
-
-==== merge (rvalue reference)
-```c++
-template<typename H2, typename P2>
-void merge(unordered_map<Key, T, H2, P2, Alloc>&& source);
-```
-
-[horizontal]
-Notes:;; Does not support merging with a compatible `unordered_multimap` yet.
+Notes:;;
++
+--
+* Pointers and references to transferred elements remain valid.
+* Invalidates iterators to transferred elements.
+* Invalidates iterators belonging to `*this`.
+* Iterators to non-transferred elements in `source` remain valid.
+--
 
 ---
 

--- a/doc/unordered/unordered_multimap.adoc
+++ b/doc/unordered/unordered_multimap.adoc
@@ -126,7 +126,11 @@ namespace boost {
     template<class H2, class P2>
       void xref:#unordered_multimap_merge[merge](unordered_multimap<Key, T, H2, P2, Allocator>& source);
     template<class H2, class P2>
-      void xref:#unordered_multimap_merge_rvalue_reference[merge](unordered_multimap<Key, T, H2, P2, Allocator>&& source);
+      void xref:#unordered_multimap_merge[merge](unordered_multimap<Key, T, H2, P2, Allocator>&& source);
+    template<class H2, class P2>
+      void xref:#unordered_multimap_merge[merge](unordered_map<Key, T, H2, P2, Allocator>& source);
+    template<class H2, class P2>
+      void xref:#unordered_multimap_merge[merge](unordered_map<Key, T, H2, P2, Allocator>&& source);
 
     // observers
     hasher xref:#unordered_multimap_hash_function[hash_function]() const;
@@ -1055,21 +1059,33 @@ Throws:;; Never throws an exception.
 ```c++
 template<class H2, class P2>
   void merge(unordered_multimap<Key, T, H2, P2, Allocator>& source);
-```
-
-[horizontal]
-Notes:;; Does not support merging with a compatible `unordered_map` yet.
-
----
-
-==== merge (rvalue reference)
-```c++
 template<class H2, class P2>
   void merge(unordered_multimap<Key, T, H2, P2, Allocator>&& source);
+template<class H2, class P2>
+  void merge(unordered_map<Key, T, H2, P2, Allocator>& source);
+template<class H2, class P2>
+  void merge(unordered_map<Key, T, H2, P2, Allocator>&& source);
 ```
 
+Attempt to "merge" two containers by iterating `source` and extracting all nodes in `source` and inserting them into `*this`.
+
+Because `source` can have a different hash function and key equality predicate, the key of each node in
+`source` is rehashed using `this\->hash_function()` and then, if required, compared using `this\->key_eq()`.
+
+The behavior of this function is undefined if `this\->get_allocator() != source.get_allocator()`.
+
+This function does not copy or move any elements and instead simply relocates the nodes from `source`
+into `*this`.
+
 [horizontal]
-Notes:;; Does not support merging with a compatible `unordered_map` yet.
+Notes:;;
++
+--
+* Pointers and references to transferred elements remain valid.
+* Invalidates iterators to transferred elements.
+* Invalidates iterators belonging to `*this`.
+* Iterators to non-transferred elements in `source` remain valid.
+--
 
 ---
 

--- a/doc/unordered/unordered_multiset.adoc
+++ b/doc/unordered/unordered_multiset.adoc
@@ -120,7 +120,11 @@ namespace boost {
     template<class H2, class P2>
       void xref:#unordered_multiset_merge[merge](unordered_multiset<Key, H2, P2, Allocator>& source);
     template<class H2, class P2>
-      void xref:#unordered_multiset_merge_rvalue_reference[merge](unordered_multiset<Key, H2, P2, Allocator>&& source);
+      void xref:#unordered_multiset_merge[merge](unordered_multiset<Key, H2, P2, Allocator>&& source);
+    template<class H2, class P2>
+      void xref:#unordered_multiset_merge[merge](unordered_set<Key, H2, P2, Allocator>& source);
+    template<class H2, class P2>
+      void xref:#unordered_multiset_merge[merge](unordered_set<Key, H2, P2, Allocator>&& source);
 
     // observers
     hasher xref:#unordered_multiset_hash_function[hash_function]() const;
@@ -1013,21 +1017,33 @@ Throws:;; Never throws an exception.
 ```c++
 template<class H2, class P2>
   void merge(unordered_multiset<Key, H2, P2, Allocator>& source);
-```
-
-[horizontal]
-Notes:;; Does not support merging with a compatible `unordered_set` yet.
-
----
-
-==== merge (rvalue reference)
-```c++
 template<class H2, class P2>
   void merge(unordered_multiset<Key, H2, P2, Allocator>&& source);
+template<class H2, class P2>
+  void merge(unordered_set<Key, H2, P2, Allocator>& source);
+template<class H2, class P2>
+  void merge(unordered_set<Key, H2, P2, Allocator>&& source);
 ```
 
+Attempt to "merge" two containers by iterating `source` and extracting all nodes in `source` and inserting them into `*this`.
+
+Because `source` can have a different hash function and key equality predicate, the key of each node in
+`source` is rehashed using `this\->hash_function()` and then, if required, compared using `this\->key_eq()`.
+
+The behavior of this function is undefined if `this\->get_allocator() != source.get_allocator()`.
+
+This function does not copy or move any elements and instead simply relocates the nodes from `source`
+into `*this`.
+
 [horizontal]
-Notes:;; Does not support merging with a compatible `unordered_set` yet.
+Notes:;;
++
+--
+* Pointers and references to transferred elements remain valid.
+* Invalidates iterators to transferred elements.
+* Invalidates iterators belonging to `*this`.
+* Iterators to non-transferred elements in `source` remain valid.
+--
 
 ---
 

--- a/doc/unordered/unordered_set.adoc
+++ b/doc/unordered/unordered_set.adoc
@@ -121,7 +121,11 @@ namespace boost {
     template<class H2, class P2>
       void xref:#unordered_set_merge[merge](unordered_set<Key, H2, P2, Allocator>& source);
     template<class H2, class P2>
-      void xref:#unordered_set_merge_rvalue_reference[merge](unordered_set<Key, H2, P2, Allocator>&& source);
+      void xref:#unordered_set_merge[merge](unordered_set<Key, H2, P2, Allocator>&& source);
+    template<class H2, class P2>
+      void xref:#unordered_set_merge[merge](unordered_multiset<Key, H2, P2, Allocator>& source);
+    template<class H2, class P2>
+      void xref:#unordered_set_merge[merge](unordered_multiset<Key, H2, P2, Allocator>&& source);
 
     // observers
     hasher xref:#unordered_set_hash_function[hash_function]() const;
@@ -1037,21 +1041,34 @@ Throws:;; Never throws an exception.
 ```c++
 template<class H2, class P2>
   void merge(unordered_set<Key, H2, P2, Allocator>& source);
-```
-
-[horizontal]
-Notes:;; Does not support merging with a compatible `unordered_multiset` yet.
-
----
-
-==== merge (rvalue reference)
-```c++
 template<class H2, class P2>
   void merge(unordered_set<Key, H2, P2, Allocator>&& source);
+template<class H2, class P2>
+  void merge(unordered_multiset<Key, H2, P2, Allocator>& source);
+template<class H2, class P2>
+  void merge(unordered_multiset<Key, H2, P2, Allocator>&& source);
 ```
 
+Attempt to "merge" two containers by iterating `source` and extracting any node in `source` that is not contained
+in `*this` and then inserting it into `*this`.
+
+Because `source` can have a different hash function and key equality predicate, the key of each node in
+`source` is rehashed using `this\->hash_function()` and then, if required, compared using `this\->key_eq()`.
+
+The behavior of this function is undefined if `this\->get_allocator() != source.get_allocator()`.
+
+This function does not copy or move any elements and instead simply relocates the nodes from `source`
+into `*this`.
+
 [horizontal]
-Notes:;; Does not support merging with a compatible `unordered_multiset` yet.
+Notes:;;
++
+--
+* Pointers and references to transferred elements remain valid.
+* Invalidates iterators to transferred elements.
+* Invalidates iterators belonging to `*this`.
+* Iterators to non-transferred elements in `source` remain valid.
+--
 
 ---
 


### PR DESCRIPTION
As it turns out, supporting for merging `unordered_map` <-> `unordered_multimap` and `unordered_set` <-> `unordered_multiset` is already done, the docs were simply just not updated.

Closes #103 