### PR TITLE
Optimize `emplace()` for arguments of the form `k, v`

### DIFF
--- a/doc/unordered/changes.adoc
+++ b/doc/unordered/changes.adoc
@@ -6,6 +6,11 @@
 :github-pr-url: https://github.com/boostorg/unordered/pull
 :cpp: C++
 
+== Release 1.85.0
+
+* Optimized `emplace()` for a `value_type` or `init_type` (if applicable) argument to bypass creating an intermediate object. The argument is already the same type as the would-be intermediate object.
+* Optimized `emplace()` for `k,v` arguments on map containers to delay constructing the object until it is certain that an element should be inserted. This optimization happens when the map's `key_type` is move constructible or when the `k` argument is a `key_type`.
+
 == Release 1.84.0 - Major update
 
 * Added `boost::concurrent_flat_set`.

--- a/doc/unordered/concurrent_flat_map.adoc
+++ b/doc/unordered/concurrent_flat_map.adoc
@@ -908,7 +908,9 @@ Inserts an object, constructed with the arguments `args`, in the table if and on
 Requires:;; `value_type` is constructible from `args`.
 Returns:;; `true` if an insert took place.
 Concurrency:;; Blocking on rehashing of `*this`.
-Notes:;; Invalidates pointers and references to elements if a rehashing is issued.
+Notes:;; Invalidates pointers and references to elements if a rehashing is issued. +
++
+If `args...` is of the form `k,v`, it delays constructing the whole object until it is certain that an element should be inserted, using only the `k` argument to check.
 
 ---
 

--- a/doc/unordered/copyright.adoc
+++ b/doc/unordered/copyright.adoc
@@ -15,4 +15,6 @@ Copyright (C) 2022-2023 Joaqu&iacute;n M L&oacute;pez Mu&ntilde;oz
 
 Copyright (C) 2022-2023 Peter Dimov
 
+Copyright (C) 2024 Braden Ganetsky
+
 Distributed under the Boost Software License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/doc/unordered/unordered_flat_map.adoc
+++ b/doc/unordered/unordered_flat_map.adoc
@@ -750,6 +750,8 @@ Returns:;; The `bool` component of the return type is `true` if an insert took p
 If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
 Throws:;; If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
 Notes:;; Can invalidate iterators, pointers and references, but only if the insert causes the load to be greater than the maximum load. +
++
+If `args...` is of the form `k,v`, it delays constructing the whole object until it is certain that an element should be inserted, using only the `k` argument to check.
 
 ---
 
@@ -769,6 +771,8 @@ Returns:;; The `bool` component of the return type is `true` if an insert took p
 If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
 Throws:;; If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
 Notes:;; Can invalidate iterators, pointers and references, but only if the insert causes the load to be greater than the maximum load. +
++
+If `args...` is of the form `k,v`, it delays constructing the whole object until it is certain that an element should be inserted, using only the `k` argument to check.
 
 ---
 

--- a/doc/unordered/unordered_map.adoc
+++ b/doc/unordered/unordered_map.adoc
@@ -797,7 +797,9 @@ If an insert took place, then the iterator points to the newly inserted element.
 Throws:;; If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
 Notes:;; Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
 +
-Pointers and references to elements are never invalidated.
+Pointers and references to elements are never invalidated. +
++
+If `args...` is of the form `k,v`, it delays constructing the whole object until it is certain that an element should be inserted, using only the `k` argument to check. This optimization happens when the map's `key_type` is move constructible or when the `k` argument is a `key_type`.
 
 ---
 
@@ -818,7 +820,9 @@ Notes:;; The standard is fairly vague on the meaning of the hint. But the only p
 +
 Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
 +
-Pointers and references to elements are never invalidated.
+Pointers and references to elements are never invalidated. +
++
+If `args...` is of the form `k,v`, it delays constructing the whole object until it is certain that an element should be inserted, using only the `k` argument to check. This optimization happens when the map's `key_type` is move constructible or when the `k` argument is a `key_type`.
 
 ---
 

--- a/doc/unordered/unordered_node_map.adoc
+++ b/doc/unordered/unordered_node_map.adoc
@@ -767,6 +767,8 @@ Returns:;; The `bool` component of the return type is `true` if an insert took p
 If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
 Throws:;; If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
 Notes:;; Can invalidate iterators, but only if the insert causes the load to be greater than the maximum load. +
