### PR TITLE
Use as_const to remove any possibility of use-after-move

### DIFF
--- a/include/boost/unordered/detail/type_traits.hpp
+++ b/include/boost/unordered/detail/type_traits.hpp
@@ -219,6 +219,17 @@ namespace boost {
       using iter_to_alloc_t =
         typename std::pair<iter_key_t<T> const, iter_val_t<T> >;
 #endif
+
+#if BOOST_CXX_VERSION < 201703L
+      template <class T>
+      constexpr typename std::add_const<T>::type& as_const(T& t) noexcept
+      {
+        return t;
+      }
+      template <class T> void as_const(const T&&) = delete;
+#else
+      using std::as_const;
+#endif
     } // namespace detail
   } // namespace unordered
 } // namespace boost

--- a/include/boost/unordered/unordered_map.hpp
+++ b/include/boost/unordered/unordered_map.hpp
@@ -198,7 +198,7 @@ namespace boost {
       template <class... Args> std::pair<iterator, bool> emplace(Args&&... args)
       {
         return table_.emplace_unique(
-          table::extractor::extract(std::forward<Args>(args)...),
+          table::extractor::extract(detail::as_const(args)...),
           std::forward<Args>(args)...);
       }
 
@@ -206,7 +206,7 @@ namespace boost {
       iterator emplace_hint(const_iterator hint, Args&&... args)
       {
         return table_.emplace_hint_unique(hint,
-          table::extractor::extract(std::forward<Args>(args)...),
+          table::extractor::extract(detail::as_const(args)...),
           std::forward<Args>(args)...);
       }
 

--- a/include/boost/unordered/unordered_set.hpp
+++ b/include/boost/unordered/unordered_set.hpp
@@ -194,7 +194,7 @@ namespace boost {
       template <class... Args> std::pair<iterator, bool> emplace(Args&&... args)
       {
         return table_.emplace_unique(
-          table::extractor::extract(std::forward<Args>(args)...),
+          table::extractor::extract(detail::as_const(args)...),
           std::forward<Args>(args)...);
       }
 
@@ -202,7 +202,7 @@ namespace boost {
       iterator emplace_hint(const_iterator hint, Args&&... args)
       {
         return table_.emplace_hint_unique(hint,
-          table::extractor::extract(std::forward<Args>(args)...),
+          table::extractor::extract(detail::as_const(args)...),
           std::forward<Args>(args)...);
       }
 


### PR DESCRIPTION
Closes #270 