### PR TITLE
Use std::ref instead of copying the function parameter…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,20 +57,23 @@ jobs:
           - { compiler: gcc-9,     cxxstd: '11,14,17',    os: 'ubuntu-22.04', install: 'g++-9' }
           - { compiler: gcc-10,    cxxstd: '11,14,17,20', os: 'ubuntu-22.04', install: 'g++-10' }
           - { compiler: gcc-11,    cxxstd: '11,14,17,20', os: 'ubuntu-22.04', install: 'g++-11' }
-          - { name: "gcc-12 w/ sanitizers (11)", sanitize: yes,
-              compiler: gcc-12,    cxxstd: '11',          os: 'ubuntu-22.04', ccache_key: "san1" }
-          - { name: "gcc-12 w/ sanitizers (14)", sanitize: yes,
-              compiler: gcc-12,    cxxstd: '14',          os: 'ubuntu-22.04', ccache_key: "san1" }
-          - { name: "gcc-12 w/ sanitizers (17)", sanitize: yes,
-              compiler: gcc-12,    cxxstd: '17',          os: 'ubuntu-22.04', ccache_key: "san2" }
-          - { name: "gcc-12 w/ sanitizers (20)", sanitize: yes,
-              compiler: gcc-12,    cxxstd: '20',          os: 'ubuntu-22.04', ccache_key: "san2" }
-          - { name: "gcc-12 w/ sanitizers (2b)", sanitize: yes,
-              compiler: gcc-12,    cxxstd: '2b',          os: 'ubuntu-22.04', ccache_key: "san2" }
+          - { compiler: gcc-12,    cxxstd: '11,14,17,20', os: 'ubuntu-22.04', install: 'g++-12' }
+          - { compiler: gcc-13,    cxxstd: '11,14,17,20', os: 'ubuntu-24.04', install: 'g++-13' }
+          - { compiler: gcc-14,    cxxstd: '11,14,17,20', os: 'ubuntu-24.04', install: 'g++-14' }
+          - { name: "gcc-14 w/ sanitizers (11)", sanitize: yes,
+              compiler: gcc-14,    cxxstd: '11',          os: 'ubuntu-24.04', install: 'g++-14', ccache_key: "san1" }
+          - { name: "gcc-14 w/ sanitizers (14)", sanitize: yes,
+              compiler: gcc-14,    cxxstd: '14',          os: 'ubuntu-24.04', install: 'g++-14', ccache_key: "san1" }
+          - { name: "gcc-14 w/ sanitizers (17)", sanitize: yes,
+              compiler: gcc-14,    cxxstd: '17',          os: 'ubuntu-24.04', install: 'g++-14', ccache_key: "san2" }
+          - { name: "gcc-14 w/ sanitizers (20)", sanitize: yes,
+              compiler: gcc-14,    cxxstd: '20',          os: 'ubuntu-24.04', install: 'g++-14', ccache_key: "san2" }
+          - { name: "gcc-14 w/ sanitizers (2b)", sanitize: yes,
+              compiler: gcc-14,    cxxstd: '2b',          os: 'ubuntu-24.04', install: 'g++-14', ccache_key: "san2" }
           - { name: Collect coverage, coverage: yes,
-              compiler: gcc-12,    cxxstd: '20',          os: 'ubuntu-22.04', install: 'g++-12-multilib', address-model: '32,64', ccache_key: "cov" }
+              compiler: gcc-14,    cxxstd: '20',          os: 'ubuntu-24.04', install: 'g++-14 g++-14-multilib', address-model: '32,64', ccache_key: "cov" }
 
-          - { name: "cfoa tsan (gcc-12)", cxxstd: '11,14,17,20,2b', os: 'ubuntu-22.04', compiler: gcc-12,
+          - { name: "cfoa tsan (gcc-14)", cxxstd: '11,14,17,20,2b', os: 'ubuntu-24.04', install: 'g++-14', compiler: gcc-14,
               targets: 'libs/unordered/test//cfoa_tests', thread-sanitize: yes, ccache_key: "tsan" }
 
           # Linux, clang, libc++
@@ -88,23 +91,30 @@ jobs:
               compiler: clang-12,   cxxstd: '2b',          os: 'ubuntu-20.04', stdlib: libc++, install: 'clang-12 libc++-12-dev libc++abi-12-dev', ccache_key: "san2" }
           - { compiler: 'clang-13', cxxstd: '11,14',       os: 'ubuntu-22.04', stdlib: libc++, install: 'clang-13 libc++-13-dev libc++abi-13-dev' }
           - { compiler: 'clang-13', cxxstd: '17,20,2b',    os: 'ubuntu-22.04', stdlib: libc++, install: 'clang-13 libc++-13-dev libc++abi-13-dev' }
