### PR TITLE
Drone: llvm apt installation

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -34,8 +34,9 @@ local linux_pipeline(name, image, environment, packages = "", sources = [], arch
             commands:
             [
                 'set -e',
+                'echo $DRONE_STAGE_MACHINE',
                 'uname -a',
-                'wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -',
+                'curl -sSL --retry 5 https://apt.llvm.org/llvm-snapshot.gpg.key | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/llvm-snapshot.gpg',
             ] +
             (if sources != [] then [ ('apt-add-repository "' + source + '"') for source in sources ] else []) +
             (if packages != "" then [ 'apt-get update', 'apt-get -y install ' + packages ] else []) +
@@ -66,6 +67,8 @@ local macos_pipeline(name, environment, xcode_version = "12.2", osx_version = "c
             environment: environment + { "DEVELOPER_DIR": "/Applications/Xcode-" + xcode_version + ".app/Contents/Developer" },
             commands:
             [
+                'echo $DRONE_STAGE_MACHINE',
+                'sw_vers',
                 'uname -a',
                 'export LIBRARY=' + library,
                 './.drone/drone.sh',


### PR DESCRIPTION
- `apt-key` is deprecated
- `curl` will retry on more conditions than `wget`
- move debugging output $DRONE_STAGE_MACHINE to as early as possible in the script

If this goes well and tests are passing, then it's worthwhile to copy over to any other repos also.  
