### PR TITLE
Update internal table to no longer allocate on default constructions and when the bucket count is 0

### DIFF
--- a/include/boost/unordered/detail/fca.hpp
+++ b/include/boost/unordered/detail/fca.hpp
@@ -494,11 +494,25 @@ namespace boost {
         group_pointer groups;
 
       public:
+        grouped_bucket_array()
+            : empty_value<node_allocator_type>(
+                empty_init_t(), node_allocator_type()),
+              size_index_(0), size_(0), buckets(), groups()
+        {
+        }
+
         grouped_bucket_array(size_type n, const Allocator& al)
             : empty_value<node_allocator_type>(empty_init_t(), al),
-              size_index_(size_policy::size_index(n)),
-              size_(size_policy::size(size_index_)), buckets(), groups()
+              size_index_(0),
+              size_(0), buckets(), groups()
         {
+          if (n == 0) {
+            return;
+          }
+
+          size_index_ = size_policy::size_index(n);
+          size_ = size_policy::size(size_index_);
+
           bucket_allocator_type bucket_alloc = this->get_bucket_allocator();
           group_allocator_type group_alloc = this->get_group_allocator();
 

--- a/include/boost/unordered/detail/implementation.hpp
+++ b/include/boost/unordered/detail/implementation.hpp
@@ -200,7 +200,7 @@ namespace boost {
       template <typename Types> struct table;
 
       static const float minimum_max_load_factor = 1e-3f;
-      static const std::size_t default_bucket_count = 11;
+      static const std::size_t default_bucket_count = 0;
 
       struct move_tag
       {

--- a/include/boost/unordered/unordered_map.hpp
+++ b/include/boost/unordered/unordered_map.hpp
@@ -1664,8 +1664,6 @@ namespace boost {
 
     template <class K, class T, class H, class P, class A>
     unordered_map<K, T, H, P, A>::unordered_map()
-        : table_(boost::unordered::detail::default_bucket_count, hasher(),
-            key_equal(), allocator_type())
     {
     }
 
@@ -2147,8 +2145,6 @@ namespace boost {
 
     template <class K, class T, class H, class P, class A>
     unordered_multimap<K, T, H, P, A>::unordered_multimap()
-        : table_(boost::unordered::detail::default_bucket_count, hasher(),
-            key_equal(), allocator_type())
     {
     }
 

--- a/include/boost/unordered/unordered_set.hpp
+++ b/include/boost/unordered/unordered_set.hpp
@@ -1266,8 +1266,6 @@ namespace boost {
     ////////////////////////////////////////////////////////////////////////////
     template <class T, class H, class P, class A>
     unordered_set<T, H, P, A>::unordered_set()
-        : table_(boost::unordered::detail::default_bucket_count, hasher(),
-            key_equal(), allocator_type())
     {
     }
 
@@ -1664,8 +1662,6 @@ namespace boost {
 
     template <class T, class H, class P, class A>
     unordered_multiset<T, H, P, A>::unordered_multiset()
-        : table_(boost::unordered::detail::default_bucket_count, hasher(),
-            key_equal(), allocator_type())
     {
     }
 

--- a/test/exception/insert_exception_tests.cpp
+++ b/test/exception/insert_exception_tests.cpp
@@ -95,7 +95,7 @@ void insert_rehash_exception_test(
   T*, Inserter insert, test::random_generator gen)
 {
   for (int i = 0; i < 5; ++i) {
-    T x;
+    T x(1);
     rehash_prep(x);
 
     test::random_values<T> v2(5, gen);
@@ -393,7 +393,7 @@ template <typename T>
 void insert_range_rehash_exception_test(T*, test::random_generator gen)
 {
   for (int i = 0; i < 5; ++i) {
-    T x;
+    T x(1);
     rehash_prep(x);
 
     test::random_values<T> v2(5, gen);

--- a/test/unordered/assign_tests.cpp
+++ b/test/unordered/assign_tests.cpp
@@ -45,6 +45,7 @@ namespace assign_tests {
       BOOST_TEST(x.empty());
       BOOST_TEST(test::equivalent(x.hash_function(), hf));
       BOOST_TEST(test::equivalent(x.key_eq(), eq));
+      BOOST_TEST(test::detail::tracker.count_allocations == 0);
     }
 
     BOOST_LIGHTWEIGHT_TEST_OSTREAM << "assign_tests1.2\n";
@@ -94,6 +95,7 @@ namespace assign_tests {
       BOOST_TEST(test::equivalent(x1.key_eq(), eq1));
       BOOST_TEST(test::equivalent(x2.hash_function(), hf1));
       BOOST_TEST(test::equivalent(x2.key_eq(), eq1));
+      BOOST_TEST(test::detail::tracker.count_allocations == 0);
       test::check_container(x1, x2);
     }
 

--- a/test/unordered/copy_tests.cpp
+++ b/test/unordered/copy_tests.cpp
@@ -43,6 +43,23 @@ namespace copy_tests {
       BOOST_TEST(x.max_load_factor() == y.max_load_factor());
       BOOST_TEST(test::selected_count(y.get_allocator()) ==
                  (allocator_type::is_select_on_copy));
+      BOOST_TEST(test::detail::tracker.count_allocations == 0);
+      test::check_equivalent_keys(y);
+    }
+
+    {
+      test::check_instances check_;
+
+      T x(0);
+      T y(x);
+      BOOST_TEST(y.empty());
+      BOOST_TEST(test::equivalent(y.hash_function(), hf));
+      BOOST_TEST(test::equivalent(y.key_eq(), eq));
+      BOOST_TEST(test::equivalent(y.get_allocator(), al));
+      BOOST_TEST(x.max_load_factor() == y.max_load_factor());
+      BOOST_TEST(test::selected_count(y.get_allocator()) ==
+                 (allocator_type::is_select_on_copy));
+      BOOST_TEST(test::detail::tracker.count_allocations == 0);
       test::check_equivalent_keys(y);
     }
 
@@ -94,6 +111,22 @@ namespace copy_tests {
     {
       test::check_instances check_;
 
+      T x(0, hf, eq, al);
+      T y(x);
+      BOOST_TEST(y.empty());
+      BOOST_TEST(test::equivalent(y.hash_function(), hf));
+      BOOST_TEST(test::equivalent(y.key_eq(), eq));
+      BOOST_TEST(test::equivalent(y.get_allocator(), al));
+      BOOST_TEST(x.max_load_factor() == y.max_load_factor());
+      BOOST_TEST(test::selected_count(y.get_allocator()) ==
+                 (allocator_type::is_select_on_copy));
+      BOOST_TEST(test::detail::tracker.count_allocations == 0);
+      test::check_equivalent_keys(y);
+    }
+
+    {
+      test::check_instances check_;
+
       T x(10000, hf, eq, al);
       T y(x);
       BOOST_TEST(y.empty());
@@ -103,6 +136,21 @@ namespace copy_tests {
       BOOST_TEST(x.max_load_factor() == y.max_load_factor());
       BOOST_TEST(test::selected_count(y.get_allocator()) ==
                  (allocator_type::is_select_on_copy));
+      test::check_equivalent_keys(y);
+    }
+
+    {
+      test::check_instances check_;
+
+      T x(0, hf, eq, al);
+      T y(x, al2);
+      BOOST_TEST(y.empty());
+      BOOST_TEST(test::equivalent(y.hash_function(), hf));
+      BOOST_TEST(test::equivalent(y.key_eq(), eq));
+      BOOST_TEST(test::equivalent(y.get_allocator(), al2));
+      BOOST_TEST(x.max_load_factor() == y.max_load_factor());
+      BOOST_TEST(test::selected_count(y.get_allocator()) == 0);
+      BOOST_TEST(test::detail::tracker.count_allocations == 0);
       test::check_equivalent_keys(y);
     }
 
@@ -123,6 +171,22 @@ namespace copy_tests {
     {
       test::check_instances check_;
 
+      test::random_values<T> v;
+
+      T x(v.begin(), v.end(), 0, hf, eq, al);
+      T y(x);
+      test::unordered_equivalence_tester<T> equivalent(x);
+      BOOST_TEST(equivalent(y));
+      test::check_equivalent_keys(y);
+      BOOST_TEST(test::selected_count(y.get_allocator()) ==
+                 (allocator_type::is_select_on_copy));
+      BOOST_TEST(test::equivalent(y.get_allocator(), al));
+      BOOST_TEST(test::detail::tracker.count_allocations == 0);
+    }
+
+    {
+      test::check_instances check_;
+
       test::random_values<T> v(1000, generator);
 
       T x(v.begin(), v.end(), 0, hf, eq, al);
@@ -133,6 +197,21 @@ namespace copy_tests {
       BOOST_TEST(test::selected_count(y.get_allocator()) ==
                  (allocator_type::is_select_on_copy));
       BOOST_TEST(test::equivalent(y.get_allocator(), al));
+    }
+
+    {
+      test::check_instances check_;
+
+      test::random_values<T> v;
+
+      T x(v.begin(), v.end(), 0, hf, eq, al);
+      T y(x, al2);
+      test::unordered_equivalence_tester<T> equivalent(x);
+      BOOST_TEST(equivalent(y));
+      test::check_equivalent_keys(y);
+      BOOST_TEST(test::selected_count(y.get_allocator()) == 0);
+      BOOST_TEST(test::equivalent(y.get_allocator(), al2));
+      BOOST_TEST(test::detail::tracker.count_allocations == 0);
     }
 
     {

--- a/test/unordered/scary_tests.cpp
+++ b/test/unordered/scary_tests.cpp
@@ -224,7 +224,7 @@ template <class C1, class C2> void scary_test()
   typename C2::const_iterator cbegin(x.cbegin());
   BOOST_TEST(cbegin == x.cend());
 
-  BOOST_ASSERT(x.bucket_count() > 0);
+  BOOST_TEST_EQ(x.bucket_count(), 0u);
 
   typename C2::local_iterator lbegin(x.begin(0));
   BOOST_TEST(lbegin == x.end(0));


### PR DESCRIPTION
Also make sure assignment operators don't allocate either as:
```cpp
T x;
T y;
x = y;
```
heavily implies no allocations should be happening.