+          - { compiler: 'clang-14', cxxstd: '11,14',       os: 'ubuntu-22.04', stdlib: libc++, install: 'clang-14 libc++-14-dev libc++abi-14-dev' }
+          - { compiler: 'clang-14', cxxstd: '17,20,2b',    os: 'ubuntu-22.04', stdlib: libc++, install: 'clang-14 libc++-14-dev libc++abi-14-dev' }
+          - { compiler: 'clang-15', cxxstd: '11,14',       os: 'ubuntu-22.04', stdlib: libc++, install: 'clang-15 libc++-15-dev libc++abi-15-dev' }
+          - { compiler: 'clang-15', cxxstd: '17,20,2b',    os: 'ubuntu-22.04', stdlib: libc++, install: 'clang-15 libc++-15-dev libc++abi-15-dev' }
+          - { compiler: 'clang-16', cxxstd: '11,14',       os: 'ubuntu-24.04', stdlib: libc++, install: 'clang-16 libc++-16-dev libc++abi-16-dev' }
+          - { compiler: 'clang-16', cxxstd: '17,20,2b',    os: 'ubuntu-24.04', stdlib: libc++, install: 'clang-16 libc++-16-dev libc++abi-16-dev' }
+          - { compiler: 'clang-17', cxxstd: '11,14',       os: 'ubuntu-24.04', stdlib: libc++, install: 'clang-17 libc++-17-dev libc++abi-17-dev' }
+          - { compiler: 'clang-17', cxxstd: '17,20,2b',    os: 'ubuntu-24.04', stdlib: libc++, install: 'clang-17 libc++-17-dev libc++abi-17-dev' }
+          - { compiler: 'clang-18', cxxstd: '11,14',       os: 'ubuntu-24.04', stdlib: libc++, install: 'clang-18 libc++-18-dev libc++abi-18-dev' }
+          - { compiler: 'clang-18', cxxstd: '17,20,2b',    os: 'ubuntu-24.04', stdlib: libc++, install: 'clang-18 libc++-18-dev libc++abi-18-dev' }
 
           # not using libc++ because of https://github.com/llvm/llvm-project/issues/52771
-          - { name: "clang-14 w/ sanitizers (11,14)", sanitize: yes,
-              compiler: clang-14,  cxxstd: '11,14', os: 'ubuntu-22.04', ccache_key: "san1" }
-          - { name: "clang-14 w/ sanitizers (17)", sanitize: yes,
-              compiler: clang-14,  cxxstd: '17',    os: 'ubuntu-22.04', ccache_key: "san2" }
-          - { name: "clang-14 w/ sanitizers (20)", sanitize: yes,
-              compiler: clang-14,  cxxstd: '20',   container: 'ubuntu:22.04',  os: 'ubuntu-latest', ccache_key: "san2" }
-          - { name: "clang-14 w/ sanitizers (2b)", sanitize: yes,
-              compiler: clang-14,  cxxstd: '2b',   container: 'ubuntu:22.04',  os: 'ubuntu-latest', ccache_key: "san2" }
+          - { name: "clang-18 w/ sanitizers (11,14)", sanitize: yes,
+              compiler: clang-18,  cxxstd: '11,14', os: 'ubuntu-24.04', ccache_key: "san1" }
+          - { name: "clang-18 w/ sanitizers (17)", sanitize: yes,
+              compiler: clang-18,  cxxstd: '17',    os: 'ubuntu-24.04', ccache_key: "san2" }
+          - { name: "clang-18 w/ sanitizers (20)", sanitize: yes,
+              compiler: clang-18,  cxxstd: '20',   container: 'ubuntu:24.04',  os: 'ubuntu-latest', ccache_key: "san2" }
+          - { name: "clang-18 w/ sanitizers (2b)", sanitize: yes,
+              compiler: clang-18,  cxxstd: '2b',   container: 'ubuntu:24.04',  os: 'ubuntu-latest', ccache_key: "san2" }
 
