### PR TITLE
Fix/remove lifted ops

### DIFF
--- a/include/boost/unordered/concurrent_flat_map.hpp
+++ b/include/boost/unordered/concurrent_flat_map.hpp
@@ -855,8 +855,6 @@ namespace boost {
 #endif
 
   } // namespace unordered
-
-  using unordered::concurrent_flat_map;
 } // namespace boost
 
 #endif // BOOST_UNORDERED_CONCURRENT_FLAT_MAP_HPP

--- a/include/boost/unordered/concurrent_flat_map_fwd.hpp
+++ b/include/boost/unordered/concurrent_flat_map_fwd.hpp
@@ -46,9 +46,6 @@ namespace boost {
   } // namespace unordered
 
   using boost::unordered::concurrent_flat_map;
-  using boost::unordered::swap;
-  using boost::unordered::operator==;
-  using boost::unordered::operator!=;
 } // namespace boost
 
 #endif // BOOST_UNORDERED_CONCURRENT_FLAT_MAP_HPP

--- a/include/boost/unordered/concurrent_flat_set.hpp
+++ b/include/boost/unordered/concurrent_flat_set.hpp
@@ -711,8 +711,6 @@ namespace boost {
 #endif
 
   } // namespace unordered
-
-  using unordered::concurrent_flat_set;
 } // namespace boost
 
 #endif // BOOST_UNORDERED_CONCURRENT_FLAT_SET_HPP

--- a/include/boost/unordered/concurrent_flat_set_fwd.hpp
+++ b/include/boost/unordered/concurrent_flat_set_fwd.hpp
@@ -47,9 +47,6 @@ namespace boost {
   } // namespace unordered
 
   using boost::unordered::concurrent_flat_set;
-  using boost::unordered::swap;
-  using boost::unordered::operator==;
-  using boost::unordered::operator!=;
 } // namespace boost
 
 #endif // BOOST_UNORDERED_CONCURRENT_FLAT_SET_FWD_HPP

--- a/include/boost/unordered/unordered_flat_map_fwd.hpp
+++ b/include/boost/unordered/unordered_flat_map_fwd.hpp
@@ -39,10 +39,6 @@ namespace boost {
   } // namespace unordered
 
   using boost::unordered::unordered_flat_map;
-
-  using boost::unordered::swap;
-  using boost::unordered::operator==;
-  using boost::unordered::operator!=;
 } // namespace boost
 
 #endif

--- a/include/boost/unordered/unordered_flat_set_fwd.hpp
+++ b/include/boost/unordered/unordered_flat_set_fwd.hpp
@@ -39,10 +39,6 @@ namespace boost {
   } // namespace unordered
 
   using boost::unordered::unordered_flat_set;
-
-  using boost::unordered::swap;
-  using boost::unordered::operator==;
-  using boost::unordered::operator!=;
 } // namespace boost
 
 #endif

--- a/include/boost/unordered/unordered_map_fwd.hpp
+++ b/include/boost/unordered/unordered_map_fwd.hpp
@@ -60,11 +60,8 @@ namespace boost {
     template <class Iter, class NodeType> struct insert_return_type_map;
   } // namespace unordered
 
-  using boost::unordered::swap;
   using boost::unordered::unordered_map;
   using boost::unordered::unordered_multimap;
-  using boost::unordered::operator==;
-  using boost::unordered::operator!=;
 } // namespace boost
 
 #endif

--- a/include/boost/unordered/unordered_node_map_fwd.hpp
+++ b/include/boost/unordered/unordered_node_map_fwd.hpp
@@ -39,10 +39,6 @@ namespace boost {
   } // namespace unordered
 
   using boost::unordered::unordered_node_map;
-
-  using boost::unordered::swap;
-  using boost::unordered::operator==;
-  using boost::unordered::operator!=;
 } // namespace boost
 
 #endif

--- a/include/boost/unordered/unordered_node_set_fwd.hpp
+++ b/include/boost/unordered/unordered_node_set_fwd.hpp
@@ -39,10 +39,6 @@ namespace boost {
   } // namespace unordered
 
   using boost::unordered::unordered_node_set;
-
-  using boost::unordered::swap;
-  using boost::unordered::operator==;
-  using boost::unordered::operator!=;
 } // namespace boost
 
 #endif

--- a/include/boost/unordered/unordered_set_fwd.hpp
+++ b/include/boost/unordered/unordered_set_fwd.hpp
@@ -58,11 +58,8 @@ namespace boost {
     template <class Iter, class NodeType> struct insert_return_type_set;
   } // namespace unordered
 
-  using boost::unordered::swap;
   using boost::unordered::unordered_multiset;
   using boost::unordered::unordered_set;
-  using boost::unordered::operator==;
-  using boost::unordered::operator!=;
 } // namespace boost
 
 #endif

--- a/test/unordered/compile_tests.hpp
+++ b/test/unordered/compile_tests.hpp
@@ -496,11 +496,6 @@ template <class X> void equality_test(X& r)
 
   test::check_return_type<bool>::equals(a == b);
   test::check_return_type<bool>::equals(a != b);
-
-#ifndef BOOST_UNORDERED_FOA_TESTS
-  test::check_return_type<bool>::equals(boost::operator==(a, b));
-  test::check_return_type<bool>::equals(boost::operator!=(a, b));
-#endif
 }
 
 template <class X, class T> void unordered_unique_test(X& r, T const& t)

--- a/test/unordered/compile_tests.hpp
+++ b/test/unordered/compile_tests.hpp
@@ -1,6 +1,6 @@
 
 // Copyright 2005-2009 Daniel James.
-// Copyright 2022 Christian Mazakas.
+// Copyright 2022-2023 Christian Mazakas.
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
@@ -496,8 +496,11 @@ template <class X> void equality_test(X& r)
 
   test::check_return_type<bool>::equals(a == b);
   test::check_return_type<bool>::equals(a != b);
+
+#ifndef BOOST_UNORDERED_FOA_TESTS
   test::check_return_type<bool>::equals(boost::operator==(a, b));
   test::check_return_type<bool>::equals(boost::operator!=(a, b));
+#endif
 }
 
 template <class X, class T> void unordered_unique_test(X& r, T const& t)


### PR DESCRIPTION
Opening the PR for discussion. I've removed all lifting `using` directives for `swap` and `operator(==|!=)`, _except_ in the case of `boost::unordered_[multi](map|set)`, and I wonder if we should go ahead and remove those too --I can't think of any legitimate use case where they could be needed.