### PR TITLE
Fixed bug in the `const` version of `unordered_multimap::find(k, hash, eq)`

### DIFF
--- a/doc/unordered/changes.adoc
+++ b/doc/unordered/changes.adoc
@@ -11,6 +11,7 @@
 * Optimized `emplace()` for a `value_type` or `init_type` (if applicable) argument to bypass creating an intermediate object. The argument is already the same type as the would-be intermediate object.
 * Optimized `emplace()` for `k,v` arguments on map containers to delay constructing the object until it is certain that an element should be inserted. This optimization happens when the map's `key_type` is move constructible or when the `k` argument is a `key_type`.
 * Fixed support for allocators with `explicit` copy constructors ({github-pr-url}/234[PR#234^]).
+* Fixed bug in the `const` version of `unordered_multimap::find(k, hash, eq)` ({github-pr-url}/238[PR#238^]).
 
 == Release 1.84.0 - Major update
 

--- a/include/boost/unordered/unordered_map.hpp
+++ b/include/boost/unordered/unordered_map.hpp
@@ -2057,8 +2057,7 @@ namespace boost {
     unordered_multimap<K, T, H, P, A>::find(CompatibleKey const& k,
       CompatibleHash const& hash, CompatiblePredicate const& eq) const
     {
-      return const_iterator(
-        table_.find_node_impl(table::policy::apply_hash(hash, k), k, eq));
+      return table_.transparent_find(k, hash, eq);
     }
 
     template <class K, class T, class H, class P, class A>

--- a/test/unordered/find_tests.cpp
+++ b/test/unordered/find_tests.cpp
@@ -1,6 +1,7 @@
 
 // Copyright 2006-2009 Daniel James.
 // Copyright (C) 2022-2023 Christian Mazakas
+// Copyright (C) 2024 Joaquin M Lopez Munoz.
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
@@ -112,6 +113,7 @@ namespace find_tests {
     typedef typename test::random_values<X>::iterator value_iterator;
     test::random_values<X> v(500, generator);
     X x(v.begin(), v.end());
+    X const& x_const = x;
 
     compatible_hash h;
     compatible_predicate eq;
@@ -119,6 +121,7 @@ namespace find_tests {
     for (value_iterator it = v.begin(), end = v.end(); it != end; ++it) {
       typename X::key_type key = test::get_key<X>(*it);
       BOOST_TEST(x.find(key) == x.find(compatible_key(key), h, eq));
+      BOOST_TEST(x_const.find(key) == x_const.find(compatible_key(key), h, eq));
     }
 
     test::random_values<X> v2(20, generator);
@@ -126,6 +129,7 @@ namespace find_tests {
     for (value_iterator it = v2.begin(), end = v2.end(); it != end; ++it) {
       typename X::key_type key = test::get_key<X>(*it);
       BOOST_TEST(x.find(key) == x.find(compatible_key(key), h, eq));
+      BOOST_TEST(x_const.find(key) == x_const.find(compatible_key(key), h, eq));
     }
   }
 


### PR DESCRIPTION
Fixes #237.