### PR TITLE
update ui bundle

### DIFF
--- a/doc/unordered-playbook.yml
+++ b/doc/unordered-playbook.yml
@@ -10,5 +10,5 @@ output:
   dir: html
 ui:
   bundle:
-    url: https://github.com/cmazakas/unordered-ui-bundle/raw/450505aa457796028a36e9d712e5d52f9f394c1a/ui-bundle.zip
+    url: https://github.com/cmazakas/unordered-ui-bundle/raw/c80db72a7ba804256beb36e3a46d9c7df265d8d7/ui-bundle.zip
   output_dir: unordered/_


### PR DESCRIPTION
I've removed all the top-padding that made the deployed version of the docs look awkward.

Here's some previews of what locally edited versions look like that I tried to recreate the fixes for here: https://github.com/cmazakas/unordered-ui-bundle/commit/7096ecdf6924d46f52b49ff940ac0418f40d142b


![Screenshot From 2025-01-21 10-57-33](https://github.com/user-attachments/assets/feeaf98e-7b02-4392-9105-3214a514f98e)
![Screenshot From 2025-01-21 10-59-22](https://github.com/user-attachments/assets/eeeb6d00-84ea-47e2-9a43-324155ae025d)