++
+If `args...` is of the form `k,v`, it delays constructing the whole object until it is certain that an element should be inserted, using only the `k` argument to check. This optimization happens when `key_type` is move constructible or when the `k` argument is a `key_type`.
 
 ---
 
@@ -786,6 +788,8 @@ Returns:;; The `bool` component of the return type is `true` if an insert took p
 If an insert took place, then the iterator points to the newly inserted element. Otherwise, it points to the element with equivalent key.
 Throws:;; If an exception is thrown by an operation other than a call to `hasher` the function has no effect.
 Notes:;; Can invalidate iterators, but only if the insert causes the load to be greater than the maximum load. +
++
+If `args...` is of the form `k,v`, it delays constructing the whole object until it is certain that an element should be inserted, using only the `k` argument to check. This optimization happens when `key_type` is move constructible or when the `k` argument is a `key_type`.
 
 ---
 

--- a/include/boost/unordered/detail/allocator_constructed.hpp
+++ b/include/boost/unordered/detail/allocator_constructed.hpp
@@ -1,0 +1,59 @@
+/* Copyright 2024 Braden Ganetsky.
+ * Distributed under the Boost Software License, Version 1.0.
+ * (See accompanying file LICENSE_1_0.txt or copy at
+ * http://www.boost.org/LICENSE_1_0.txt)
+ *
+ * See https://www.boost.org/libs/unordered for library home page.
+ */
+
+#ifndef BOOST_UNORDERED_DETAIL_ALLOCATOR_CONSTRUCTED_HPP
+#define BOOST_UNORDERED_DETAIL_ALLOCATOR_CONSTRUCTED_HPP
+
+#include <boost/core/allocator_traits.hpp>
+#include <boost/unordered/detail/opt_storage.hpp>
+
+namespace boost {
+  namespace unordered {
+    namespace detail {
+
+      struct allocator_policy
+      {
+        template <class Allocator, class T, class... Args>
+        static void construct(Allocator& a, T* p, Args&&... args)
+        {
+          boost::allocator_construct(a, p, std::forward<Args>(args)...);
+        }
+
+        template <class Allocator, class T>
+        static void destroy(Allocator& a, T* p)
+        {
+          boost::allocator_destroy(a, p);
+        }
+      };
+
+      /* constructs a stack-based object with the given policy and allocator */
+      template <class Allocator, class T, class Policy = allocator_policy>
+      class allocator_constructed
+      {
+        opt_storage<T> storage;
+        Allocator alloc;
+
+      public:
+        template <class... Args>
+        allocator_constructed(Allocator const& alloc_, Args&&... args)
+            : alloc(alloc_)
+        {
+          Policy::construct(
+            alloc, storage.address(), std::forward<Args>(args)...);
+        }
+
+        ~allocator_constructed() { Policy::destroy(alloc, storage.address()); }
+
+        T& value() { return *storage.address(); }
+      };
+
+    } /* namespace detail */
+  }   /* namespace unordered */
+} /* namespace boost */
+
+#endif

--- a/include/boost/unordered/detail/foa/concurrent_table.hpp
+++ b/include/boost/unordered/detail/foa/concurrent_table.hpp
@@ -691,6 +691,18 @@ public:
     return emplace_impl(std::forward<Value>(x));
   }
 
+  /* Optimizations for maps for (k,v) to avoid eagerly constructing value */
+  template <typename K, typename V>
+  BOOST_FORCEINLINE auto emplace(K&& k, V&& v) ->
+    typename std::enable_if<is_emplace_kv_able<concurrent_table, K>::value,
+      bool>::type
+  {
+    alloc_cted_or_fwded_key_type<type_policy, Allocator, K&&> x(
+      this->al(), std::forward<K>(k));
+    return emplace_impl(
+      try_emplace_args_t{}, x.move_or_fwd(), std::forward<V>(v));
+  }
+
   BOOST_FORCEINLINE bool
   insert(const init_type& x){return emplace_impl(x);}
 

