### PR TITLE
Fix compiling on Cygwin for tests using Interprocess

### DIFF
--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -42,7 +42,9 @@ path-constant BOOST_UNORDERED_TEST_DIR : . ;
 
 run quick.cpp ;
 
-compile debuggability/visualization_tests.cpp ;
+compile debuggability/visualization_tests.cpp
+  : <target-os>cygwin:<define>_XOPEN_SOURCE=600
+  ;
 
 compile unordered/self_include_tests_obj.cpp
   : <define>BOOST_UNORDERED_HEADER="boost/unordered_map.hpp"


### PR DESCRIPTION
See [this related commit](https://github.com/boostorg/interprocess/commit/5b9a58d6801dfea2bb0ac0d1556d729d97a7ae70) in Interprocess.