### PR TITLE
Fix for bugs in `foa::table_core` assignment when using POC(C|M)A, fancy, unequal allocators

### DIFF
--- a/include/boost/unordered/detail/foa/concurrent_table.hpp
+++ b/include/boost/unordered/detail/foa/concurrent_table.hpp
@@ -504,16 +504,13 @@ public:
           x.arrays.elements_});},
       size_ctrl_type{x.size_ctrl.ml,x.size_ctrl.size}}
   {
-    ah.release();
-    x.arrays=ah.get();
+    x.arrays=ah.release();
     x.size_ctrl.ml=x.initial_max_load();
     x.size_ctrl.size=0;
   }
 
   concurrent_table(compatible_nonconcurrent_table&& x):
-    concurrent_table(std::move(x), arrays_holder<
-      typename compatible_nonconcurrent_table::arrays_type,Allocator
-    >{compatible_nonconcurrent_table::arrays_type::new_(x.al(),0),x.al()})
+    concurrent_table(std::move(x),x.make_empty_arrays())
   {}
 
   ~concurrent_table()=default;

--- a/include/boost/unordered/detail/foa/core.hpp
+++ b/include/boost/unordered/detail/foa/core.hpp
@@ -1541,7 +1541,7 @@ public:
         size_ctrl.ml=std::size_t(x.size_ctrl.ml);
         size_ctrl.size=std::size_t(x.size_ctrl.size);
         x.arrays=ah.release();
-        x.size_ctrl.ml=initial_max_load();
+        x.size_ctrl.ml=x.initial_max_load();
         x.size_ctrl.size=0;
       }
       else{

--- a/include/boost/unordered/detail/foa/core.hpp
+++ b/include/boost/unordered/detail/foa/core.hpp
@@ -970,34 +970,26 @@ Ptr to_pointer(Ptr p)
 template<typename Arrays,typename Allocator>
 struct arrays_holder
 {
-  arrays_holder(Arrays const& arrays, Allocator const& al)
-    :arrays_{arrays},al_{al}
+  arrays_holder(const Arrays& arrays,const Allocator& al):
+    arrays_{arrays},al_{al}
   {}
   
-  arrays_holder(arrays_holder const&)=delete;
+  /* not defined but VS in pre-C++17 mode needs to see it for RVO */
+  arrays_holder(arrays_holder const&);
   arrays_holder& operator=(arrays_holder const&)=delete;
 
-  ~arrays_holder()
-  {
-    if (!released_){
-      arrays_.delete_(al_,arrays_);
-    }
-  }
+  ~arrays_holder(){if(!released_)arrays_.delete_(al_,arrays_);}
 
-  Arrays const& get()const
+  const Arrays& release()
   {
+    released_=true;
     return arrays_;
   }
 
-  void release()
-  {
-    released_=true;
-  }
-
 private:
-  Arrays arrays_;
+  Arrays    arrays_;
   Allocator al_;
-  bool released_=false;
+  bool      released_=false;
 };
 
 template<typename Value,typename Group,typename SizePolicy,typename Allocator>
@@ -1367,6 +1359,7 @@ public:
   using size_type=std::size_t;
   using difference_type=std::ptrdiff_t;
   using locator=table_locator<group_type,element_type>;
+  using arrays_holder_type=arrays_holder<arrays_type,Allocator>;
 
   table_core(
     std::size_t n=default_bucket_count,const Hash& h_=Hash(),
@@ -1394,15 +1387,12 @@ public:
     table_core{x,alloc_traits::select_on_container_copy_construction(x.al())}{}
 
   template<typename ArraysFn>
-  table_core(
-    table_core&& x,arrays_holder<arrays_type,Allocator>&& ah,
-    ArraysFn arrays_fn):
+  table_core(table_core&& x,arrays_holder_type&& ah,ArraysFn arrays_fn):
     table_core(
       std::move(x.h()),std::move(x.pred()),std::move(x.al()),
       arrays_fn,x.size_ctrl)
   {
-    ah.release();
-    x.arrays=ah.get();
+    x.arrays=ah.release();
     x.size_ctrl.ml=x.initial_max_load();
     x.size_ctrl.size=0;
   }
@@ -1414,9 +1404,7 @@ public:
       std::is_nothrow_move_constructible<Allocator>::value&&
       !uses_fancy_pointers):
     table_core{
-      std::move(x),arrays_holder<arrays_type,Allocator>{
-        x.new_arrays(0),x.al()},
-      [&x]{return x.arrays;}}
+      std::move(x),x.make_empty_arrays(),[&x]{return x.arrays;}}
   {}
 
   table_core(const table_core& x,const Allocator& al_):
