### PR TITLE
Fix sequential generator

### DIFF
--- a/test/helpers/generators.hpp
+++ b/test/helpers/generators.hpp
@@ -43,8 +43,8 @@ namespace test {
   inline int generate(int const*, random_generator g)
   {
     if (g == sequential) {
-      BOOST_ASSERT(
-        g + 1 < INT_MAX && "test::reset_sequence() should be invoked");
+      BOOST_ASSERT_MSG(
+        origin < INT_MAX, "test::reset_sequence() should be invoked");
       return origin++;
     }
 


### PR DESCRIPTION
* `g` isn't `origin` so don't compare it to `INT_MAX`
* `origin + 1` can potentially overflow so we remove it
* opt into more idiomatic usage `BOOST_ASSERT_MSG()`