### PR TITLE
Remove extraneous semicolons

### DIFF
--- a/include/boost/unordered/concurrent_flat_map.hpp
+++ b/include/boost/unordered/concurrent_flat_map.hpp
@@ -662,7 +662,7 @@ namespace boost {
       float max_load_factor() const noexcept
       {
         return table_.max_load_factor();
-      };
+      }
       void max_load_factor(float) {}
       size_type max_load() const noexcept { return table_.max_load(); }
 

--- a/include/boost/unordered/detail/foa/core.hpp
+++ b/include/boost/unordered/detail/foa/core.hpp
@@ -285,7 +285,7 @@ struct group15
     std::size_t pos=reinterpret_cast<uintptr_t>(pc)%sizeof(group15);
     group15    *pg=reinterpret_cast<group15*>(pc-pos);
     return !pg->is_not_overflowed(*pc);
-  };
+  }
 
   inline int match_available()const
   {

--- a/include/boost/unordered/detail/implementation.hpp
+++ b/include/boost/unordered/detail/implementation.hpp
@@ -1624,7 +1624,7 @@ namespace boost {
           typedef std::ptrdiff_t difference_type;
           typedef std::forward_iterator_tag iterator_category;
 
-          iterator() : p(), itb(){};
+          iterator() : p(), itb(){}
 
           reference operator*() const BOOST_NOEXCEPT { return dereference(); }
           pointer operator->() const BOOST_NOEXCEPT
@@ -1715,7 +1715,7 @@ namespace boost {
           typedef std::ptrdiff_t difference_type;
           typedef std::forward_iterator_tag iterator_category;
 
-          c_iterator() : p(), itb(){};
+          c_iterator() : p(), itb(){}
           c_iterator(iterator<Node, Bucket> it) : p(it.p), itb(it.itb) {}
 
           reference operator*() const BOOST_NOEXCEPT { return dereference(); }
@@ -3393,7 +3393,7 @@ namespace boost {
             }
           }
           buckets_.unlink_empty_buckets();
-          BOOST_RETHROW;
+          BOOST_RETHROW
         }
         BOOST_CATCH_END
 

--- a/test/exception/insert_exception_tests.cpp
+++ b/test/exception/insert_exception_tests.cpp
@@ -84,7 +84,7 @@ void insert_exception_test(T*, Inserter insert, test::random_generator gen)
     test::random_values<T> v(10, gen);
     T x;
 
-    EXCEPTION_LOOP(insert_exception_test_impl(x, generate(insert, x), v));
+    EXCEPTION_LOOP(insert_exception_test_impl(x, generate(insert, x), v))
   }
 }
 
@@ -100,7 +100,7 @@ void insert_rehash_exception_test(
     rehash_prep(x);
 
     test::random_values<T> v2(5, gen);
-    EXCEPTION_LOOP(insert_exception_test_impl(x, generate(insert, x), v2));
+    EXCEPTION_LOOP(insert_exception_test_impl(x, generate(insert, x), v2))
   }
 }
 
@@ -458,7 +458,7 @@ void insert_range_exception_test(T*, test::random_generator gen)
     test::random_values<T> v(10, gen);
     T x;
 
-    EXCEPTION_LOOP(insert_range_exception_test_impl(x, v));
+    EXCEPTION_LOOP(insert_range_exception_test_impl(x, v))
   }
 }
 
@@ -470,7 +470,7 @@ void insert_range_rehash_exception_test(T*, test::random_generator gen)
     rehash_prep(x);
 
     test::random_values<T> v2(5, gen);
-    EXCEPTION_LOOP(insert_range_exception_test_impl(x, v2));
+    EXCEPTION_LOOP(insert_range_exception_test_impl(x, v2))
   }
 }
 

--- a/test/helpers/invariants.hpp
+++ b/test/helpers/invariants.hpp
@@ -89,7 +89,7 @@ namespace test {
         }
       }
 #endif
-    };
+    }
 
     // Check that size matches up.
 

