### PR TITLE
Fix `operator->` for `local_iterator`s

### DIFF
--- a/include/boost/unordered/detail/fca.hpp
+++ b/include/boost/unordered/detail/fca.hpp
@@ -317,8 +317,7 @@ namespace boost {
         grouped_local_bucket_iterator() : p() {}
 
         reference operator*() const noexcept { return dereference(); }
-
-        pointer operator->() const noexcept { return boost::to_address(p); }
+        pointer operator->() const noexcept { return get_address(); }
 
         grouped_local_bucket_iterator& operator++() noexcept
         {
@@ -354,6 +353,7 @@ namespace boost {
         grouped_local_bucket_iterator(node_pointer p_) : p(p_) {}
 
         value_type& dereference() const noexcept { return p->value(); }
+        value_type* get_address() const noexcept { return p->value_ptr(); }
 
         bool equal(const grouped_local_bucket_iterator& x) const noexcept
         {
@@ -385,8 +385,7 @@ namespace boost {
         }
 
         reference operator*() const noexcept { return dereference(); }
-
-        pointer operator->() const noexcept { return boost::to_address(p); }
+        pointer operator->() const noexcept { return get_address(); }
 
         const_grouped_local_bucket_iterator& operator++() noexcept
         {
@@ -420,6 +419,7 @@ namespace boost {
         const_grouped_local_bucket_iterator(node_pointer p_) : p(p_) {}
 
         value_type& dereference() const noexcept { return p->value(); }
+        value_type* get_address() const noexcept { return p->value_ptr(); }
 
         bool equal(const const_grouped_local_bucket_iterator& x) const noexcept
         {

--- a/test/unordered/compile_tests.hpp
+++ b/test/unordered/compile_tests.hpp
@@ -345,6 +345,7 @@ void unordered_map_test(X& r, Key const& k, T const& v)
 {
   typedef typename X::value_type value_type;
   typedef typename X::key_type key_type;
+  typedef typename X::mapped_type mapped_type;
 
   BOOST_STATIC_ASSERT(
     (boost::is_same<value_type, std::pair<key_type const, T> >::value));
@@ -455,6 +456,18 @@ void unordered_map_test(X& r, Key const& k, T const& v)
   r.emplace_hint(r.begin(), k, v);
   r.emplace_hint(r.begin(), k_lvalue, v_lvalue);
   r.emplace_hint(r.begin(), rvalue(k), rvalue(v));
+
+  // Iterator dereferencing
+  test::check_return_type<value_type>::equals(*r.find(k));
+  test::check_return_type<Key>::equals(r.find(k)->first);
+  test::check_return_type<mapped_type>::equals(r.find(k)->second);
+
+#ifndef BOOST_UNORDERED_FOA_TESTS
+  // Local iterator dereferencing
+  test::check_return_type<value_type>::equals(*r.begin(r.bucket(k)));
+  test::check_return_type<Key>::equals(r.begin(r.bucket(k))->first);
+  test::check_return_type<mapped_type>::equals(r.begin(r.bucket(k))->second);
+#endif
 
 #ifdef BOOST_UNORDERED_FOA_TESTS
   r.emplace_hint(r.begin(), std::piecewise_construct, std::make_tuple(k),


### PR DESCRIPTION
Invoking this operator causes a compile break.  This appears to have been caused by b1a9cde69.