### PR TITLE
Add Boost::align dependency to CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ target_include_directories(boost_unordered INTERFACE include)
 
 target_link_libraries(boost_unordered
   INTERFACE
+    Boost::align
     Boost::assert
     Boost::config
     Boost::container


### PR DESCRIPTION
This is required after #112

@cmazakas @pdimov Please merge soon as this currently breaks the super-project CMake build