### PR TITLE
documented non-const reference passing to `erase_if`

### DIFF
--- a/doc/modules/ROOT/pages/reference/concurrent_flat_map.adoc
+++ b/doc/modules/ROOT/pages/reference/concurrent_flat_map.adoc
@@ -1429,7 +1429,9 @@ Erases the element `x` with key equivalent to `k` if it exists and `f(x)` is `tr
 [horizontal]
 Returns:;; The number of elements erased (0 or 1).
 Throws:;; Only throws an exception if it is thrown by `hasher`, `key_equal` or `f`.
-Notes:;; The `template<class K, class F>` overload only participates in overload resolution if `std::is_execution_policy_v<std::remove_cvref_t<ExecutionPolicy>>` is `false`. +
+Notes:;; `f` is passed a non-const reference to `x`. +
++
+The `template<class K, class F>` overload only participates in overload resolution if `std::is_execution_policy_v<std::remove_cvref_t<ExecutionPolicy>>` is `false`. +
 +
 The `template<class K, class F>` overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
 
@@ -1440,7 +1442,7 @@ The `template<class K, class F>` overload only participates in overload resoluti
 template<class F> size_type erase_if(F f);
 ```
 
-Successively invokes `f` with references to each of the elements in the table, and erases those for which `f` returns `true`.
+Successively invokes `f` with non-const references to each of the elements in the table, and erases those for which `f` returns `true`.
 
 [horizontal]
 Returns:;; The number of elements erased.
@@ -1453,7 +1455,7 @@ Throws:;; Only throws an exception if it is thrown by `f`.
 template<class ExecutionPolicy, class  F> void erase_if(ExecutionPolicy&& policy, F f);
 ```
 
-Invokes `f` with references to each of the elements in the table, and erases those for which `f` returns `true`.
+Invokes `f` with non-const references to each of the elements in the table, and erases those for which `f` returns `true`.
 Execution is parallelized according to the semantics of the execution policy specified.
 
 [horizontal]

--- a/doc/modules/ROOT/pages/reference/concurrent_node_map.adoc
+++ b/doc/modules/ROOT/pages/reference/concurrent_node_map.adoc
@@ -1519,7 +1519,9 @@ Erases the element `x` with key equivalent to `k` if it exists and `f(x)` is `tr
 [horizontal]
 Returns:;; The number of elements erased (0 or 1).
 Throws:;; Only throws an exception if it is thrown by `hasher`, `key_equal` or `f`.
-Notes:;; The `template<class K, class F>` overload only participates in overload resolution if `std::is_execution_policy_v<std::remove_cvref_t<ExecutionPolicy>>` is `false`. +
+Notes:;; `f` is passed a non-const reference to `x`. +
++
+The `template<class K, class F>` overload only participates in overload resolution if `std::is_execution_policy_v<std::remove_cvref_t<ExecutionPolicy>>` is `false`. +
 +
 The `template<class K, class F>` overload only participates in overload resolution if `Hash::is_transparent` and `Pred::is_transparent` are valid member typedefs. The library assumes that `Hash` is callable with both `K` and `Key` and that `Pred` is transparent. This enables heterogeneous lookup which avoids the cost of instantiating an instance of the `Key` type.
 
@@ -1530,7 +1532,7 @@ The `template<class K, class F>` overload only participates in overload resoluti
 template<class F> size_type erase_if(F f);
 ```
 
-Successively invokes `f` with references to each of the elements in the table, and erases those for which `f` returns `true`.
+Successively invokes `f` with non-const references to each of the elements in the table, and erases those for which `f` returns `true`.
 
 [horizontal]
 Returns:;; The number of elements erased.
@@ -1543,7 +1545,7 @@ Throws:;; Only throws an exception if it is thrown by `f`.
 template<class ExecutionPolicy, class  F> void erase_if(ExecutionPolicy&& policy, F f);
 ```
 
