### PR TITLE
Feature/foa fast iteration

### DIFF
--- a/doc/unordered/changes.adoc
+++ b/doc/unordered/changes.adoc
@@ -6,6 +6,10 @@
 :github-pr-url: https://github.com/boostorg/unordered/pull
 :cpp: C++
 
+== Release 1.83.0
+
+* Sped up iteration of open-addressing containers.
+
 == Release 1.82.0 - Major update
 
 * {cpp}03 support is planned for deprecation. Boost 1.84.0 will no longer support

--- a/include/boost/unordered/detail/foa.hpp
+++ b/include/boost/unordered/detail/foa.hpp
@@ -161,6 +161,7 @@ static const std::size_t default_bucket_count = 0;
 struct group15
 {
   static constexpr int N=15;
+  static constexpr bool regular_layout=true;
 
   struct dummy_group_type
   {
@@ -184,6 +185,11 @@ struct group15
   {
     BOOST_ASSERT(pos<N);
     return at(pos)==sentinel_;
+  }
+
+  static inline bool is_sentinel(unsigned char* pc)noexcept
+  {
+    return *pc==sentinel_;
   }
 
   inline void reset(std::size_t pos)
@@ -230,6 +236,11 @@ struct group15
   {
     return _mm_movemask_epi8(
       _mm_cmpeq_epi8(m,_mm_setzero_si128()))&0x7FFF;
+  }
+
+  static inline bool is_occupied(unsigned char* pc)noexcept
+  {
+    return *pc!=available_;
   }
 
   inline int match_occupied()const
@@ -320,6 +331,7 @@ private:
 struct group15
 {
   static constexpr int N=15;
+  static constexpr bool regular_layout=true;
 
   struct dummy_group_type
   {
@@ -343,6 +355,11 @@ struct group15
   {
     BOOST_ASSERT(pos<N);
     return pos==N-1&&at(N-1)==sentinel_;
+  }
+
+  static inline bool is_sentinel(unsigned char* pc)noexcept
+  {
+    return *pc==sentinel_;
   }
 
   inline void reset(std::size_t pos)
@@ -384,6 +401,11 @@ struct group15
   inline int match_available()const
   {
     return simde_mm_movemask_epi8(vceqq_s8(m,vdupq_n_s8(0)))&0x7FFF;
+  }
+
+  static inline bool is_occupied(unsigned char* pc)noexcept
+  {
+    return *pc!=available_;
   }
 
   inline int match_occupied()const
@@ -478,6 +500,7 @@ private:
 struct group15
 {
   static constexpr int N=15;
+  static constexpr bool regular_layout=false;
 
   struct dummy_group_type
   {
@@ -809,8 +832,7 @@ class table;
  *   - pg = pc-n
  * 
  * (for explanatory purposes pg and pc are treated above as if they were memory
- * addresses rather than pointers).The main drawback of this two-pointer
- * representation is that iterator increment is relatively slow.
+ * addresses rather than pointers).
  * 
  * p = nullptr is conventionally used to mark end() iterators.
  */
@@ -823,6 +845,9 @@ class table_iterator
 {
   using type_policy=TypePolicy;
   using table_element_type=typename type_policy::element_type;
+  using group_type=Group;
+  static constexpr auto N=group_type::N;
+  static constexpr auto regular_layout=group_type::regular_layout;
 
 public:
   using difference_type=std::ptrdiff_t;
@@ -861,32 +886,64 @@ private:
   template<typename,typename,typename,typename> friend class table;
 
   table_iterator(Group* pg,std::size_t n,const table_element_type* p_):
-    pc{reinterpret_cast<unsigned char*>(const_cast<Group*>(pg))+n},
+    pc{reinterpret_cast<unsigned char*>(const_cast<group_type*>(pg))+n},
     p{const_cast<table_element_type*>(p_)}
     {}
 
-  inline std::size_t rebase() noexcept
-  {
-    std::size_t off=reinterpret_cast<uintptr_t>(pc)%sizeof(Group);
-    pc-=off;
-    return off;
-  }
-
   inline void increment()noexcept
   {
-    std::size_t n0=rebase();
+    increment(std::integral_constant<bool,regular_layout>{});
+  }
 
-    int mask=(reinterpret_cast<Group*>(pc)->match_occupied()>>(n0+1))<<(n0+1);
+  inline void increment(std::true_type /* regular layout */)noexcept
+  {
+    for(;;){
+      ++p;
+      if(reinterpret_cast<uintptr_t>(pc)%sizeof(group_type)==N-1){
+        pc+=sizeof(group_type)-(N-1);
+        break;
+      }
+      ++pc;
+      if(!group_type::is_occupied(pc))continue;
+      if(BOOST_UNLIKELY(group_type::is_sentinel(pc)))p=nullptr;
+      return;
+    }
+
+    for(;;){
+      int mask=reinterpret_cast<group_type*>(pc)->match_occupied();
+      if(mask!=0){
+        auto n=unchecked_countr_zero(mask);
+        if(BOOST_UNLIKELY(reinterpret_cast<group_type*>(pc)->is_sentinel(n))){
+          p=nullptr;
+        }
+        else{
+          pc+=n;
+          p+=n;
+        }
+        return;
+      }
+      pc+=sizeof(group_type);
+      p+=N;
+    }
+  }
+
+  inline void increment(std::false_type /* interleaved */)noexcept
+  {
+    std::size_t n0=reinterpret_cast<uintptr_t>(pc)%sizeof(group_type);
+    pc-=n0;
+
+    int mask=(
+      reinterpret_cast<group_type*>(pc)->match_occupied()>>(n0+1))<<(n0+1);
     if(!mask){
       do{
-        pc+=sizeof(Group);
-        p+=Group::N;
+        pc+=sizeof(group_type);
+        p+=N;
       }
-      while((mask=reinterpret_cast<Group*>(pc)->match_occupied())==0);
+      while((mask=reinterpret_cast<group_type*>(pc)->match_occupied())==0);
     }
 
     auto n=unchecked_countr_zero(mask);
-    if(BOOST_UNLIKELY(reinterpret_cast<Group*>(pc)->is_sentinel(n))){
+    if(BOOST_UNLIKELY(reinterpret_cast<group_type*>(pc)->is_sentinel(n))){
       p=nullptr;
     }
     else{

--- a/include/boost/unordered/detail/foa.hpp
+++ b/include/boost/unordered/detail/foa.hpp
@@ -39,12 +39,24 @@
 #include <type_traits>
 #include <utility>
 
-#if defined(__SSE2__)||\
+#if !defined(BOOST_UNORDERED_DISABLE_SSE2)
+#if defined(BOOST_UNORDERED_ENABLE_SSE2)|| \
+    defined(__SSE2__)|| \
     defined(_M_X64)||(defined(_M_IX86_FP)&&_M_IX86_FP>=2)
 #define BOOST_UNORDERED_SSE2
-#include <emmintrin.h>
-#elif defined(__ARM_NEON)&&!defined(__ARM_BIG_ENDIAN)
+#endif
+#endif
+
+#if !defined(BOOST_UNORDERED_DISABLE_NEON)
+#if defined(BOOST_UNORDERED_ENABLE_NEON)||\
+    (defined(__ARM_NEON)&&!defined(__ARM_BIG_ENDIAN))
 #define BOOST_UNORDERED_LITTLE_ENDIAN_NEON
+#endif
+#endif
+
+#if defined(BOOST_UNORDERED_SSE2)
+#include <emmintrin.h>
+#elif defined(BOOST_UNORDERED_LITTLE_ENDIAN_NEON)
 #include <arm_neon.h>
 #endif
 
@@ -2198,13 +2210,7 @@ private:
 } /* namespace unordered */
 } /* namespace boost */
 
+#undef BOOST_UNORDERED_STATIC_ASSERT_HASH_PRED
 #undef BOOST_UNORDERED_ASSUME
 #undef BOOST_UNORDERED_HAS_BUILTIN
-#undef BOOST_UNORDERED_STATIC_ASSERT_HASH_PRED
-#ifdef BOOST_UNORDERED_LITTLE_ENDIAN_NEON
-#undef BOOST_UNORDERED_LITTLE_ENDIAN_NEON
-#endif
-#ifdef BOOST_UNORDERED_SSE2
-#undef BOOST_UNORDERED_SSE2
-#endif
 #endif

--- a/include/boost/unordered/detail/foa.hpp
+++ b/include/boost/unordered/detail/foa.hpp
@@ -892,6 +892,7 @@ private:
 
   inline void increment()noexcept
   {
+    BOOST_UNORDERED_ASSUME(p!=nullptr);
     increment(std::integral_constant<bool,regular_layout>{});
   }
 

--- a/include/boost/unordered/detail/foa.hpp
+++ b/include/boost/unordered/detail/foa.hpp
@@ -892,7 +892,7 @@ private:
 
   inline void increment()noexcept
   {
-    BOOST_UNORDERED_ASSUME(p!=nullptr);
+    BOOST_ASSERT(p!=nullptr);
     increment(std::integral_constant<bool,regular_layout>{});
   }
 

--- a/include/boost/unordered/detail/foa.hpp
+++ b/include/boost/unordered/detail/foa.hpp
@@ -1457,7 +1457,7 @@ public:
   iterator begin()noexcept
   {
     iterator it{arrays.groups,0,arrays.elements};
-    if(!(arrays.groups[0].match_occupied()&0x1))++it;
+    if(arrays.elements&&!(arrays.groups[0].match_occupied()&0x1))++it;
     return it;
   }
 


### PR DESCRIPTION
Changed iterator increment code for "regular layout" group implementations (basically, those for SSE2 and Neon). Iteration speed improves dramatically, look for "Running erasure" in:

https://github.com/boostorg/boost_unordered_benchmarks/commit/46129697b05fab67c42cfa2b918a6e40af26d6e6