### PR TITLE
feature/foa fast copy

### DIFF
--- a/include/boost/unordered/detail/foa.hpp
+++ b/include/boost/unordered/detail/foa.hpp
@@ -1533,8 +1533,13 @@ private:
 
   void copy_elements_array_from(const table& x,std::true_type /* -> memcpy */)
   {
+    /* reinterpret_cast: GCC may complain about value_type not being trivially
+     * copy-assignable when we're relying on trivial copy constructibility.
+     */
     std::memcpy(
-      arrays.elements,x.arrays.elements,x.capacity()*sizeof(value_type));
+      reinterpret_cast<unsigned char*>(arrays.elements),
+      reinterpret_cast<unsigned char*>(x.arrays.elements),
+      x.capacity()*sizeof(value_type));
   }
 
   void copy_elements_array_from(const table& x,std::false_type /* -> manual */)

--- a/include/boost/unordered/detail/foa.hpp
+++ b/include/boost/unordered/detail/foa.hpp
@@ -21,6 +21,7 @@
 #include <boost/core/pointer_traits.hpp>
 #include <boost/cstdint.hpp>
 #include <boost/predef.h>
+#include <boost/type_traits/has_trivial_copy.hpp>
 #include <boost/type_traits/is_nothrow_swappable.hpp>
 #include <boost/unordered/detail/xmx.hpp>
 #include <boost/unordered/hash_traits.hpp>
@@ -1528,7 +1529,15 @@ private:
     copy_elements_array_from(
       x,
       std::integral_constant<
-        bool,std::is_trivially_copy_constructible<value_type>::value>{});
+        bool,
+#if BOOST_WORKAROUND(BOOST_LIBSTDCXX_VERSION,<50000)
+        /* std::is_trivially_copy_constructible not provided */
+        boost::has_trivial_copy<value_type>::value
+#else
+        std::is_trivially_copy_constructible<value_type>::value
+#endif
+      >{}
+    );
   }
 
   void copy_elements_array_from(const table& x,std::true_type /* -> memcpy */)


### PR DESCRIPTION
When copy constructing or copy assigning an unordered flat container, if the source and target bucket arrays have the same size, then:
* The metadata array is copied via `memcpy`.
* If `value_type` is trivially copy assignable, a single `memcpy` call is used to copy all the elements;
* else, elements are copied one by one but directly into place, i.e. bypassing the standard insertion algorithm.

This should speed up copy/copy assignment by an order of magnitude under the right conditions (haven't measured), and will make us look good in the related test on Martin's benchmarks.