-Invokes `f` with references to each of the elements in the table, and erases those for which `f` returns `true`.
+Invokes `f` with non-const references to each of the elements in the table, and erases those for which `f` returns `true`.
 Execution is parallelized according to the semantics of the execution policy specified.
 
 [horizontal]

--- a/doc/modules/ROOT/pages/reference/unordered_flat_map.adoc
+++ b/doc/modules/ROOT/pages/reference/unordered_flat_map.adoc
@@ -1514,6 +1514,8 @@ for (auto i = c.begin(), last = c.end(); i != last; ) {
 }
 return original_size - c.size();
 ```
++
+Note that the references passed to `pred` are non-const.
 
 === Serialization
 

--- a/doc/modules/ROOT/pages/reference/unordered_map.adoc
+++ b/doc/modules/ROOT/pages/reference/unordered_map.adoc
@@ -1766,7 +1766,9 @@ for (auto i = c.begin(), last = c.end(); i != last; ) {
   }
 }
 return original_size - c.size();
-```
+``` 
++
+Note that the references passed to `pred` are non-const.
 
 === Serialization
 

--- a/doc/modules/ROOT/pages/reference/unordered_multimap.adoc
+++ b/doc/modules/ROOT/pages/reference/unordered_multimap.adoc
@@ -1486,6 +1486,8 @@ for (auto i = c.begin(), last = c.end(); i != last; ) {
 }
 return original_size - c.size();
 ```
++
+Note that the references passed to `pred` are non-const.
 
 === Serialization
 

