### PR TITLE
Docs: download extension

### DIFF
--- a/doc/package-lock.json
+++ b/doc/package-lock.json
@@ -5,6 +5,9 @@
     "packages": {
         "": {
             "name": "doc",
+            "dependencies": {
+                "@cppalliance/antora-downloads-extension": "^0.0.2"
+            },
             "devDependencies": {
                 "@antora/cli": ">=3.1.14",
                 "@antora/site-generator": ">=3.1.14",
@@ -286,6 +289,12 @@
                 "npm": ">=5.0.0",
                 "yarn": ">=1.1.0"
             }
+        },
+        "node_modules/@cppalliance/antora-downloads-extension": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/@cppalliance/antora-downloads-extension/-/antora-downloads-extension-0.0.2.tgz",
+            "integrity": "sha512-2wXahlvRz9J75ZSfzDeP4XpIZiqIm+w/YjmCWJxFPp6oWgP7e8f6ps7HqdtHNGxnK5mG38OjiCFdHjmHYfgbDA==",
+            "license": "BSL-1.0"
         },
         "node_modules/@iarna/toml": {
             "version": "2.2.5",

--- a/doc/package.json
+++ b/doc/package.json
@@ -3,5 +3,8 @@
       "@antora/cli": ">=3.1.14",
       "@antora/site-generator": ">=3.1.14",
       "antora": ">=3.1.14"
+    },
+    "dependencies": {
+      "@cppalliance/antora-downloads-extension": "^0.0.2"
     }
   }

--- a/doc/unordered-playbook.yml
+++ b/doc/unordered-playbook.yml
@@ -12,3 +12,7 @@ ui:
   bundle:
     url: https://github.com/boostorg/unordered-ui-bundle/raw/c80db72a7ba804256beb36e3a46d9c7df265d8d7/ui-bundle.zip
   output_dir: unordered/_
+
+antora:
+  extensions:
+    - require: '@cppalliance/antora-downloads-extension'


### PR DESCRIPTION
When building antora docs, retry the UI download if it fails.

Generally, any network downloads in any build scripts should be configured to retry.   

For example, `curl` has options `--retry` and `--retry-all-errors`.   

source code: https://github.com/cppalliance/antora-downloads-extension
