### PR TITLE
Update changelog to reflect planned C++03 deprecation

### DIFF
--- a/doc/unordered/changes.adoc
+++ b/doc/unordered/changes.adoc
@@ -8,6 +8,8 @@
 
 == Release 1.82.0 - Major update
 
+* {cpp}03 support is planned for deprecation. Boost 1.84.0 will no longer support
+  {cpp}03 mode and {cpp}11 will become the new minimum for using the library.
 * Added node-based, open-addressing containers
   `boost::unordered_node_map` and `boost::unordered_node_set`.
 * Extended heterogeneous lookup to more member functions as specified in

--- a/doc/unordered/compliance.adoc
+++ b/doc/unordered/compliance.adoc
@@ -143,3 +143,5 @@ The main differences with C++ unordered associative containers are:
   ** `value_type` must be move-constructible.
   ** Pointer stability is not kept under rehashing.
   ** There is no API for node extraction/insertion.
+
+//-


### PR DESCRIPTION
As voted on, 1.84.0 will no longer support C++03.