### PR TITLE
drone.jsonnet update

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -32,6 +32,7 @@ local linux_pipeline(name, image, environment, packages = "", sources = [], arch
             commands:
             [
                 'set -e',
+                'uname -a',
                 'wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -',
             ] +
             (if sources != [] then [ ('apt-add-repository "' + source + '"') for source in sources ] else []) +
@@ -63,6 +64,7 @@ local macos_pipeline(name, environment, xcode_version = "12.2", osx_version = "c
             environment: environment + { "DEVELOPER_DIR": "/Applications/Xcode-" + xcode_version + ".app/Contents/Developer" },
             commands:
             [
+                'uname -a',
                 'export LIBRARY=' + library,
                 './.drone/drone.sh',
             ]
@@ -89,6 +91,7 @@ local windows_pipeline(name, image, environment, arch = "amd64") =
             environment: environment,
             commands:
             [
+                'echo $env:DRONE_STAGE_MACHINE',
                 'cmd /C .drone\\\\drone.bat ' + library,
             ]
         }
@@ -168,8 +171,9 @@ local windows_pipeline(name, image, environment, arch = "amd64") =
     ),
 
     macos_pipeline(
-        "MacOS 10.15 Xcode 12.2 ASAN",
+        "MacOS 12.4 Xcode 13.4.1 ASAN",
         { TOOLSET: 'clang', COMPILER: 'clang++', CXXSTD: '03,11,14,1z' } + asan,
+        xcode_version = "13.4.1", osx_version = "monterey",
     ),
 
     windows_pipeline(

--- a/.drone/drone.sh
+++ b/.drone/drone.sh
@@ -5,6 +5,7 @@
 # https://www.boost.org/LICENSE_1_0.txt
 
 set -ex
+export PATH=~/.local/bin:/usr/local/bin:$PATH
 
 DRONE_BUILD_DIR=$(pwd)
 


### PR DESCRIPTION
Ideas for .drone.jsonnet:

- A new set of macminis are running Monterey 12.4 with Xcode 12.5 through 13.4. If jobs are distributed across both Monterey and Catalina it can balance the load more. 

- Add 'uname' diagnostics at the beginning of each job to show the name of the runner and the architecture.

- Append "/usr/local/bin" to PATH, which seems to be needed on OSX.

@pdimov consider these changes for other repos also.