### PR TITLE
Fix compilation on Clang < 3.8

### DIFF
--- a/include/boost/unordered/detail/implementation.hpp
+++ b/include/boost/unordered/detail/implementation.hpp
@@ -1416,8 +1416,6 @@ namespace boost {
         {
           node_constructor<Alloc> a(alloc);
           a.create_node();
-#if !(BOOST_COMP_CLANG && BOOST_COMP_CLANG < BOOST_VERSION_NUMBER(3, 8, 0) &&  \
-      defined(BOOST_LIBSTDCXX11))
 
           typedef typename boost::allocator_value_type<Alloc>::type node;
           typedef typename node::value_type value_type;
@@ -1426,6 +1424,8 @@ namespace boost {
 
           value_allocator val_alloc(alloc);
 
+#if !(BOOST_COMP_CLANG && BOOST_COMP_CLANG < BOOST_VERSION_NUMBER(3, 8, 0) &&  \
+      defined(BOOST_LIBSTDCXX11))
           boost::allocator_construct(val_alloc, a.node_->value_ptr(),
             std::piecewise_construct,
             std::forward_as_tuple(boost::forward<Key>(k)),


### PR DESCRIPTION
`val_alloc` is used in the other branch of the #ifdef too. CI Test runs for such old clangs are missing hence this went undetected. Added those in #114