--- a/doc/modules/ROOT/pages/reference/unordered_node_map.adoc
+++ b/doc/modules/ROOT/pages/reference/unordered_node_map.adoc
@@ -1618,6 +1618,8 @@ for (auto i = c.begin(), last = c.end(); i != last; ) {
 }
 return original_size - c.size();
 ```
++
+Note that the references passed to `pred` are non-const.
 
 === Serialization
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -408,8 +408,8 @@ run cfoa/serialization_tests.cpp
       <library>/boost/serialization//boost_serialization/<warnings>off
       <library>/boost/container//boost_container/<warnings-as-errors>off
       <toolset>gcc,<target-os>windows:<build>no # Boost.Atomic no longer supports MinGW
-      <toolset>gcc,<thread-sanitizer>:norecover<build>no # TSAN does not support atomic_thread_fence
-      <toolset>clang,<thread-sanitizer>:norecover<build>no # idem
+      <toolset>gcc,<thread-sanitizer>norecover:<build>no # TSAN does not support atomic_thread_fence
+      <toolset>clang,<thread-sanitizer>norecover:<build>no # idem
     : cfoa_serialization_tests ;
 
 rule make_cfoa_interprocess_concurrency_tests ( name : defines ? )

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -157,7 +157,8 @@ run unordered/serialization_tests.cpp
       <toolset>clang:<inlining>on
       <toolset>clang:<optimization>space
       <library>/boost/serialization//boost_serialization/<warnings>off
-      <library>/boost/container//boost_container/<warnings-as-errors>off ;
+      <library>/boost/container//boost_container/<warnings-as-errors>off
+      <toolset>gcc,<target-os>windows:<build>no ;
 
 compile-fail unordered/insert_node_type_fail.cpp : <define>UNORDERED_TEST_MAP      : insert_node_type_fail_map ;
 compile-fail unordered/insert_node_type_fail.cpp : <define>UNORDERED_TEST_MULTIMAP : insert_node_type_fail_multimap ;
@@ -268,6 +269,7 @@ run unordered/serialization_tests.cpp
       <toolset>clang:<optimization>space
       <library>/boost/serialization//boost_serialization/<warnings>off
       <library>/boost/container//boost_container/<warnings-as-errors>off
+      <toolset>gcc,<target-os>windows:<build>no
     : foa_serialization_tests ;
 
 local FOA_EXCEPTION_TESTS =
@@ -405,6 +407,7 @@ run cfoa/serialization_tests.cpp
       <toolset>clang:<optimization>space
       <library>/boost/serialization//boost_serialization/<warnings>off
       <library>/boost/container//boost_container/<warnings-as-errors>off
+      <toolset>gcc,<target-os>windows:<build>no
     : cfoa_serialization_tests ;
 
 rule make_cfoa_interprocess_concurrency_tests ( name : defines ? )

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -156,7 +156,8 @@ run unordered/serialization_tests.cpp
       <toolset>gcc:<optimization>space
       <toolset>clang:<inlining>on
       <toolset>clang:<optimization>space
-      <library>/boost/serialization//boost_serialization/<warnings>off ;
+      <library>/boost/serialization//boost_serialization/<warnings>off
+      <library>/boost/container//boost_container/<warnings-as-errors>off ;
 
 compile-fail unordered/insert_node_type_fail.cpp : <define>UNORDERED_TEST_MAP      : insert_node_type_fail_map ;
 compile-fail unordered/insert_node_type_fail.cpp : <define>UNORDERED_TEST_MULTIMAP : insert_node_type_fail_multimap ;
@@ -266,6 +267,7 @@ run unordered/serialization_tests.cpp
       <toolset>clang:<inlining>on
       <toolset>clang:<optimization>space
       <library>/boost/serialization//boost_serialization/<warnings>off
+      <library>/boost/container//boost_container/<warnings-as-errors>off
     : foa_serialization_tests ;
 
 local FOA_EXCEPTION_TESTS =
@@ -402,6 +404,7 @@ run cfoa/serialization_tests.cpp
       <toolset>clang:<inlining>on
       <toolset>clang:<optimization>space
       <library>/boost/serialization//boost_serialization/<warnings>off
+      <library>/boost/container//boost_container/<warnings-as-errors>off
     : cfoa_serialization_tests ;
 
 rule make_cfoa_interprocess_concurrency_tests ( name : defines ? )

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -408,8 +408,8 @@ run cfoa/serialization_tests.cpp
       <library>/boost/serialization//boost_serialization/<warnings>off
       <library>/boost/container//boost_container/<warnings-as-errors>off
       <toolset>gcc,<target-os>windows:<build>no # Boost.Atomic no longer supports MinGW
-      <toolset>gcc,<sanitize>thread:<build>no # TSAN does not support atomic_thread_fence
-      <toolset>clang,<sanitize>thread:<build>no # idem
+      <toolset>gcc,<thread-sanitizer>on:<build>no # TSAN does not support atomic_thread_fence
+      <toolset>clang,<thread-sanitizer>on:<build>no # idem
     : cfoa_serialization_tests ;
 
 rule make_cfoa_interprocess_concurrency_tests ( name : defines ? )

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -408,6 +408,8 @@ run cfoa/serialization_tests.cpp
       <library>/boost/serialization//boost_serialization/<warnings>off
       <library>/boost/container//boost_container/<warnings-as-errors>off
       <toolset>gcc,<target-os>windows:<build>no # Boost.Atomic no longer supports MinGW
+      <toolset>gcc,<sanitize>thread:<build>no # TSAN does not support atomic_thread_fence
+      <toolset>clang,<sanitize>thread:<build>no # idem
     : cfoa_serialization_tests ;
 
 rule make_cfoa_interprocess_concurrency_tests ( name : defines ? )

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -408,8 +408,8 @@ run cfoa/serialization_tests.cpp
       <library>/boost/serialization//boost_serialization/<warnings>off
       <library>/boost/container//boost_container/<warnings-as-errors>off
       <toolset>gcc,<target-os>windows:<build>no # Boost.Atomic no longer supports MinGW
-      <toolset>gcc,<thread-sanitizer>on:<build>no # TSAN does not support atomic_thread_fence
-      <toolset>clang,<thread-sanitizer>on:<build>no # idem
+      <toolset>gcc,<thread-sanitizer>:norecover<build>no # TSAN does not support atomic_thread_fence
+      <toolset>clang,<thread-sanitizer>:norecover<build>no # idem
     : cfoa_serialization_tests ;
 
 rule make_cfoa_interprocess_concurrency_tests ( name : defines ? )

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -158,7 +158,7 @@ run unordered/serialization_tests.cpp
       <toolset>clang:<optimization>space
       <library>/boost/serialization//boost_serialization/<warnings>off
       <library>/boost/container//boost_container/<warnings-as-errors>off
-      <toolset>gcc,<target-os>windows:<build>no ;
+      <toolset>gcc,<target-os>windows:<build>no ; # Boost.Atomic no longer supports MinGW
 
 compile-fail unordered/insert_node_type_fail.cpp : <define>UNORDERED_TEST_MAP      : insert_node_type_fail_map ;
 compile-fail unordered/insert_node_type_fail.cpp : <define>UNORDERED_TEST_MULTIMAP : insert_node_type_fail_multimap ;
@@ -269,7 +269,7 @@ run unordered/serialization_tests.cpp
       <toolset>clang:<optimization>space
       <library>/boost/serialization//boost_serialization/<warnings>off
       <library>/boost/container//boost_container/<warnings-as-errors>off
-      <toolset>gcc,<target-os>windows:<build>no
+      <toolset>gcc,<target-os>windows:<build>no # Boost.Atomic no longer supports MinGW
     : foa_serialization_tests ;
 
 local FOA_EXCEPTION_TESTS =
@@ -407,7 +407,7 @@ run cfoa/serialization_tests.cpp
       <toolset>clang:<optimization>space
       <library>/boost/serialization//boost_serialization/<warnings>off
       <library>/boost/container//boost_container/<warnings-as-errors>off
-      <toolset>gcc,<target-os>windows:<build>no
+      <toolset>gcc,<target-os>windows:<build>no # Boost.Atomic no longer supports MinGW
     : cfoa_serialization_tests ;
 
 rule make_cfoa_interprocess_concurrency_tests ( name : defines ? )

--- a/test/unordered/erase_if.cpp
+++ b/test/unordered/erase_if.cpp
@@ -1,4 +1,5 @@
 // Copyright 2021-2022 Christian Mazakas.
+// Copyright 2025 Joaquin M Lopez Munoz.
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
@@ -42,7 +43,34 @@ namespace test {
     }
   };
 
+  template <class T>
+  struct non_const_pred;
+
+  template<class T, class U>
+  struct non_const_pred<std::pair<const T, U> >
+  {
+    bool operator()(std::pair<const T, U>& x) const
+    {
+      U u = std::move(x.second);
+      (void)u;
+      return true;
+    }
+  };
+
 } // namespace test
+
+template <class UnorderedMap> void test_map_nonconst_erase_if()
+{
+  typedef UnorderedMap map_type;
+  typedef typename map_type::value_type value_type;
+  typedef typename map_type::size_type size_type;
+
+  map_type m;
+  m.insert(value_type());
+  size_type num_erased = erase_if(m, test::non_const_pred<value_type>());
+  BOOST_TEST(m.empty());
+  BOOST_TEST_EQ(num_erased, 1u);
+}
 
 template <class UnorderedMap> void test_map_erase_if()
 {
@@ -71,6 +99,8 @@ template <class UnorderedMap> void test_map_erase_if()
   num_erased = erase_if(map, test::is_even());
   BOOST_TEST_EQ(map.size(), 2u);
   BOOST_TEST_EQ(num_erased, size - map.size());
+
+  test_map_nonconst_erase_if<map_type>();
 }
 
 template <class UnorderedSet> void test_set_erase_if()


### PR DESCRIPTION
This merely documents the status quo by which `erase_if` for maps passes non-const references to the user-provided predicate. Mentioned in this [this conversation](https://github.com/boostorg/unordered/issues/308#issuecomment-2774518565).