### PR TITLE
erase(iterator) perf

### DIFF
--- a/include/boost/unordered/detail/implementation.hpp
+++ b/include/boost/unordered/detail/implementation.hpp
@@ -2928,6 +2928,23 @@ namespace boost {
           return 1;
         }
 
+        iterator erase_node(c_iterator pos) {
+          c_iterator next = pos;
+          ++next;
+          
+          bucket_iterator itb = pos.itb;
+          node_pointer* pp = boost::addressof(itb->next);
+          while (*pp != pos.p) {
+            pp = boost::addressof((*pp)->next);
+          }
+
+          buckets_.extract_node_after(itb, pp);
+          this->delete_node(pos.p);
+          --size_;
+
+          return iterator(next.p, next.itb);
+        }
+
         iterator erase_nodes_range(c_iterator first, c_iterator last)
         {
           if (first == last) {

--- a/include/boost/unordered/unordered_map.hpp
+++ b/include/boost/unordered/unordered_map.hpp
@@ -1856,18 +1856,14 @@ namespace boost {
     typename unordered_map<K, T, H, P, A>::iterator
     unordered_map<K, T, H, P, A>::erase(iterator position)
     {
-      const_iterator last = position;
-      ++last;
-      return table_.erase_nodes_range(position, last);
+      return table_.erase_node(position);
     }
 
     template <class K, class T, class H, class P, class A>
     typename unordered_map<K, T, H, P, A>::iterator
     unordered_map<K, T, H, P, A>::erase(const_iterator position)
     {
-      const_iterator last = position;
-      ++last;
-      return table_.erase_nodes_range(position, last);
+      return table_.erase_node(position);
     }
 
     template <class K, class T, class H, class P, class A>
@@ -2340,9 +2336,7 @@ namespace boost {
     unordered_multimap<K, T, H, P, A>::erase(iterator position)
     {
       BOOST_ASSERT(position != this->end());
-      iterator next = position;
-      ++next;
-      return table_.erase_nodes_range(position, next);
+      return table_.erase_node(position);
     }
 
     template <class K, class T, class H, class P, class A>
@@ -2350,9 +2344,7 @@ namespace boost {
     unordered_multimap<K, T, H, P, A>::erase(const_iterator position)
     {
       BOOST_ASSERT(position != this->end());
-      const_iterator next = position;
-      ++next;
-      return table_.erase_nodes_range(position, next);
+      return table_.erase_node(position);
     }
 
     template <class K, class T, class H, class P, class A>

--- a/include/boost/unordered/unordered_set.hpp
+++ b/include/boost/unordered/unordered_set.hpp
@@ -1457,9 +1457,7 @@ namespace boost {
     typename unordered_set<T, H, P, A>::iterator
     unordered_set<T, H, P, A>::erase(const_iterator position)
     {
-      const_iterator last = position;
-      ++last;
-      return table_.erase_nodes_range(position, last);
+      return table_.erase_node(position);
     }
 
     template <class T, class H, class P, class A>
@@ -1853,10 +1851,7 @@ namespace boost {
     unordered_multiset<T, H, P, A>::erase(const_iterator position)
     {
       BOOST_ASSERT(position != this->end());
-      iterator next = position;
-      ++next;
-      table_.erase_nodes_range(position, next);
-      return next;
+      return table_.erase_node(position);
     }
 
     template <class T, class H, class P, class A>


### PR DESCRIPTION
Add a dedicated `erase_node()` function to the table class used internally by the implementation, creating optimizer-friendly code for cl.exe.

Partially addresses https://github.com/boostorg/unordered/issues/137