### PR TITLE
Feature/visit until

### DIFF
--- a/doc/unordered/changes.adoc
+++ b/doc/unordered/changes.adoc
@@ -6,6 +6,11 @@
 :github-pr-url: https://github.com/boostorg/unordered/pull
 :cpp: C++
 
+== Release 1.84.0
+
+* Added `[c]visit_until` and `[c]visit_while` operations to `boost::concurrent_map`,
+with serial and parallel variants.
+
 == Release 1.83.0 - Major update
 
 * Added `boost::concurrent_flat_map`, a fast, thread-safe hashmap based on open addressing.

--- a/doc/unordered/changes.adoc
+++ b/doc/unordered/changes.adoc
@@ -8,7 +8,7 @@
 
 == Release 1.84.0
 
-* Added `[c]visit_until` and `[c]visit_while` operations to `boost::concurrent_map`,
+* Added `[c]visit_while` operations to `boost::concurrent_map`,
 with serial and parallel variants.
 
 == Release 1.83.0 - Major update

--- a/doc/unordered/concurrent.adoc
+++ b/doc/unordered/concurrent.adoc
@@ -158,7 +158,7 @@ Traversal can be interrupted midway:
 
 [source,c++]
 ----
-// finds the key to a given (unique value)
+// finds the key to a given (unique) value
 
 int  key = 0;
 int  value = ...;

--- a/doc/unordered/concurrent.adoc
+++ b/doc/unordered/concurrent.adoc
@@ -154,7 +154,34 @@ m.visit_all(std::execution::par, [](auto& x) { // run in parallel
 });
 ----
 
-There is another whole-table visitation operation, `erase_if`:
+Traversal can be interrupted midway:
+
+[source,c++]
+----
+// finds the key to a given (unique value)
+
+int  key = 0;
+int  value = ...;
+bool found = m.visit_until([&](const auto& x) {
+  if(x.second == value) {
+    key = x.first;
+    return true;  // finish
+  }
+  else {
+    return false; // keep on visiting
+  }
+});
+
+if(found) { ... }
+
+// check if all values are != 0
+
+bool all_ok = m.visit_while([&](const auto& x) {
+  return x.second != 0;
+});
+----
+
+There is one last whole-table visitation operation, `erase_if`:
 
 [source,c++]
 ----
@@ -163,8 +190,8 @@ m.erase_if([](auto& x) {
 });
 ----
 
-`erase_if` can also be parallelized. Note that, in order to increase efficiency,
-these operations do not block the table during execution: this implies that elements
+`visit_until`, `visit_while` and `erase_if` can also be parallelized. Note that, in order to increase efficiency,
+whole-table visitation operations do not block the table during execution: this implies that elements
 may be inserted, modified or erased by other threads during visitation. It is
 advisable not to assume too much about the exact global state of a `boost::concurrent_flat_map`
 at any point in your program.

--- a/doc/unordered/concurrent.adoc
+++ b/doc/unordered/concurrent.adoc
@@ -162,23 +162,17 @@ Traversal can be interrupted midway:
 
 int  key = 0;
 int  value = ...;