--- a/include/boost/unordered/detail/foa/concurrent_table.hpp
+++ b/include/boost/unordered/detail/foa/concurrent_table.hpp
@@ -1,6 +1,7 @@
 /* Fast open-addressing concurrent hash table.
  *
  * Copyright 2023 Joaquin M Lopez Munoz.
+ * Copyright 2024 Braden Ganetsky.
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or copy at
  * http://www.boost.org/LICENSE_1_0.txt)

--- a/include/boost/unordered/detail/foa/concurrent_table.hpp
+++ b/include/boost/unordered/detail/foa/concurrent_table.hpp
@@ -1320,7 +1320,7 @@ private:
   {
     auto lck=shared_access();
 
-    auto x=alloc_make_insert_type<type_policy>(
+    alloc_cted_insert_type<type_policy,Allocator,Args...> x(
       this->al(),std::forward<Args>(args)...);
     int res=unprotected_norehash_emplace_or_visit(
       access_mode,std::forward<F>(f),type_policy::move(x.value()));

--- a/include/boost/unordered/detail/foa/core.hpp
+++ b/include/boost/unordered/detail/foa/core.hpp
@@ -2,6 +2,7 @@
  *
  * Copyright 2022-2023 Joaquin M Lopez Munoz.
  * Copyright 2023 Christian Mazakas.
+ * Copyright 2024 Braden Ganetsky.
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or copy at
  * http://www.boost.org/LICENSE_1_0.txt)

--- a/include/boost/unordered/detail/foa/flat_map_types.hpp
+++ b/include/boost/unordered/detail/foa/flat_map_types.hpp
@@ -1,4 +1,5 @@
 // Copyright (C) 2023 Christian Mazakas
+// Copyright (C) 2024 Braden Ganetsky
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 

--- a/include/boost/unordered/detail/foa/flat_map_types.hpp
+++ b/include/boost/unordered/detail/foa/flat_map_types.hpp
@@ -56,12 +56,23 @@ namespace boost {
             boost::allocator_construct(al, p, std::forward<Args>(args)...);
           }
 
+          template <class A, class... Args>
+          static void construct(A& al, key_type* p, Args&&... args)
+          {
+            boost::allocator_construct(al, p, std::forward<Args>(args)...);
+          }
+
           template <class A> static void destroy(A& al, init_type* p) noexcept
           {
             boost::allocator_destroy(al, p);
           }
 
           template <class A> static void destroy(A& al, value_type* p) noexcept
+          {
+            boost::allocator_destroy(al, p);
+          }
+
+          template <class A> static void destroy(A& al, key_type* p) noexcept
           {
             boost::allocator_destroy(al, p);
           }

--- a/include/boost/unordered/detail/foa/node_map_types.hpp
+++ b/include/boost/unordered/detail/foa/node_map_types.hpp
@@ -1,4 +1,5 @@
 // Copyright (C) 2023 Christian Mazakas
+// Copyright (C) 2024 Braden Ganetsky
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 

--- a/include/boost/unordered/detail/foa/node_map_types.hpp
+++ b/include/boost/unordered/detail/foa/node_map_types.hpp
@@ -83,6 +83,12 @@ namespace boost {
           }
 
           template <class A, class... Args>
+          static void construct(A& al, key_type* p, Args&&... args)
+          {
+            boost::allocator_construct(al, p, std::forward<Args>(args)...);
+          }
+
+          template <class A, class... Args>
           static void construct(A& al, element_type* p, Args&&... args)
           {
             p->p = boost::allocator_allocate(al, 1);
@@ -105,6 +111,11 @@ namespace boost {
           }
 
           template <class A> static void destroy(A& al, init_type* p) noexcept
+          {
+            boost::allocator_destroy(al, p);
+          }
+
+          template <class A> static void destroy(A& al, key_type* p) noexcept
           {
             boost::allocator_destroy(al, p);
           }

--- a/include/boost/unordered/detail/foa/table.hpp
+++ b/include/boost/unordered/detail/foa/table.hpp
@@ -2,6 +2,7 @@
  *
  * Copyright 2022-2023 Joaquin M Lopez Munoz.
  * Copyright 2023 Christian Mazakas.
+ * Copyright 2024 Braden Ganetsky.
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or copy at
  * http://www.boost.org/LICENSE_1_0.txt)

--- a/include/boost/unordered/detail/foa/table.hpp
+++ b/include/boost/unordered/detail/foa/table.hpp
@@ -416,6 +416,19 @@ public:
     return emplace_impl(std::forward<T>(x));
   }
 
+  /* Optimizations for maps for (k,v) to avoid eagerly constructing value */
+  template <typename K, typename V>
+  BOOST_FORCEINLINE
+    typename std::enable_if<is_emplace_kv_able<table, K>::value,
+      std::pair<iterator, bool> >::type
+    emplace(K&& k, V&& v)
+  {
+    alloc_cted_or_fwded_key_type<type_policy, Allocator, K&&> x(
+      this->al(), std::forward<K>(k));
+    return emplace_impl(
+      try_emplace_args_t{}, x.move_or_fwd(), std::forward<V>(v));
+  }
+
   template<typename Key,typename... Args>
   BOOST_FORCEINLINE std::pair<iterator,bool> try_emplace(
     Key&& x,Args&&... args)

