### PR TITLE
Fix 'invalid argument' to boost::interprocess::shared_memory_object

### DIFF
--- a/test/unordered/mmap_tests.cpp
+++ b/test/unordered/mmap_tests.cpp
@@ -298,6 +298,7 @@ std::string shm_name_sanitize(std::string const& exe_name)
     case '\\':
     case '-':
     case '_':
+    case '+':
       return true;
 
     default:


### PR DESCRIPTION
Closes #251 