### PR TITLE
Rehashing Conformity

### DIFF
--- a/include/boost/unordered/detail/fca.hpp
+++ b/include/boost/unordered/detail/fca.hpp
@@ -494,6 +494,14 @@ namespace boost {
         group_pointer groups;
 
       public:
+        static std::size_t bucket_count_for(std::size_t num_buckets)
+        {
+          if (num_buckets == 0) {
+            return 0;
+          }
+          return size_policy::size(size_policy::size_index(num_buckets));
+        }
+
         grouped_bucket_array()
             : empty_value<node_allocator_type>(
                 empty_init_t(), node_allocator_type()),

--- a/include/boost/unordered/detail/implementation.hpp
+++ b/include/boost/unordered/detail/implementation.hpp
@@ -2524,6 +2524,17 @@ namespace boost {
           new_buckets.insert_node(itnewb, p);
         }
 
+        static std::size_t min_buckets(std::size_t num_elements, float mlf)
+        {
+          std::size_t num_buckets = static_cast<std::size_t>(
+            std::ceil(static_cast<float>(num_elements) / mlf));
+
+          if (num_buckets == 0 && num_elements > 0) { // mlf == inf
+            num_buckets = 1;
+          }
+          return num_buckets;
+        }
+
         void rehash(std::size_t);
         void reserve(std::size_t);
         void reserve_for_insert(std::size_t);
@@ -3432,22 +3443,18 @@ namespace boost {
       template <typename Types>
       inline void table<Types>::rehash(std::size_t num_buckets)
       {
-        std::size_t bc = (std::max)(num_buckets,
-          static_cast<std::size_t>(1.0f + static_cast<float>(size_) / mlf_));
+        num_buckets = (std::max)(
+          min_buckets(size_, mlf_), buckets_.bucket_count_for(num_buckets));
 
-        if (bc <= buckets_.bucket_count()) {
-          return;
+        if (num_buckets != this->bucket_count()) {
+          this->rehash_impl(num_buckets);
         }
-
-        this->rehash_impl(bc);
       }
 
       template <class Types>
       inline void table<Types>::reserve(std::size_t num_elements)
       {
-        std::size_t const num_buckets = static_cast<std::size_t>(
-          std::ceil(static_cast<float>(num_elements) / mlf_));
-
+        std::size_t num_buckets = min_buckets(num_elements, mlf_);
         this->rehash(num_buckets);
       }
 

--- a/include/boost/unordered/detail/implementation.hpp
+++ b/include/boost/unordered/detail/implementation.hpp
@@ -2071,8 +2071,6 @@ namespace boost {
 
         void recalculate_max_load()
         {
-          using namespace std;
-
           // From 6.3.1/13:
           // Only resize when size >= mlf_ * count
           std::size_t const bc = buckets_.bucket_count();
@@ -2083,8 +2081,8 @@ namespace boost {
           //
           max_load_ =
             bc == 0 ? 0
-                    : boost::unordered::detail::double_to_size(floor(
-                        static_cast<double>(mlf_) * static_cast<double>(bc)));
+                    : boost::unordered::detail::double_to_size(
+                        static_cast<double>(mlf_) * static_cast<double>(bc));
         }
 
         void max_load_factor(float z)


### PR DESCRIPTION
Update the rehash() and reserve() functions so that they behave similarly to libstdc++ and libc++, i.e. rehashing should grow and shrink the allocation accordingly while still respecting the max load factor