--- a/include/boost/unordered/detail/foa/table.hpp
+++ b/include/boost/unordered/detail/foa/table.hpp
@@ -401,7 +401,7 @@ public:
   template<typename... Args>
   BOOST_FORCEINLINE std::pair<iterator,bool> emplace(Args&&... args)
   {
-    auto x=alloc_make_insert_type<type_policy>(
+    alloc_cted_insert_type<type_policy,Allocator,Args...> x(
       this->al(),std::forward<Args>(args)...);
     return emplace_impl(type_policy::move(x.value()));
   }

--- a/include/boost/unordered/detail/implementation.hpp
+++ b/include/boost/unordered/detail/implementation.hpp
@@ -2,6 +2,7 @@
 // Copyright (C) 2005-2016 Daniel James
 // Copyright (C) 2022-2023 Joaquin M Lopez Munoz.
 // Copyright (C) 2022-2023 Christian Mazakas
+// Copyright (C) 2024 Braden Ganetsky
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/include/boost/unordered/detail/map.hpp
+++ b/include/boost/unordered/detail/map.hpp
@@ -1,6 +1,7 @@
 
 // Copyright (C) 2005-2016 Daniel James
 // Copyright (C) 2022 Christian Mazakas
+// Copyright (C) 2024 Braden Ganetsky
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 

--- a/include/boost/unordered/detail/map.hpp
+++ b/include/boost/unordered/detail/map.hpp
@@ -18,6 +18,7 @@ namespace boost {
         typedef std::pair<K const, M> value_type;
         typedef H hasher;
         typedef P key_equal;
+        typedef K key_type;
         typedef K const const_key_type;
 
         typedef

--- a/include/boost/unordered/detail/type_traits.hpp
+++ b/include/boost/unordered/detail/type_traits.hpp
@@ -1,4 +1,5 @@
 // Copyright (C) 2022-2023 Christian Mazakas
+// Copyright (C) 2024 Braden Ganetsky
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/include/boost/unordered/detail/type_traits.hpp
+++ b/include/boost/unordered/detail/type_traits.hpp
@@ -48,6 +48,20 @@ namespace boost {
 
       template <typename... Ts> using void_t = typename make_void<Ts...>::type;
 
+      template <class T, class = void> struct is_complete : std::false_type
+      {
+      };
+
+      template <class T>
+      struct is_complete<T, void_t<int[sizeof(T)]> > : std::true_type
+      {
+      };
+
+      template <class T>
+      using is_complete_and_move_constructible =
+        typename std::conditional<is_complete<T>::value,
+          std::is_move_constructible<T>, std::false_type>::type;
+
 #if BOOST_WORKAROUND(BOOST_LIBSTDCXX_VERSION, < 50000)
       /* std::is_trivially_default_constructible not provided */
       template <class T>

--- a/test/cfoa/emplace_tests.cpp
+++ b/test/cfoa/emplace_tests.cpp
@@ -1,5 +1,6 @@
 // Copyright (C) 2023 Christian Mazakas
 // Copyright (C) 2023 Joaquin M Lopez Munoz
+// Copyright (C) 2024 Braden Ganetsky
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 

--- a/test/cfoa/helpers.hpp
+++ b/test/cfoa/helpers.hpp
@@ -207,7 +207,8 @@ template <class T> struct stateful_allocator2
   bool operator!=(stateful_allocator2 const& rhs) const { return x_ != rhs.x_; }
 };
 
-struct raii
+template <class Tag>
+struct basic_raii
 {
   static std::atomic<std::uint32_t> default_constructor;
   static std::atomic<std::uint32_t> copy_constructor;
@@ -219,17 +220,17 @@ struct raii
 
   int x_ = -1;
 
-  raii() { ++default_constructor; }
-  raii(int const x) : x_{x} { ++default_constructor; }
-  raii(raii const& rhs) : x_{rhs.x_} { ++copy_constructor; }
-  raii(raii&& rhs) noexcept : x_{rhs.x_}
+  basic_raii() { ++default_constructor; }
+  basic_raii(int const x) : x_{x} { ++default_constructor; }
+  basic_raii(basic_raii const& rhs) : x_{rhs.x_} { ++copy_constructor; }
+  basic_raii(basic_raii&& rhs) noexcept : x_{rhs.x_}
   {
     rhs.x_ = -1;
     ++move_constructor;
   }
-  ~raii() { ++destructor; }
+  ~basic_raii() { ++destructor; }
 
-  raii& operator=(raii const& rhs)
+  basic_raii& operator=(basic_raii const& rhs)
   {
     ++copy_assignment;
     if (this != &rhs) {
@@ -238,7 +239,7 @@ struct raii
     return *this;
   }
 
-  raii& operator=(raii&& rhs) noexcept
+  basic_raii& operator=(basic_raii&& rhs) noexcept
   {
     ++move_assignment;
     if (this != &rhs) {
@@ -248,37 +249,37 @@ struct raii
     return *this;
   }
 
-  friend bool operator==(raii const& lhs, raii const& rhs)
+  friend bool operator==(basic_raii const& lhs, basic_raii const& rhs)
   {
     return lhs.x_ == rhs.x_;
   }
 
-  friend bool operator!=(raii const& lhs, raii const& rhs)
+  friend bool operator!=(basic_raii const& lhs, basic_raii const& rhs)
   {
     return !(lhs == rhs);
   }
 
-  friend bool operator==(raii const& lhs, int const x) { return lhs.x_ == x; }
-  friend bool operator!=(raii const& lhs, int const x)
+  friend bool operator==(basic_raii const& lhs, int const x) { return lhs.x_ == x; }
+  friend bool operator!=(basic_raii const& lhs, int const x)
   {
     return !(lhs.x_ == x);
   }
 
-  friend bool operator==(int const x, raii const& rhs) { return rhs.x_ == x; }
+  friend bool operator==(int const x, basic_raii const& rhs) { return rhs.x_ == x; }
 
-  friend bool operator!=(int const x, raii const& rhs)
+  friend bool operator!=(int const x, basic_raii const& rhs)
   {
     return !(rhs.x_ == x);
   }
 
-  friend std::ostream& operator<<(std::ostream& os, raii const& rhs)
+  friend std::ostream& operator<<(std::ostream& os, basic_raii const& rhs)
   {
     os << "{ x_: " << rhs.x_ << " }";
     return os;
   }
 
   friend std::ostream& operator<<(
-    std::ostream& os, std::pair<raii const, raii> const& rhs)
+    std::ostream& os, std::pair<basic_raii const, basic_raii> const& rhs)
   {
     os << "pair<" << rhs.first << ", " << rhs.second << ">";
     return os;
@@ -294,16 +295,30 @@ struct raii
     move_assignment = 0;
   }
 
-  friend void swap(raii& lhs, raii& rhs) { std::swap(lhs.x_, rhs.x_); }
+  friend void swap(basic_raii& lhs, basic_raii& rhs) { std::swap(lhs.x_, rhs.x_); }
 };
 
-std::atomic<std::uint32_t> raii::default_constructor{0};
-std::atomic<std::uint32_t> raii::copy_constructor{0};
-std::atomic<std::uint32_t> raii::move_constructor{0};
-std::atomic<std::uint32_t> raii::destructor{0};
-std::atomic<std::uint32_t> raii::copy_assignment{0};
-std::atomic<std::uint32_t> raii::move_assignment{0};
+template <class Tag> std::atomic<std::uint32_t> basic_raii<Tag>::default_constructor(0);
+template <class Tag> std::atomic<std::uint32_t> basic_raii<Tag>::copy_constructor(0);
+template <class Tag> std::atomic<std::uint32_t> basic_raii<Tag>::move_constructor(0);
+template <class Tag> std::atomic<std::uint32_t> basic_raii<Tag>::destructor(0);
+template <class Tag> std::atomic<std::uint32_t> basic_raii<Tag>::copy_assignment(0);
+template <class Tag> std::atomic<std::uint32_t> basic_raii<Tag>::move_assignment(0);
 
+struct raii_tag_
+{
+};
+class raii : public basic_raii<raii_tag_>
+{
+  using basic_raii::basic_raii;
+};
+
+template <class Tag>
+std::size_t hash_value(basic_raii<Tag> const& r) noexcept
+{
+  boost::hash<int> hasher;
+  return hasher(r.x_);
+}
 std::size_t hash_value(raii const& r) noexcept
 {
   boost::hash<int> hasher;
@@ -311,6 +326,13 @@ std::size_t hash_value(raii const& r) noexcept
 }
 
 namespace std {
+  template <class Tag> struct hash<basic_raii<Tag>>
+  {
+    std::size_t operator()(basic_raii<Tag> const& r) const noexcept
+    {
+      return hash_value(r);
+    }
+  };
   template <> struct hash<raii>
   {
     std::size_t operator()(raii const& r) const noexcept

--- a/test/cfoa/helpers.hpp
+++ b/test/cfoa/helpers.hpp
@@ -1,5 +1,6 @@
 // Copyright (C) 2023 Christian Mazakas
 // Copyright (C) 2023 Joaquin M Lopez Munoz
+// Copyright (C) 2024 Braden Ganetsky
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 

--- a/test/helpers/count.hpp
+++ b/test/helpers/count.hpp
@@ -1,5 +1,6 @@
 
 // Copyright 2008-2009 Daniel James.
+// Copyright 2024 Braden Ganetsky.
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or move at http://www.boost.org/LICENSE_1_0.txt)
 

--- a/test/helpers/count.hpp
+++ b/test/helpers/count.hpp
@@ -147,6 +147,8 @@ namespace test {
     static smf_count count;
     static void reset_count() { count.reset(); }
 
+    smf_counted_object(int index) : smf_counted_object() { index_ = index; }
+
     smf_counted_object() : index_(++running_index)
     {
       count.default_construct();
@@ -184,9 +186,10 @@ namespace test {
       return boost::hash<int>()(x.index_);
     }
 
+    int index_;
+
   private:
     static int running_index;
-    int index_;
   };
   template <class Tag> smf_count smf_counted_object<Tag>::count = {};
   template <class Tag> int smf_counted_object<Tag>::running_index = 0;

--- a/test/helpers/unordered.hpp
+++ b/test/helpers/unordered.hpp
@@ -21,4 +21,10 @@
 #include "postfix.hpp"
 // clang-format on
 
+#if defined(BOOST_LIBSTDCXX_VERSION)
+#if BOOST_LIBSTDCXX_VERSION < 60000
+#define BOOST_UNORDERED_NO_INIT_TYPE_TESTS
+#endif
+#endif
+
 #endif

--- a/test/unordered/emplace_smf_tests.cpp
+++ b/test/unordered/emplace_smf_tests.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 Braden Ganetsky.
+// Copyright 2023-2024 Braden Ganetsky.
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 

--- a/test/unordered/init_type_insert_tests.cpp
+++ b/test/unordered/init_type_insert_tests.cpp
@@ -12,12 +12,6 @@
 
 #include <boost/config.hpp>
 
-#if defined(BOOST_LIBSTDCXX_VERSION)
-#if BOOST_LIBSTDCXX_VERSION < 60000
-#define BOOST_UNORDERED_NO_INIT_TYPE_TESTS
-#endif
-#endif
-
 struct move_only
 {
   int x_ = -1;


### PR DESCRIPTION
Closes #226