--- a/test/objects/exception.hpp
+++ b/test/objects/exception.hpp
@@ -53,7 +53,7 @@ namespace test {
       {
         UNORDERED_SCOPE(object::object())
         {
-          UNORDERED_EPOINT("Mock object default constructor.");
+          UNORDERED_EPOINT("Mock object default constructor.")
         }
       }
 
@@ -61,7 +61,7 @@ namespace test {
       {
         UNORDERED_SCOPE(object::object(int))
         {
-          UNORDERED_EPOINT("Mock object constructor by value.");
+          UNORDERED_EPOINT("Mock object constructor by value.")
         }
       }
 
@@ -70,7 +70,7 @@ namespace test {
       {
         UNORDERED_SCOPE(object::object(object))
         {
-          UNORDERED_EPOINT("Mock object copy constructor.");
+          UNORDERED_EPOINT("Mock object copy constructor.")
         }
       }
 
@@ -85,7 +85,7 @@ namespace test {
         UNORDERED_SCOPE(object::operator=(object))
         {
           tag1_ = x.tag1_;
-          UNORDERED_EPOINT("Mock object assign operator 1.");
+          UNORDERED_EPOINT("Mock object assign operator 1.")
           tag2_ = x.tag2_;
           // UNORDERED_EPOINT("Mock object assign operator 2.");
         }
@@ -96,7 +96,7 @@ namespace test {
       {
         UNORDERED_SCOPE(operator==(object, object))
         {
-          UNORDERED_EPOINT("Mock object equality operator.");
+          UNORDERED_EPOINT("Mock object equality operator.")
         }
 
         return x1.tag1_ == x2.tag1_ && x1.tag2_ == x2.tag2_;
@@ -106,7 +106,7 @@ namespace test {
       {
         UNORDERED_SCOPE(operator!=(object, object))
         {
-          UNORDERED_EPOINT("Mock object inequality operator.");
+          UNORDERED_EPOINT("Mock object inequality operator.")
         }
 
         return !(x1.tag1_ == x2.tag1_ && x1.tag2_ == x2.tag2_);
@@ -150,7 +150,7 @@ namespace test {
       {
         UNORDERED_SCOPE(hash::object())
         {
-          UNORDERED_EPOINT("Mock hash default constructor.");
+          UNORDERED_EPOINT("Mock hash default constructor.")
         }
       }
 
@@ -158,7 +158,7 @@ namespace test {
       {
         UNORDERED_SCOPE(hash::hash(hash))
         {
-          UNORDERED_EPOINT("Mock hash copy constructor.");
+          UNORDERED_EPOINT("Mock hash copy constructor.")
         }
       }
 
@@ -166,9 +166,9 @@ namespace test {
       {
         UNORDERED_SCOPE(hash::operator=(hash))
         {
-          UNORDERED_EPOINT("Mock hash assign operator 1.");
+          UNORDERED_EPOINT("Mock hash assign operator 1.")
           tag_ = x.tag_;
-          UNORDERED_EPOINT("Mock hash assign operator 2.");
+          UNORDERED_EPOINT("Mock hash assign operator 2.")
         }
         return *this;
       }
@@ -177,7 +177,7 @@ namespace test {
       {
         UNORDERED_SCOPE(hash::operator()(object))
         {
-          UNORDERED_EPOINT("Mock hash function.");
+          UNORDERED_EPOINT("Mock hash function.")
         }
 
         return hash_impl(x);
@@ -187,7 +187,7 @@ namespace test {
       {
         UNORDERED_SCOPE(hash::operator()(std::pair<object, object>))
         {
-          UNORDERED_EPOINT("Mock hash pair function.");
+          UNORDERED_EPOINT("Mock hash pair function.")
         }
 
         return hash_impl(x.first) * 193ul + hash_impl(x.second) * 97ul + 29ul;
@@ -214,7 +214,7 @@ namespace test {
       {
         UNORDERED_SCOPE(operator==(hash, hash))
         {
-          UNORDERED_EPOINT("Mock hash equality function.");
+          UNORDERED_EPOINT("Mock hash equality function.")
         }
         return x1.tag_ == x2.tag_;
       }
@@ -223,7 +223,7 @@ namespace test {
       {
         UNORDERED_SCOPE(hash::operator!=(hash, hash))
         {
-          UNORDERED_EPOINT("Mock hash inequality function.");
+          UNORDERED_EPOINT("Mock hash inequality function.")
         }
         return x1.tag_ != x2.tag_;
       }
@@ -300,7 +300,7 @@ namespace test {
       {
         UNORDERED_SCOPE(equal_to::equal_to())
         {
-          UNORDERED_EPOINT("Mock equal_to default constructor.");
+          UNORDERED_EPOINT("Mock equal_to default constructor.")
         }
       }
 
@@ -308,7 +308,7 @@ namespace test {
       {
         UNORDERED_SCOPE(equal_to::equal_to(equal_to))
         {
-          UNORDERED_EPOINT("Mock equal_to copy constructor.");
+          UNORDERED_EPOINT("Mock equal_to copy constructor.")
         }
       }
 
@@ -316,9 +316,9 @@ namespace test {
       {
         UNORDERED_SCOPE(equal_to::operator=(equal_to))
         {
-          UNORDERED_EPOINT("Mock equal_to assign operator 1.");
+          UNORDERED_EPOINT("Mock equal_to assign operator 1.")
           tag_ = x.tag_;
-          UNORDERED_EPOINT("Mock equal_to assign operator 2.");
+          UNORDERED_EPOINT("Mock equal_to assign operator 2.")
         }
         return *this;
       }
@@ -327,7 +327,7 @@ namespace test {
       {
         UNORDERED_SCOPE(equal_to::operator()(object, object))
         {
-          UNORDERED_EPOINT("Mock equal_to function.");
+          UNORDERED_EPOINT("Mock equal_to function.")
         }
 
         return equal_impl(x1, x2);
@@ -339,7 +339,7 @@ namespace test {
         UNORDERED_SCOPE(equal_to::operator()(
           std::pair<object, object>, std::pair<object, object>))
         {
-          UNORDERED_EPOINT("Mock equal_to function.");
+          UNORDERED_EPOINT("Mock equal_to function.")
         }
 
         return equal_impl(x1.first, x2.first) &&
@@ -362,7 +362,7 @@ namespace test {
       {
         UNORDERED_SCOPE(operator==(equal_to, equal_to))
         {
-          UNORDERED_EPOINT("Mock equal_to equality function.");
+          UNORDERED_EPOINT("Mock equal_to equality function.")
         }
         return x1.tag_ == x2.tag_;
       }
@@ -371,7 +371,7 @@ namespace test {
       {
         UNORDERED_SCOPE(operator!=(equal_to, equal_to))
         {
-          UNORDERED_EPOINT("Mock equal_to inequality function.");
+          UNORDERED_EPOINT("Mock equal_to inequality function.")
         }
         return x1.tag_ != x2.tag_;
       }
@@ -412,7 +412,7 @@ namespace test {
       {
         UNORDERED_SCOPE(allocator::allocator())
         {
-          UNORDERED_EPOINT("Mock allocator default constructor.");
+          UNORDERED_EPOINT("Mock allocator default constructor.")
         }
         test::detail::tracker.allocator_ref();
       }
@@ -460,7 +460,7 @@ namespace test {
         T* ptr = 0;
         UNORDERED_SCOPE(allocator::allocate(size_type))
         {
-          UNORDERED_EPOINT("Mock allocator allocate function.");
+          UNORDERED_EPOINT("Mock allocator allocate function.")
 
           using namespace std;
           ptr = (T*)malloc(n * sizeof(T));
@@ -478,7 +478,7 @@ namespace test {
         T* ptr = 0;
         UNORDERED_SCOPE(allocator::allocate(size_type, const_pointer))
         {
-          UNORDERED_EPOINT("Mock allocator allocate function.");
+          UNORDERED_EPOINT("Mock allocator allocate function.")
 
           using namespace std;
           ptr = (T*)malloc(n * sizeof(T));
@@ -507,7 +507,7 @@ namespace test {
       {
         UNORDERED_SCOPE(allocator::construct(U*, Arg))
         {
-          UNORDERED_EPOINT("Mock allocator construct function.");
+          UNORDERED_EPOINT("Mock allocator construct function.")
           new (p) U(t);
         }
         test::detail::tracker.track_construct((void*)p, sizeof(U), tag_);
@@ -517,7 +517,7 @@ namespace test {
       {
         UNORDERED_SCOPE(allocator::construct(U*, BOOST_FWD_REF(Args)...))
         {
-          UNORDERED_EPOINT("Mock allocator construct function.");
+          UNORDERED_EPOINT("Mock allocator construct function.")
           new (p) U(boost::forward<Args>(args)...);
         }
         test::detail::tracker.track_construct((void*)p, sizeof(U), tag_);
@@ -535,7 +535,7 @@ namespace test {
       {
         UNORDERED_SCOPE(allocator::construct(pointer, T))
         {
-          UNORDERED_EPOINT("Mock allocator max_size function.");
+          UNORDERED_EPOINT("Mock allocator max_size function.")
         }
         return (std::numeric_limits<std::size_t>::max)();
       }
@@ -592,7 +592,7 @@ namespace test {
       {
         UNORDERED_SCOPE(allocator2::allocator2())
         {
-          UNORDERED_EPOINT("Mock allocator2 default constructor.");
+          UNORDERED_EPOINT("Mock allocator2 default constructor.")
         }
         test::detail::tracker.allocator_ref();
       }
@@ -641,7 +641,7 @@ namespace test {
         T* ptr = 0;
         UNORDERED_SCOPE(allocator2::allocate(size_type))
         {
-          UNORDERED_EPOINT("Mock allocator2 allocate function.");
+          UNORDERED_EPOINT("Mock allocator2 allocate function.")
 
           using namespace std;
           ptr = (T*)malloc(n * sizeof(T));
@@ -659,7 +659,7 @@ namespace test {
         T* ptr = 0;
         UNORDERED_SCOPE(allocator2::allocate(size_type, const_pointer))
         {
-          UNORDERED_EPOINT("Mock allocator2 allocate function.");
+          UNORDERED_EPOINT("Mock allocator2 allocate function.")
 
           using namespace std;
           ptr = (T*)malloc(n * sizeof(T));
@@ -688,7 +688,7 @@ namespace test {
       {
         UNORDERED_SCOPE(allocator2::construct(U*, V))
         {
-          UNORDERED_EPOINT("Mock allocator2 construct function.");
+          UNORDERED_EPOINT("Mock allocator2 construct function.")
           new (p) U(v);
         }
         test::detail::tracker.track_construct((void*)p, sizeof(U), tag_);
@@ -699,7 +699,7 @@ namespace test {
       {
         UNORDERED_SCOPE(allocator2::construct(U*, BOOST_FWD_REF(Args)...))
         {
-          UNORDERED_EPOINT("Mock allocator2 construct function.");
+          UNORDERED_EPOINT("Mock allocator2 construct function.")
           new (p) U(boost::forward<Args>(args)...);
         }
         test::detail::tracker.track_construct((void*)p, sizeof(U), tag_);
@@ -717,7 +717,7 @@ namespace test {
       {
         UNORDERED_SCOPE(allocator2::construct(pointer, T))
         {
-          UNORDERED_EPOINT("Mock allocator2 max_size function.");
+          UNORDERED_EPOINT("Mock allocator2 max_size function.")
         }
         return (std::numeric_limits<std::size_t>::max)();
       }

--- a/test/unordered/compile_tests.hpp
+++ b/test/unordered/compile_tests.hpp
@@ -700,7 +700,7 @@ void unordered_test(X& x, Key& k, Hash& hf, Pred& eq)
   const_iterator q1 = a.cbegin(), q2 = a.cend();
   test::check_return_type<iterator>::equals(a.erase(q1, q2));
 
-  TEST_NOEXCEPT_EXPR(a.clear());
+  TEST_NOEXCEPT_EXPR(a.clear())
   a.clear();
 
   X const b;

--- a/test/unordered/reserve_tests.cpp
+++ b/test/unordered/reserve_tests.cpp
@@ -39,8 +39,8 @@ template <typename T> struct A
     std::free(p);
   }
 
-  bool operator==(A const& a) const { return i == a.i; };
-  bool operator!=(A const& a) const { return i != a.i; };
+  bool operator==(A const& a) const { return i == a.i; }
+  bool operator!=(A const& a) const { return i != a.i; }
 };
 
 template <class T> int A<T>::count = 0;

--- a/test/unordered/transparent_tests.cpp
+++ b/test/unordered/transparent_tests.cpp
@@ -1689,14 +1689,14 @@ template <class UnorderedMap> void test_map_transparent_at(UnorderedMap*)
   map.at(0) = 7331;
   BOOST_TEST_EQ(key::count_, key_count);
 
-  BOOST_TEST_THROWS(map.at(4), std::out_of_range);
+  BOOST_TEST_THROWS(map.at(4), std::out_of_range)
   BOOST_TEST_EQ(key::count_, key_count);
 
   UnorderedMap const& m = map;
   BOOST_TEST_EQ(m.at(0), 7331);
   BOOST_TEST_EQ(key::count_, key_count);
 
-  BOOST_TEST_THROWS(m.at(4), std::out_of_range);
+  BOOST_TEST_THROWS(m.at(4), std::out_of_range)
   BOOST_TEST_EQ(key::count_, key_count);
 }
 
@@ -1719,7 +1719,7 @@ template <class UnorderedMap> void test_map_non_transparent_at(UnorderedMap*)
   BOOST_TEST_EQ(key::count_, key_count + 1);
 
   key_count = key::count_;
-  BOOST_TEST_THROWS(map.at(4), std::out_of_range);
+  BOOST_TEST_THROWS(map.at(4), std::out_of_range)
   BOOST_TEST_EQ(key::count_, key_count + 1);
 
   key_count = key::count_;
@@ -1728,7 +1728,7 @@ template <class UnorderedMap> void test_map_non_transparent_at(UnorderedMap*)
   BOOST_TEST_EQ(key::count_, key_count + 1);
 
   key_count = key::count_;
-  BOOST_TEST_THROWS(m.at(4), std::out_of_range);
+  BOOST_TEST_THROWS(m.at(4), std::out_of_range)
   BOOST_TEST_EQ(key::count_, key_count + 1);
 }
 


### PR DESCRIPTION
This should fix https://github.com/boostorg/unordered/issues/190

Note: I didn't add `-Wextra-semi -Wextra-semi-stmt` to the testing Jamfile because Boost.Move has a single extraneous `;` as well and because we use `-Werror`, this breaks _our_ build until Move is fixed.

Because we're going to drop Move as a dependency in the next release, we can add `-Wextra-semi -Wextra-semi-stmt` to the test Jamfile then.

This PR was accomplished by manually hand-editing Boost.Move and then running the test suite locally with:
```
<toolset>clang-14:<cxxflags>"-Wunused-template -Wextra-semi -Wextra-semi-stmt"
```