-          - { name: "cfoa tsan (clang-14)", cxxstd: '11,14,17,20,2b', os: 'ubuntu-22.04', compiler: clang-14,
+          - { name: "cfoa tsan (clang-18)", cxxstd: '11,14,17,20,2b', os: 'ubuntu-24.04', compiler: clang-18,
               targets: 'libs/unordered/test//cfoa_tests', thread-sanitize: yes,
-              stdlib: libc++, install: 'clang-14 libc++-14-dev libc++abi-14-dev', ccache_key: "tsan" }
-
-          - { compiler: 'clang-15', cxxstd: '11,14',    os: 'ubuntu-22.04', stdlib: libc++, install: 'clang-15 libc++-15-dev libc++abi-15-dev' }
-          - { compiler: 'clang-15', cxxstd: '17,20,2b', os: 'ubuntu-22.04', stdlib: libc++, install: 'clang-15 libc++-15-dev libc++abi-15-dev' }
+              stdlib: libc++, install: 'clang-18 libc++-18-dev libc++abi-18-dev', ccache_key: "tsan" }
 
           # OSX, clang
           - { compiler: clang, cxxstd: '11,14,17,2a',    os: 'macos-12', sanitize: yes, ccache_key: "san1" }
@@ -239,7 +249,12 @@ jobs:
 
       - name: Run tests
         if: '!matrix.coverity'
-        run: B2_TARGETS=${{matrix.targets}} ci/build.sh
+        run: |
+            if [[ ${B2_TSAN} == "yes" ]] && [[ $(uname) == "Linux" ]]; then
+                echo 0 | sudo tee /proc/sys/kernel/randomize_va_space
+                sudo sysctl vm.mmap_rnd_bits=28
+            fi
+            B2_TARGETS=${{matrix.targets}} ci/build.sh
 
       - name: Upload coverage
         if: matrix.coverage
@@ -326,8 +341,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { sys: MINGW32, compiler: gcc, cxxstd: '11,17,20' }
-          - { sys: MINGW64, compiler: gcc, cxxstd: '11,17,20' }
+          - { sys: MINGW32, compiler: gcc, cxxstd: '11,17,20', variant: 'release' }
+          - { sys: MINGW64, compiler: gcc, cxxstd: '11,17,20', variant: 'debug,release' }
 
     needs: [runner-selection]
     runs-on: ${{ fromJSON(needs.runner-selection.outputs.labelmatrix)['windows-latest'] }}
@@ -361,9 +376,12 @@ jobs:
           B2_CXXSTD: ${{matrix.cxxstd}}
           B2_SANITIZE: ${{matrix.sanitize}}
           B2_STDLIB: ${{matrix.stdlib}}
+          B2_VARIANT: ${{matrix.variant}}
         run: ci/github/install.sh
 
       - name: Run tests
+        env:
+          B2_VARIANT: ${{matrix.variant}}
         run: ci/build.sh
 
       # Run also the CMake tests to avoid having to setup another matrix for CMake on MSYS

