### PR TITLE
removed ccache for macos-13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,8 +117,8 @@ jobs:
               stdlib: libc++, install: 'clang-18 libc++-18-dev libc++abi-18-dev', ccache_key: "tsan" }
 
           # OSX, clang
-          - { compiler: clang, cxxstd: '11,14,17,20,2b', os: 'macos-13', sanitize: yes }
-          - { compiler: clang, cxxstd: '11,14,17,20,2b', os: 'macos-13', thread-sanitize: yes, targets: 'libs/unordered/test//cfoa_tests' }
+          - { compiler: clang, cxxstd: '11,14,17,20,2b', os: 'macos-13', sanitize: yes, ccache: no, ccache_key: "san1" }
+          - { compiler: clang, cxxstd: '11,14,17,20,2b', os: 'macos-13', thread-sanitize: yes, targets: 'libs/unordered/test//cfoa_tests', ccache: no, ccache_key: "tsan" }
           - { compiler: clang, cxxstd: '11,14,17,20,2b', os: 'macos-14' }
           - { compiler: clang, cxxstd: '11,14,17,20,2b', os: 'macos-15' }
 


### PR DESCRIPTION
Homebrew support for ccache on MacOS 13 has entered Tier 3.