-bool found = m.visit_until([&](const auto& x) {
+bool found = !m.visit_while([&](const auto& x) {
   if(x.second == value) {
     key = x.first;
-    return true;  // finish
+    return false; // finish
   }
   else {
-    return false; // keep on visiting
+    return true;  // keep on visiting
   }
 });
 
 if(found) { ... }
-
-// check if all values are != 0
-
-bool all_ok = m.visit_while([&](const auto& x) {
-  return x.second != 0;
-});
 ----
 
 There is one last whole-table visitation operation, `erase_if`:
@@ -190,7 +184,7 @@ m.erase_if([](auto& x) {
 });
 ----
 
-`visit_until`, `visit_while` and `erase_if` can also be parallelized. Note that, in order to increase efficiency,
+`visit_while` and `erase_if` can also be parallelized. Note that, in order to increase efficiency,
 whole-table visitation operations do not block the table during execution: this implies that elements
 may be inserted, modified or erased by other threads during visitation. It is
 advisable not to assume too much about the exact global state of a `boost::concurrent_flat_map`

--- a/doc/unordered/concurrent_flat_map.adoc
+++ b/doc/unordered/concurrent_flat_map.adoc
@@ -114,16 +114,6 @@ namespace boost {
     template<class ExecutionPolicy, class F>
       void xref:#concurrent_flat_map_parallel_cvisit_all[cvisit_all](ExecutionPolicy&& policy, F f) const;
 
-    template<class F> bool xref:#concurrent_flat_map_cvisit_until[visit_until](F f);
-    template<class F> bool xref:#concurrent_flat_map_cvisit_until[visit_until](F f) const;
-    template<class F> bool xref:#concurrent_flat_map_cvisit_until[cvisit_until](F f) const;
-    template<class ExecutionPolicy, class F>
-      bool xref:#concurrent_flat_map_parallel_cvisit_until[visit_until](ExecutionPolicy&& policy, F f);
-    template<class ExecutionPolicy, class F>
-      bool xref:#concurrent_flat_map_parallel_cvisit_until[visit_until](ExecutionPolicy&& policy, F f) const;
-    template<class ExecutionPolicy, class F>
-      bool xref:#concurrent_flat_map_parallel_cvisit_until[cvisit_until](ExecutionPolicy&& policy, F f) const;
-
     template<class F> bool xref:#concurrent_flat_map_cvisit_while[visit_while](F f);
     template<class F> bool xref:#concurrent_flat_map_cvisit_while[visit_while](F f) const;
     template<class F> bool xref:#concurrent_flat_map_cvisit_while[cvisit_while](F f) const;
@@ -737,50 +727,6 @@ Notes:;; Only available in compilers supporting C++17 parallel algorithms. +
 These overloads only participate in overload resolution if `std::is_execution_policy_v<std::remove_cvref_t<ExecutionPolicy>>` is `true`. +
 +
 Unsequenced execution policies are not allowed.
-
----
-
-==== [c]visit_until
-
-```c++
-template<class F> bool visit_until(F f);
-template<class F> bool visit_until(F f) const;
-template<class F> bool cvisit_until(F f) const;
-```
-
-Successively invokes `f` with references to each of the elements in the table until `f` returns `true`
-or all the elements are visited.
-Such references to the elements are const iff `*this` is const.
-
-[horizontal]
-Returns:;; `true` iff `f` ever returns `true`.
-
----
-
-==== Parallel [c]visit_until
-
-```c++
-template<class ExecutionPolicy, class F> bool visit_until(ExecutionPolicy&& policy, F f);
-template<class ExecutionPolicy, class F> bool visit_until(ExecutionPolicy&& policy, F f) const;
-template<class ExecutionPolicy, class F> bool cvisit_until(ExecutionPolicy&& policy, F f) const;
-```
-
-Invokes `f` with references to each of the elements in the table until `f` returns `true`
-or all the elements are visited.
-Such references to the elements are const iff `*this` is const.
-Execution is parallelized according to the semantics of the execution policy specified.
-
-[horizontal]
-Returns:;; `true` iff `f` ever returns `true`.
-Throws:;; Depending on the exception handling mechanism of the execution policy used, may call `std::terminate` if an exception is thrown within `f`.
-Notes:;; Only available in compilers supporting C++17 parallel algorithms. +
-+
-These overloads only participate in overload resolution if `std::is_execution_policy_v<std::remove_cvref_t<ExecutionPolicy>>` is `true`. +
-+
-Unsequenced execution policies are not allowed. +
-+
-Parallelization implies that execution does not necessary finish as soon as `f` returns `true`, and as a result
-`f` may be invoked with further elements for which the return value is also `true`.
 
 ---
 

--- a/doc/unordered/concurrent_flat_map.adoc
+++ b/doc/unordered/concurrent_flat_map.adoc
@@ -114,6 +114,26 @@ namespace boost {
     template<class ExecutionPolicy, class F>
       void xref:#concurrent_flat_map_parallel_cvisit_all[cvisit_all](ExecutionPolicy&& policy, F f) const;
 
+    template<class F> bool xref:#concurrent_flat_map_cvisit_until[visit_until](F f);
+    template<class F> bool xref:#concurrent_flat_map_cvisit_until[visit_until](F f) const;
+    template<class F> bool xref:#concurrent_flat_map_cvisit_until[cvisit_until](F f) const;
+    template<class ExecutionPolicy, class F>
+      bool xref:#concurrent_flat_map_parallel_cvisit_until[visit_until](ExecutionPolicy&& policy, F f);
+    template<class ExecutionPolicy, class F>
+      bool xref:#concurrent_flat_map_parallel_cvisit_until[visit_until](ExecutionPolicy&& policy, F f) const;
+    template<class ExecutionPolicy, class F>
+      bool xref:#concurrent_flat_map_parallel_cvisit_until[cvisit_until](ExecutionPolicy&& policy, F f) const;
+
+    template<class F> bool xref:#concurrent_flat_map_cvisit_while[visit_while](F f);
+    template<class F> bool xref:#concurrent_flat_map_cvisit_while[visit_while](F f) const;
+    template<class F> bool xref:#concurrent_flat_map_cvisit_while[cvisit_while](F f) const;
+    template<class ExecutionPolicy, class F>
+      bool xref:#concurrent_flat_map_parallel_cvisit_while[visit_while](ExecutionPolicy&& policy, F f);
+    template<class ExecutionPolicy, class F>
+      bool xref:#concurrent_flat_map_parallel_cvisit_while[visit_while](ExecutionPolicy&& policy, F f) const;
+    template<class ExecutionPolicy, class F>
+      bool xref:#concurrent_flat_map_parallel_cvisit_while[cvisit_while](ExecutionPolicy&& policy, F f) const;
+
     // capacity
     ++[[nodiscard]]++ bool xref:#concurrent_flat_map_empty[empty]() const noexcept;
     size_type xref:#concurrent_flat_map_size[size]() const noexcept;
@@ -717,6 +737,94 @@ Notes:;; Only available in compilers supporting C++17 parallel algorithms. +
 These overloads only participate in overload resolution if `std::is_execution_policy_v<std::remove_cvref_t<ExecutionPolicy>>` is `true`. +
 +
 Unsequenced execution policies are not allowed.
+
+---
+
+==== [c]visit_until
+
+```c++
+template<class F> bool visit_until(F f);
+template<class F> bool visit_until(F f) const;
+template<class F> bool cvisit_until(F f) const;
+```
+
+Successively invokes `f` with references to each of the elements in the table until `f` returns `true`
+or all the elements are visited.
+Such references to the elements are const iff `*this` is const.
+
+[horizontal]
+Returns:;; `true` iff `f` ever returns `true`.
+
+---
+
+==== Parallel [c]visit_until
+
+```c++
+template<class ExecutionPolicy, class F> bool visit_until(ExecutionPolicy&& policy, F f);
+template<class ExecutionPolicy, class F> bool visit_until(ExecutionPolicy&& policy, F f) const;
+template<class ExecutionPolicy, class F> bool cvisit_until(ExecutionPolicy&& policy, F f) const;
+```
+
+Invokes `f` with references to each of the elements in the table until `f` returns `true`
+or all the elements are visited.
+Such references to the elements are const iff `*this` is const.
+Execution is parallelized according to the semantics of the execution policy specified.
+
+[horizontal]
+Returns:;; `true` iff `f` ever returns `true`.
+Throws:;; Depending on the exception handling mechanism of the execution policy used, may call `std::terminate` if an exception is thrown within `f`.
+Notes:;; Only available in compilers supporting C++17 parallel algorithms. +
++
+These overloads only participate in overload resolution if `std::is_execution_policy_v<std::remove_cvref_t<ExecutionPolicy>>` is `true`. +
++
+Unsequenced execution policies are not allowed. +
++
+Parallelization implies that execution does not necessary finish as soon as `f` returns `true`, and as a result
+`f` may be invoked with further elements for which the return value is also `true`.
+
+---
+
+==== [c]visit_while
+
+```c++
+template<class F> bool visit_while(F f);
+template<class F> bool visit_while(F f) const;
+template<class F> bool cvisit_while(F f) const;
+```
+
+Successively invokes `f` with references to each of the elements in the table until `f` returns `false`
+or all the elements are visited.
+Such references to the elements are const iff `*this` is const.
+
+[horizontal]
+Returns:;; `false` iff `f` ever returns `false`.
+
+---
+
+==== Parallel [c]visit_while
+
+```c++
+template<class ExecutionPolicy, class F> bool visit_while(ExecutionPolicy&& policy, F f);
+template<class ExecutionPolicy, class F> bool visit_while(ExecutionPolicy&& policy, F f) const;
+template<class ExecutionPolicy, class F> bool cvisit_while(ExecutionPolicy&& policy, F f) const;
+```
+
+Invokes `f` with references to each of the elements in the table until `f` returns `false`
+or all the elements are visited.
+Such references to the elements are const iff `*this` is const.
+Execution is parallelized according to the semantics of the execution policy specified.
+
+[horizontal]
+Returns:;; `false` iff `f` ever returns `false`.
+Throws:;; Depending on the exception handling mechanism of the execution policy used, may call `std::terminate` if an exception is thrown within `f`.
+Notes:;; Only available in compilers supporting C++17 parallel algorithms. +
++
+These overloads only participate in overload resolution if `std::is_execution_policy_v<std::remove_cvref_t<ExecutionPolicy>>` is `true`. +
++
+Unsequenced execution policies are not allowed. +
++
+Parallelization implies that execution does not necessary finish as soon as `f` returns `false`, and as a result
+`f` may be invoked with further elements for which the return value is also `false`.
 
 ---
 

--- a/include/boost/unordered/concurrent_flat_map.hpp
+++ b/include/boost/unordered/concurrent_flat_map.hpp
@@ -355,56 +355,6 @@ namespace boost {
       }
 #endif
 
-      template <class F> bool visit_until(F f)
-      {
-        BOOST_UNORDERED_STATIC_ASSERT_INVOCABLE(F)
-        return table_.visit_until(f);
-      }
-
-      template <class F> bool visit_until(F f) const
-      {
-        BOOST_UNORDERED_STATIC_ASSERT_CONST_INVOCABLE(F)
-        return table_.visit_until(f);
-      }
-
-      template <class F> bool cvisit_until(F f) const
-      {
-        BOOST_UNORDERED_STATIC_ASSERT_CONST_INVOCABLE(F)
-        return table_.cvisit_until(f);
-      }
-
-#if defined(BOOST_UNORDERED_PARALLEL_ALGORITHMS)
-      template <class ExecPolicy, class F>
-      typename std::enable_if<detail::is_execution_policy<ExecPolicy>::value,
-        bool>::type
-      visit_until(ExecPolicy&& p, F f)
-      {
-        BOOST_UNORDERED_STATIC_ASSERT_INVOCABLE(F)
-        BOOST_UNORDERED_STATIC_ASSERT_EXEC_POLICY(ExecPolicy)
-        return table_.visit_until(p, f);
-      }
-
-      template <class ExecPolicy, class F>
-      typename std::enable_if<detail::is_execution_policy<ExecPolicy>::value,
-        bool>::type
-      visit_until(ExecPolicy&& p, F f) const
-      {
-        BOOST_UNORDERED_STATIC_ASSERT_CONST_INVOCABLE(F)
-        BOOST_UNORDERED_STATIC_ASSERT_EXEC_POLICY(ExecPolicy)
-        return table_.visit_until(p, f);
-      }
-
-      template <class ExecPolicy, class F>
-      typename std::enable_if<detail::is_execution_policy<ExecPolicy>::value,
-        bool>::type
-      cvisit_until(ExecPolicy&& p, F f) const
-      {
-        BOOST_UNORDERED_STATIC_ASSERT_CONST_INVOCABLE(F)
-        BOOST_UNORDERED_STATIC_ASSERT_EXEC_POLICY(ExecPolicy)
-        return table_.cvisit_until(p, f);
-      }
-#endif
-
       template <class F> bool visit_while(F f)
       {
         BOOST_UNORDERED_STATIC_ASSERT_INVOCABLE(F)

--- a/include/boost/unordered/concurrent_flat_map.hpp
+++ b/include/boost/unordered/concurrent_flat_map.hpp
@@ -355,6 +355,106 @@ namespace boost {
       }
 #endif
 
+      template <class F> bool visit_until(F f)
+      {
+        BOOST_UNORDERED_STATIC_ASSERT_INVOCABLE(F)
+        return table_.visit_until(f);
+      }
+
+      template <class F> bool visit_until(F f) const
+      {
+        BOOST_UNORDERED_STATIC_ASSERT_CONST_INVOCABLE(F)
+        return table_.visit_until(f);
+      }
+
+      template <class F> bool cvisit_until(F f) const
+      {
+        BOOST_UNORDERED_STATIC_ASSERT_CONST_INVOCABLE(F)
+        return table_.cvisit_until(f);
+      }
+
+#if defined(BOOST_UNORDERED_PARALLEL_ALGORITHMS)
+      template <class ExecPolicy, class F>
+      typename std::enable_if<detail::is_execution_policy<ExecPolicy>::value,
+        bool>::type
+      visit_until(ExecPolicy&& p, F f)
+      {
+        BOOST_UNORDERED_STATIC_ASSERT_INVOCABLE(F)
+        BOOST_UNORDERED_STATIC_ASSERT_EXEC_POLICY(ExecPolicy)
+        return table_.visit_until(p, f);
+      }
+
+      template <class ExecPolicy, class F>
+      typename std::enable_if<detail::is_execution_policy<ExecPolicy>::value,
+        bool>::type
+      visit_until(ExecPolicy&& p, F f) const
+      {
+        BOOST_UNORDERED_STATIC_ASSERT_CONST_INVOCABLE(F)
+        BOOST_UNORDERED_STATIC_ASSERT_EXEC_POLICY(ExecPolicy)
+        return table_.visit_until(p, f);
+      }
+
+      template <class ExecPolicy, class F>
+      typename std::enable_if<detail::is_execution_policy<ExecPolicy>::value,
+        bool>::type
+      cvisit_until(ExecPolicy&& p, F f) const
+      {
+        BOOST_UNORDERED_STATIC_ASSERT_CONST_INVOCABLE(F)
+        BOOST_UNORDERED_STATIC_ASSERT_EXEC_POLICY(ExecPolicy)
+        return table_.cvisit_until(p, f);
+      }
+#endif
+
+      template <class F> bool visit_while(F f)
+      {
+        BOOST_UNORDERED_STATIC_ASSERT_INVOCABLE(F)
+        return table_.visit_while(f);
+      }
+
+      template <class F> bool visit_while(F f) const
+      {
+        BOOST_UNORDERED_STATIC_ASSERT_CONST_INVOCABLE(F)
+        return table_.visit_while(f);
+      }
+
+      template <class F> bool cvisit_while(F f) const
+      {
+        BOOST_UNORDERED_STATIC_ASSERT_CONST_INVOCABLE(F)
+        return table_.cvisit_while(f);
+      }
+
+#if defined(BOOST_UNORDERED_PARALLEL_ALGORITHMS)
+      template <class ExecPolicy, class F>
+      typename std::enable_if<detail::is_execution_policy<ExecPolicy>::value,
+        bool>::type
+      visit_while(ExecPolicy&& p, F f)
+      {
+        BOOST_UNORDERED_STATIC_ASSERT_INVOCABLE(F)
+        BOOST_UNORDERED_STATIC_ASSERT_EXEC_POLICY(ExecPolicy)
+        return table_.visit_while(p, f);
+      }
+
+      template <class ExecPolicy, class F>
+      typename std::enable_if<detail::is_execution_policy<ExecPolicy>::value,
+        bool>::type
+      visit_while(ExecPolicy&& p, F f) const
+      {
+        BOOST_UNORDERED_STATIC_ASSERT_CONST_INVOCABLE(F)
+        BOOST_UNORDERED_STATIC_ASSERT_EXEC_POLICY(ExecPolicy)
+        return table_.visit_while(p, f);
+      }
+
+      template <class ExecPolicy, class F>
+      typename std::enable_if<detail::is_execution_policy<ExecPolicy>::value,
+        bool>::type
+      cvisit_while(ExecPolicy&& p, F f) const
+      {
+        BOOST_UNORDERED_STATIC_ASSERT_CONST_INVOCABLE(F)
+        BOOST_UNORDERED_STATIC_ASSERT_EXEC_POLICY(ExecPolicy)
+        return table_.cvisit_while(p, f);
+      }
+#endif
+
       /// Modifiers
       ///
 

--- a/include/boost/unordered/detail/foa/concurrent_table.hpp
+++ b/include/boost/unordered/detail/foa/concurrent_table.hpp
@@ -539,46 +539,6 @@ public:
   }
 #endif
 
-  template<typename F> bool visit_until(F&& f)
-  {
-    return !visit_while([&](value_type& x){return !f(x);});
-  }
-
-  template<typename F> bool visit_until(F&& f)const
-  {
-    return !visit_while([&](const value_type& x){return !f(x);});
-  }
-
-  template<typename F> bool cvisit_until(F&& f)const
-  {
-    return visit_while(std::forward<F>(f));
-  }
-
-#if defined(BOOST_UNORDERED_PARALLEL_ALGORITHMS)
-  template<typename ExecutionPolicy,typename F>
-  bool visit_until(ExecutionPolicy&& policy,F&& f)
-  {
-    return !visit_while(
-      std::forward<ExecutionPolicy>(policy),
-      [&](value_type& x){return !f(x);});
-  }
-
-  template<typename ExecutionPolicy,typename F>
-  bool visit_until(ExecutionPolicy&& policy,F&& f)const
-  {
-    return !visit_while(
-      std::forward<ExecutionPolicy>(policy),
-      [&](const value_type& x){return !f(x);});
-  }
-
-  template<typename ExecutionPolicy,typename F>
-  bool cvisit_until(ExecutionPolicy&& policy,F&& f)const
-  {
-    return visit_until(
-      std::forward<ExecutionPolicy>(policy),std::forward<F>(f));
-  }
-#endif
-
   template<typename F> bool visit_while(F&& f)
   {
     return visit_while_impl(group_exclusive{},std::forward<F>(f));

--- a/include/boost/unordered/detail/foa/concurrent_table.hpp
+++ b/include/boost/unordered/detail/foa/concurrent_table.hpp
@@ -539,6 +539,86 @@ public:
   }
 #endif
 
+  template<typename F> bool visit_until(F&& f)
+  {
+    return !visit_while([&](value_type& x){return !f(x);});
+  }
+
+  template<typename F> bool visit_until(F&& f)const
+  {
+    return !visit_while([&](const value_type& x){return !f(x);});
+  }
+
+  template<typename F> bool cvisit_until(F&& f)const
+  {
+    return visit_while(std::forward<F>(f));
+  }
+
+#if defined(BOOST_UNORDERED_PARALLEL_ALGORITHMS)
+  template<typename ExecutionPolicy,typename F>
+  bool visit_until(ExecutionPolicy&& policy,F&& f)
+  {
+    return !visit_while(
+      std::forward<ExecutionPolicy>(policy),
+      [&](value_type& x){return !f(x);});
+  }
+
+  template<typename ExecutionPolicy,typename F>
+  bool visit_until(ExecutionPolicy&& policy,F&& f)const
+  {
+    return !visit_while(
+      std::forward<ExecutionPolicy>(policy),
+      [&](const value_type& x){return !f(x);});
+  }
+
+  template<typename ExecutionPolicy,typename F>
+  bool cvisit_until(ExecutionPolicy&& policy,F&& f)const
+  {
+    return visit_until(
+      std::forward<ExecutionPolicy>(policy),std::forward<F>(f));
+  }
+#endif
+
+  template<typename F> bool visit_while(F&& f)
+  {
+    return visit_while_impl(group_exclusive{},std::forward<F>(f));
+  }
+
+  template<typename F> bool visit_while(F&& f)const
+  {
+    return visit_while_impl(group_shared{},std::forward<F>(f));
+  }
+
+  template<typename F> bool cvisit_while(F&& f)const
+  {
+    return visit_while(std::forward<F>(f));
+  }
+
+#if defined(BOOST_UNORDERED_PARALLEL_ALGORITHMS)
+  template<typename ExecutionPolicy,typename F>
+  bool visit_while(ExecutionPolicy&& policy,F&& f)
+  {
+    return visit_while_impl(
+      group_exclusive{},
+      std::forward<ExecutionPolicy>(policy),std::forward<F>(f));
+  }
+
+  template<typename ExecutionPolicy,typename F>
+  bool visit_while(ExecutionPolicy&& policy,F&& f)const
+  {
+    return visit_while_impl(
+      group_shared{},
+      std::forward<ExecutionPolicy>(policy),std::forward<F>(f));
+  }
+
+  template<typename ExecutionPolicy,typename F>
+  bool cvisit_while(ExecutionPolicy&& policy,F&& f)const
+  {
+    return visit_while(
+      std::forward<ExecutionPolicy>(policy),std::forward<F>(f));
+  }
+#endif
+
   bool empty()const noexcept{return size()==0;}
   
   std::size_t size()const noexcept
@@ -970,6 +1050,29 @@ private:
   }
 #endif
 
+  template<typename GroupAccessMode,typename F>
+  bool visit_while_impl(GroupAccessMode access_mode,F&& f)const
+  {
+    auto lck=shared_access();
+    return for_all_elements_while(access_mode,[&](element_type* p){
+      return f(cast_for(access_mode,type_policy::value_from(*p)));
+    });
+  }
+
+#if defined(BOOST_UNORDERED_PARALLEL_ALGORITHMS)
+  template<typename GroupAccessMode,typename ExecutionPolicy,typename F>
+  bool visit_while_impl(
+    GroupAccessMode access_mode,ExecutionPolicy&& policy,F&& f)const
+  {
+    auto lck=shared_access();
+    return for_all_elements_while(
+      access_mode,std::forward<ExecutionPolicy>(policy),
+      [&](element_type* p){
+        return f(cast_for(access_mode,type_policy::value_from(*p)));
+      });
+  }
+#endif
+
   template<typename GroupAccessMode,typename Key,typename F>
   BOOST_FORCEINLINE std::size_t unprotected_visit(
     GroupAccessMode access_mode,
@@ -1254,18 +1357,37 @@ private:
   auto for_all_elements(GroupAccessMode access_mode,F f)const
     ->decltype(f(nullptr,0,nullptr),void())
   {
+    for_all_elements_while(
+      access_mode,[&](group_type* pg,unsigned int n,element_type* p)
+        {f(pg,n,p);return true;});
+  }
+
+  template<typename GroupAccessMode,typename F>
+  auto for_all_elements_while(GroupAccessMode access_mode,F f)const
+    ->decltype(f(nullptr),bool())
+  {
+    return for_all_elements_while(
+      access_mode,[&](group_type*,unsigned int,element_type* p){return f(p);});
+  }
+
+  template<typename GroupAccessMode,typename F>
+  auto for_all_elements_while(GroupAccessMode access_mode,F f)const
+    ->decltype(f(nullptr,0,nullptr),bool())
+  {
     auto p=this->arrays.elements;
-    if(!p)return;
-    for(auto pg=this->arrays.groups,last=pg+this->arrays.groups_size_mask+1;
-        pg!=last;++pg,p+=N){
-      auto lck=access(access_mode,(std::size_t)(pg-this->arrays.groups));
-      auto mask=this->match_really_occupied(pg,last);
-      while(mask){
-        auto n=unchecked_countr_zero(mask);
-        f(pg,n,p+n);
-        mask&=mask-1;
+    if(p){
+      for(auto pg=this->arrays.groups,last=pg+this->arrays.groups_size_mask+1;
+          pg!=last;++pg,p+=N){
+        auto lck=access(access_mode,(std::size_t)(pg-this->arrays.groups));
+        auto mask=this->match_really_occupied(pg,last);
+        while(mask){
+          auto n=unchecked_countr_zero(mask);
+          if(!f(pg,n,p+n))return false;
+          mask&=mask-1;
+        }
       }
     }
+    return true;
   }
 
 #if defined(BOOST_UNORDERED_PARALLEL_ALGORITHMS)
@@ -1289,15 +1411,38 @@ private:
          last=first+this->arrays.groups_size_mask+1;
     std::for_each(std::forward<ExecutionPolicy>(policy),first,last,
       [&,this](group_type& g){
-        std::size_t pos=static_cast<std::size_t>(&g-first);
-        auto        p=this->arrays.elements+pos*N;
-        auto        lck=access(access_mode,pos);
-        auto        mask=this->match_really_occupied(&g,last);
+        auto pos=static_cast<std::size_t>(&g-first);
+        auto p=this->arrays.elements+pos*N;
+        auto lck=access(access_mode,pos);
+        auto mask=this->match_really_occupied(&g,last);
         while(mask){
           auto n=unchecked_countr_zero(mask);
           f(&g,n,p+n);
           mask&=mask-1;
         }
+      }
+    );
+  }
+
+  template<typename GroupAccessMode,typename ExecutionPolicy,typename F>
+  bool for_all_elements_while(
+    GroupAccessMode access_mode,ExecutionPolicy&& policy,F f)const
+  {
+    if(!this->arrays.elements)return true;
+    auto first=this->arrays.groups,
+         last=first+this->arrays.groups_size_mask+1;
+    return std::all_of(std::forward<ExecutionPolicy>(policy),first,last,
+      [&,this](group_type& g){
+        auto pos=static_cast<std::size_t>(&g-first);
+        auto p=this->arrays.elements+pos*N;
+        auto lck=access(access_mode,pos);
+        auto mask=this->match_really_occupied(&g,last);
+        while(mask){
+          auto n=unchecked_countr_zero(mask);
+          if(!f(p+n))return false;
+          mask&=mask-1;
+        }
+        return true;
       }
     );
   }


### PR DESCRIPTION
Tests pending from @cmazakas, PR open for discussion. I think the API is quite uncontroversial, note however `[c]visit_(until|while)` returns a `bool`,  whereas `[c]visit_all` returns `size_type` (non-parallel versions) or `void` (parallel versions).