@@ -1468,6 +1456,11 @@ public:
     }
   }
 
+  arrays_holder_type make_empty_arrays()const
+  {
+    return make_arrays(0);
+  }
+
   table_core& operator=(const table_core& x)
   {
     BOOST_UNORDERED_STATIC_ASSERT_HASH_PRED(Hash, Pred)
@@ -1482,9 +1475,6 @@ public:
       hasher    tmp_h=x.h();
       key_equal tmp_p=x.pred();
 
-      /* already noexcept, clear() before we swap the Hash, Pred just in case
-       * the clear() impl relies on them at some point in the future.
-       */
       clear();
 
       /* Because we've asserted at compile-time that Hash and Pred are nothrow
@@ -1496,7 +1486,12 @@ public:
       swap(pred(),tmp_p);
 
       if_constexpr<pocca>([&,this]{
-        if(al()!=x.al())reserve(0);
+        if(al()!=x.al()){
+          auto ah=x.make_arrays(std::size_t(std::ceil(float(x.size())/mlf)));
+          delete_arrays(arrays);
+          arrays=ah.release();
+          size_ctrl.ml=initial_max_load();
+        }
         copy_assign_if<pocca>(al(),x.al());
       });
       /* noshrink: favor memory reuse over tightness */
@@ -1535,16 +1530,24 @@ public:
       using std::swap;
 
       clear();
-      swap(h(),x.h());
-      swap(pred(),x.pred());
 
       if(pocma||al()==x.al()){
-        reserve(0);
+        auto ah=x.make_empty_arrays();
+        swap(h(),x.h());
+        swap(pred(),x.pred());
+        delete_arrays(arrays);
         move_assign_if<pocma>(al(),x.al());
-        swap(arrays,x.arrays);
-        swap(size_ctrl,x.size_ctrl);
+        arrays=x.arrays;
+        size_ctrl.ml=std::size_t(x.size_ctrl.ml);
+        size_ctrl.size=std::size_t(x.size_ctrl.size);
+        x.arrays=ah.release();
+        x.size_ctrl.ml=initial_max_load();
+        x.size_ctrl.size=0;
       }
       else{
+        swap(h(),x.h());
+        swap(pred(),x.pred());
+
         /* noshrink: favor memory reuse over tightness */
         noshrink_reserve(x.size());
         clear_on_exit c{x};
@@ -1940,12 +1943,12 @@ private:
   {
   }
 
-  arrays_type new_arrays(std::size_t n)
+  arrays_type new_arrays(std::size_t n)const
   {
     return arrays_type::new_(al(),n);
   }
 
-  arrays_type new_arrays_for_growth()
+  arrays_type new_arrays_for_growth()const
   {
     /* Due to the anti-drift mechanism (see recover_slot), the new arrays may
      * be of the same size as the old arrays; in the limit, erasing one
@@ -1964,6 +1967,11 @@ private:
   void delete_arrays(arrays_type& arrays_)noexcept
   {
     arrays_type::delete_(al(),arrays_);
+  }
+
+  arrays_holder_type make_arrays(std::size_t n)const
+  {
+    return {new_arrays(n),al()};
   }
 
   template<typename Key,typename... Args>

--- a/include/boost/unordered/detail/foa/table.hpp
+++ b/include/boost/unordered/detail/foa/table.hpp
@@ -555,19 +555,15 @@ private:
         x.arrays.elements_};},
       size_ctrl_type{x.size_ctrl.ml,x.size_ctrl.size}}
   {
-    ah.release();
-
     compatible_concurrent_table::arrays_type::delete_group_access(x.al(),x.arrays);
-    x.arrays=ah.get();
+    x.arrays=ah.release();
     x.size_ctrl.ml=x.initial_max_load();
     x.size_ctrl.size=0;
   }
 
   template<typename ExclusiveLockGuard>
   table(compatible_concurrent_table&& x,ExclusiveLockGuard):
-    table(std::move(x),arrays_holder<
-      typename compatible_concurrent_table::arrays_type,Allocator
-    >{compatible_concurrent_table::arrays_type::new_(x.al(),0),x.al()})
+    table(std::move(x),x.make_empty_arrays())
   {}
 
   struct erase_on_exit

--- a/test/cfoa/assign_tests.cpp
+++ b/test/cfoa/assign_tests.cpp
@@ -145,14 +145,14 @@ struct poca_allocator: fancy_allocator<T>
   pointer allocate(std::size_t n)
   {
     auto p = super::allocate(n + 1);
-    reinterpret_cast<char&>(p[0]) = static_cast<char>(x_);
+    reinterpret_cast<char&>(*p) = static_cast<char>(x_);
     return p + std::ptrdiff_t(1);
   }
 
   void deallocate(pointer p, std::size_t n)
   {
     p = p + std::ptrdiff_t(-1);
-    BOOST_TEST_EQ(reinterpret_cast<char&>(p[0]), static_cast<char>(x_));
+    BOOST_TEST_EQ(reinterpret_cast<char&>(*p), static_cast<char>(x_));
     super::deallocate(p, n + 1); 
   }
 

--- a/test/cfoa/assign_tests.cpp
+++ b/test/cfoa/assign_tests.cpp
@@ -108,7 +108,7 @@ template <class T,bool POCCA, bool POCMA>
 struct poca_allocator: fancy_allocator<T>
 {
   using super = fancy_allocator<T>;
-  using pointer = super::pointer;
+  using pointer = typename super::pointer;
   using propagate_on_container_copy_assignment = 
     std::integral_constant<bool, POCCA>;
   using propagate_on_container_move_assignment = 

--- a/test/cfoa/assign_tests.cpp
+++ b/test/cfoa/assign_tests.cpp
@@ -161,10 +161,16 @@ struct poca_allocator: fancy_allocator<T>
 };
 
 template <class T> 
-struct pocca_allocator: poca_allocator<T, true, false>{};
+struct pocca_allocator: poca_allocator<T, true, false>
+{
+  using poca_allocator<T, true, false>::super;
+};
 
 template <class T> 
-struct pocma_allocator: poca_allocator<T, false, true>{};
+struct pocma_allocator: poca_allocator<T, false, true>
+{
+  using poca_allocator<T, false, true>::super;
+};
 
 namespace {
   template <class X, class GF>

--- a/test/cfoa/assign_tests.cpp
+++ b/test/cfoa/assign_tests.cpp
@@ -163,13 +163,23 @@ struct poca_allocator: fancy_allocator<T>
 template <class T> 
 struct pocca_allocator: poca_allocator<T, true, false>
 {
-  using poca_allocator<T, true, false>::super;
+  pocca_allocator() = default;
+  pocca_allocator(pocca_allocator const&) = default;
+  pocca_allocator(pocca_allocator &&) = default;
+  using poca_allocator<T, true, false>::poca_allocator;
+
+  pocca_allocator& operator=(pocca_allocator const&) = default;
 };
 
 template <class T> 
 struct pocma_allocator: poca_allocator<T, false, true>
 {
-  using poca_allocator<T, false, true>::super;
+  pocma_allocator() = default;
+  pocma_allocator(pocma_allocator const&) = default;
+  pocma_allocator(pocma_allocator &&) = default;
+  using poca_allocator<T, false, true>::poca_allocator;
+
+  pocma_allocator& operator=(pocma_allocator const&) = default;
 };
 
 namespace {


### PR DESCRIPTION
When using propagating, fancy allocators that don't compare equal, `foa::table_core` copy and move assignment deallocated storage with a different allocator than the one used for allocation. The test suite has been updated to explicitly cover these two bugs. The fix includes some slight refactoring of the existing `arrays_holder` machinery as it's now being used in more places.