--- a/doc/unordered/changes.adoc
+++ b/doc/unordered/changes.adoc
@@ -19,6 +19,7 @@ visits the element if insertion did _not_ take place).
 * Added GDB pretty-printers for all containers and iterators. For a container with an allocator that uses fancy pointers, these only work if the proper pretty-printer is written for the fancy pointer type itself.
 * Fixed `std::initializer_list` assignment issues for open-addressing containers
 ({github-pr-url}/277[PR#277^]).
+* Allowed non-copyable callables to be passed to the `std::initializer_list` overloads of `insert_{and|or}_[c]visit` for concurrent containers, by internally passing a `std::reference_wrapper` of the callable to the iterator-pair overloads.
 
 
 == Release 1.86.0

--- a/doc/unordered/concurrent_flat_map.adoc
+++ b/doc/unordered/concurrent_flat_map.adoc
@@ -1148,7 +1148,7 @@ template<class F> size_type insert_or_cvisit(std::initializer_list<value_type> i
 Equivalent to
 [listing,subs="+macros,+quotes"]
 -----
-  this->xref:#concurrent_flat_map_insert_iterator_range_or_visit[insert_or_[c\]visit](il.begin(), il.end(), f);
+  this->xref:#concurrent_flat_map_insert_iterator_range_or_visit[insert_or_[c\]visit](il.begin(), il.end(), std::ref(f));
 -----
 
 [horizontal]
@@ -1246,15 +1246,15 @@ Returns:;; The number of elements inserted.
 ==== Insert Initializer List and Visit
 ```c++
 template<class F1, class F2>
-  size_type insert_or_visit(std::initializer_list<value_type> il, F1 f1, F2 f2);
+  size_type insert_and_visit(std::initializer_list<value_type> il, F1 f1, F2 f2);
 template<class F1, class F2>
-  size_type insert_or_cvisit(std::initializer_list<value_type> il, F1 f1, F2 f2);
+  size_type insert_and_cvisit(std::initializer_list<value_type> il, F1 f1, F2 f2);
 ```
 
 Equivalent to
 [listing,subs="+macros,+quotes"]
 -----
-  this->xref:#concurrent_flat_map_insert_iterator_range_and_visit[insert_and_[c\]visit](il.begin(), il.end(), f1, f2);
+  this->xref:#concurrent_flat_map_insert_iterator_range_and_visit[insert_and_[c\]visit](il.begin(), il.end(), std::ref(f1), std::ref(f2));
 -----
 
 [horizontal]

--- a/doc/unordered/concurrent_flat_set.adoc
+++ b/doc/unordered/concurrent_flat_set.adoc
@@ -1106,7 +1106,7 @@ template<class F> size_type insert_or_cvisit(std::initializer_list<value_type> i
 Equivalent to
 [listing,subs="+macros,+quotes"]
 -----
-  this->xref:#concurrent_flat_set_insert_iterator_range_or_visit[insert_or_[c\]visit](il.begin(), il.end(), f);
+  this->xref:#concurrent_flat_set_insert_iterator_range_or_visit[insert_or_[c\]visit](il.begin(), il.end(), std::ref(f));
 -----
 
 [horizontal]
@@ -1222,7 +1222,7 @@ template<class F1, class F2>
 Equivalent to
 [listing,subs="+macros,+quotes"]
 -----
-  this->xref:#concurrent_flat_set_insert_iterator_range_and_visit[insert_and_[c\]visit](il.begin(), il.end(), f1, f2);
+  this->xref:#concurrent_flat_set_insert_iterator_range_and_visit[insert_and_[c\]visit](il.begin(), il.end(), std::ref(f1), std::ref(f2));
 -----
 
 [horizontal]

--- a/doc/unordered/concurrent_node_map.adoc
+++ b/doc/unordered/concurrent_node_map.adoc
@@ -1207,7 +1207,7 @@ template<class F> size_type insert_or_cvisit(std::initializer_list<value_type> i
 Equivalent to
 [listing,subs="+macros,+quotes"]
 -----
-  this->xref:#concurrent_node_map_insert_iterator_range_or_visit[insert_or_[c\]visit](il.begin(), il.end(), f);
+  this->xref:#concurrent_node_map_insert_iterator_range_or_visit[insert_or_[c\]visit](il.begin(), il.end(), std::ref(f));
 -----
 
 [horizontal]
@@ -1320,15 +1320,15 @@ Returns:;; The number of elements inserted.
 ==== Insert Initializer List and Visit
 ```c++
 template<class F1, class F2>
-  size_type insert_or_visit(std::initializer_list<value_type> il, F1 f1, F2 f2);
+  size_type insert_and_visit(std::initializer_list<value_type> il, F1 f1, F2 f2);
 template<class F1, class F2>
-  size_type insert_or_cvisit(std::initializer_list<value_type> il, F1 f1, F2 f2);
+  size_type insert_and_cvisit(std::initializer_list<value_type> il, F1 f1, F2 f2);
 ```
 
 Equivalent to
 [listing,subs="+macros,+quotes"]
 -----
-  this->xref:#concurrent_node_map_insert_iterator_range_and_visit[insert_and_[c\]visit](il.begin(), il.end(), f1, f2);
+  this->xref:#concurrent_node_map_insert_iterator_range_and_visit[insert_and_[c\]visit](il.begin(), il.end(), std::ref(f1), std::ref(f2));
 -----
 
 [horizontal]

--- a/doc/unordered/concurrent_node_set.adoc
+++ b/doc/unordered/concurrent_node_set.adoc
@@ -1164,7 +1164,7 @@ template<class F> size_type insert_or_cvisit(std::initializer_list<value_type> i
 Equivalent to
 [listing,subs="+macros,+quotes"]
 -----
-  this->xref:#concurrent_node_set_insert_iterator_range_or_visit[insert_or_[c\]visit](il.begin(), il.end(), f);
+  this->xref:#concurrent_node_set_insert_iterator_range_or_visit[insert_or_[c\]visit](il.begin(), il.end(), std::ref(f));
 -----
 
 [horizontal]
@@ -1295,7 +1295,7 @@ template<class F1, class F2>
 Equivalent to
 [listing,subs="+macros,+quotes"]
 -----
-  this->xref:#concurrent_node_set_insert_iterator_range_and_visit[insert_and_[c\]visit](il.begin(), il.end(), f1, f2);
+  this->xref:#concurrent_node_set_insert_iterator_range_and_visit[insert_and_[c\]visit](il.begin(), il.end(), std::ref(f1), std::ref(f2));
 -----
 
 [horizontal]

--- a/include/boost/unordered/concurrent_flat_map.hpp
+++ b/include/boost/unordered/concurrent_flat_map.hpp
@@ -487,7 +487,7 @@ namespace boost {
       size_type insert_or_visit(std::initializer_list<value_type> ilist, F f)
       {
         BOOST_UNORDERED_STATIC_ASSERT_INVOCABLE(F)
-        return this->insert_or_visit(ilist.begin(), ilist.end(), f);
+        return this->insert_or_visit(ilist.begin(), ilist.end(), std::ref(f));
       }
 
       template <class Ty, class F>
@@ -520,7 +520,7 @@ namespace boost {
       size_type insert_or_cvisit(std::initializer_list<value_type> ilist, F f)
       {
         BOOST_UNORDERED_STATIC_ASSERT_CONST_INVOCABLE(F)
-        return this->insert_or_cvisit(ilist.begin(), ilist.end(), f);
+        return this->insert_or_cvisit(ilist.begin(), ilist.end(), std::ref(f));
       }
 
       template <class Ty, class F1, class F2>
@@ -559,7 +559,8 @@ namespace boost {
       {
         BOOST_UNORDERED_STATIC_ASSERT_INVOCABLE(F1)
         BOOST_UNORDERED_STATIC_ASSERT_INVOCABLE(F2)
-        return this->insert_and_visit(ilist.begin(), ilist.end(), f1, f2);
+        return this->insert_and_visit(
+          ilist.begin(), ilist.end(), std::ref(f1), std::ref(f2));
       }
 
       template <class Ty, class F1, class F2>
@@ -598,7 +599,8 @@ namespace boost {
       {
         BOOST_UNORDERED_STATIC_ASSERT_INVOCABLE(F1)
         BOOST_UNORDERED_STATIC_ASSERT_CONST_INVOCABLE(F2)
-        return this->insert_and_cvisit(ilist.begin(), ilist.end(), f1, f2);
+        return this->insert_and_cvisit(
+          ilist.begin(), ilist.end(), std::ref(f1), std::ref(f2));
       }
 
       template <class... Args> BOOST_FORCEINLINE bool emplace(Args&&... args)

--- a/include/boost/unordered/concurrent_flat_set.hpp
+++ b/include/boost/unordered/concurrent_flat_set.hpp
@@ -478,7 +478,7 @@ namespace boost {
       size_type insert_or_visit(std::initializer_list<value_type> ilist, F f)
       {
         BOOST_UNORDERED_STATIC_ASSERT_CONST_INVOCABLE(F)
-        return this->insert_or_visit(ilist.begin(), ilist.end(), f);
+        return this->insert_or_visit(ilist.begin(), ilist.end(), std::ref(f));
       }
 
       template <class F>
@@ -520,7 +520,7 @@ namespace boost {
       size_type insert_or_cvisit(std::initializer_list<value_type> ilist, F f)
       {
         BOOST_UNORDERED_STATIC_ASSERT_CONST_INVOCABLE(F)
-        return this->insert_or_cvisit(ilist.begin(), ilist.end(), f);
+        return this->insert_or_cvisit(ilist.begin(), ilist.end(), std::ref(f));
       }
 
       template <class F1, class F2>
@@ -569,7 +569,8 @@ namespace boost {
       {
         BOOST_UNORDERED_STATIC_ASSERT_CONST_INVOCABLE(F1)
         BOOST_UNORDERED_STATIC_ASSERT_CONST_INVOCABLE(F2)
-        return this->insert_and_visit(ilist.begin(), ilist.end(), f1, f2);
+        return this->insert_and_visit(
+          ilist.begin(), ilist.end(), std::ref(f1), std::ref(f2));
       }
 
       template <class F1, class F2>
@@ -619,7 +620,8 @@ namespace boost {
       {
         BOOST_UNORDERED_STATIC_ASSERT_CONST_INVOCABLE(F1)
         BOOST_UNORDERED_STATIC_ASSERT_CONST_INVOCABLE(F2)
-        return this->insert_and_cvisit(ilist.begin(), ilist.end(), f1, f2);
+        return this->insert_and_cvisit(
+          ilist.begin(), ilist.end(), std::ref(f1), std::ref(f2));
       }
 
       template <class... Args> BOOST_FORCEINLINE bool emplace(Args&&... args)

--- a/include/boost/unordered/concurrent_node_map.hpp
+++ b/include/boost/unordered/concurrent_node_map.hpp
@@ -513,7 +513,7 @@ namespace boost {
       size_type insert_or_visit(std::initializer_list<value_type> ilist, F f)
       {
         BOOST_UNORDERED_STATIC_ASSERT_INVOCABLE(F)
-        return this->insert_or_visit(ilist.begin(), ilist.end(), f);
+        return this->insert_or_visit(ilist.begin(), ilist.end(), std::ref(f));
       }
 
       template <class F>
@@ -567,7 +567,7 @@ namespace boost {
       size_type insert_or_cvisit(std::initializer_list<value_type> ilist, F f)
       {
         BOOST_UNORDERED_STATIC_ASSERT_CONST_INVOCABLE(F)
-        return this->insert_or_cvisit(ilist.begin(), ilist.end(), f);
+        return this->insert_or_cvisit(ilist.begin(), ilist.end(), std::ref(f));
       }
 
       template <class F>
@@ -627,7 +627,8 @@ namespace boost {
       {
         BOOST_UNORDERED_STATIC_ASSERT_INVOCABLE(F1)
         BOOST_UNORDERED_STATIC_ASSERT_INVOCABLE(F2)
-        return this->insert_and_visit(ilist.begin(), ilist.end(), f1, f2);
+        return this->insert_and_visit(
+          ilist.begin(), ilist.end(), std::ref(f1), std::ref(f2));
       }
 
       template <class F1, class F2>
@@ -688,7 +689,8 @@ namespace boost {
       {
         BOOST_UNORDERED_STATIC_ASSERT_INVOCABLE(F1)
         BOOST_UNORDERED_STATIC_ASSERT_CONST_INVOCABLE(F2)
-        return this->insert_and_cvisit(ilist.begin(), ilist.end(), f1, f2);
+        return this->insert_and_cvisit(
+          ilist.begin(), ilist.end(), std::ref(f1), std::ref(f2));
       }
 
       template <class F1, class F2>

--- a/include/boost/unordered/concurrent_node_set.hpp
+++ b/include/boost/unordered/concurrent_node_set.hpp
@@ -504,7 +504,7 @@ namespace boost {
       size_type insert_or_visit(std::initializer_list<value_type> ilist, F f)
       {
         BOOST_UNORDERED_STATIC_ASSERT_CONST_INVOCABLE(F)
-        return this->insert_or_visit(ilist.begin(), ilist.end(), f);
+        return this->insert_or_visit(ilist.begin(), ilist.end(), std::ref(f));
       }
 
       template <class F>
@@ -567,7 +567,7 @@ namespace boost {
       size_type insert_or_cvisit(std::initializer_list<value_type> ilist, F f)
       {
         BOOST_UNORDERED_STATIC_ASSERT_CONST_INVOCABLE(F)
-        return this->insert_or_cvisit(ilist.begin(), ilist.end(), f);
+        return this->insert_or_cvisit(ilist.begin(), ilist.end(), std::ref(f));
       }
 
       template <class F>
@@ -638,7 +638,8 @@ namespace boost {
       {
         BOOST_UNORDERED_STATIC_ASSERT_CONST_INVOCABLE(F1)
         BOOST_UNORDERED_STATIC_ASSERT_CONST_INVOCABLE(F2)
-        return this->insert_and_visit(ilist.begin(), ilist.end(), f1, f2);
+        return this->insert_and_visit(
+          ilist.begin(), ilist.end(), std::ref(f1), std::ref(f2));
       }
 
       template <class F1, class F2>
@@ -710,7 +711,8 @@ namespace boost {
       {
         BOOST_UNORDERED_STATIC_ASSERT_CONST_INVOCABLE(F1)
         BOOST_UNORDERED_STATIC_ASSERT_CONST_INVOCABLE(F2)
-        return this->insert_and_cvisit(ilist.begin(), ilist.end(), f1, f2);
+        return this->insert_and_cvisit(
+          ilist.begin(), ilist.end(), std::ref(f1), std::ref(f2));
       }
 
       template <class F1, class F2>

--- a/include/boost/unordered/detail/concurrent_static_asserts.hpp
+++ b/include/boost/unordered/detail/concurrent_static_asserts.hpp
@@ -13,10 +13,7 @@
 #include <boost/config.hpp>
 #include <boost/mp11/algorithm.hpp>
 #include <boost/mp11/list.hpp>
-
-#include <functional>
-#include <iterator>
-#include <type_traits>
+#include <boost/unordered/detail/type_traits.hpp>
 
 #define BOOST_UNORDERED_STATIC_ASSERT_INVOCABLE(F)                             \
   static_assert(boost::unordered::detail::is_invocable<F, value_type&>::value, \
@@ -79,12 +76,19 @@
 namespace boost {
   namespace unordered {
     namespace detail {
-      template <class F, class... Args>
-      struct is_invocable
-          : std::is_constructible<std::function<void(Args...)>,
-              std::reference_wrapper<typename std::remove_reference<F>::type> >
+      template <class...> struct is_invocable_helper : std::false_type
       {
       };
+
+      template <class F, class... Args>
+      struct is_invocable_helper<
+        void_t<decltype(std::declval<F>()(std::declval<Args>()...))>, F,
+        Args...> : std::true_type
+      {
+      };
+
+      template <class F, class... Args>
+      using is_invocable = is_invocable_helper<void, F, Args...>;
 
     } // namespace detail
 

--- a/test/cfoa/insert_tests.cpp
+++ b/test/cfoa/insert_tests.cpp
@@ -947,6 +947,14 @@ namespace {
     }
   } iterator_range_insert_and_visit;
 
+  struct non_copyable_function
+  {
+    non_copyable_function() = default;
+    non_copyable_function(const non_copyable_function&) = delete;
+    non_copyable_function(non_copyable_function&&) = default;
+    template <class... Args> void operator()(Args&&...) const {}
+  };
+
   template <class X, class GF, class F>
   void insert(X*, GF gen_factory, F inserter, test::random_generator rg)
   {
@@ -1047,6 +1055,9 @@ namespace {
                             ++num_invokes;
                           }),
             init_list.size());
+
+          x.insert_or_visit(init_list, non_copyable_function{});
+          x.insert_or_cvisit(init_list, non_copyable_function{});
         });
 
         BOOST_TEST_EQ(num_invokes, (init_list.size() - x.size()) +
@@ -1105,6 +1116,11 @@ namespace {
                               ++num_invokes;
                             }),
               init_list.size());
+
+            x.insert_and_visit(
+              init_list, non_copyable_function{}, non_copyable_function{});
+            x.insert_and_cvisit(
+              init_list, non_copyable_function{}, non_copyable_function{});
           });
 
         BOOST_TEST_EQ(num_inserts, x.size());


### PR DESCRIPTION
…in std::initializer_list overloads of insert_{or|and}_[c]visit

Closes #285 