### PR TITLE
simplified doc/Jamfile.v2

### DIFF
--- a/doc/Jamfile.v2
+++ b/doc/Jamfile.v2
@@ -1,57 +1,23 @@
-import generate ;
-import path ;
-import property-set ;
-import virtual-target ;
+# Copyright 2026 Joaquin M Lopez Munoz
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-path-constant HERE : . ;
+make html_ : build_antora.sh : @run-script ;
 
-make html/index.html : build_antora.sh : @run-script ;
-generate files-to-install : html/index.html : <generating-rule>@delayed-glob ;
-install install
-  : files-to-install
-  : <location>html
-    <install-source-root>html/unordered
-  ;
-explicit html/index.html files-to-install ;
-
-# this runs the antora script
 actions run-script
 {
     bash $(>)
 }
 
-# this globs after its sources are created
-rule delayed-glob ( project name : property-set : sources * )
+make cleanup_node_modules_ : html_ : @cleanup-node-modules ;
+
+actions cleanup-node-modules
 {
-  for local src in $(sources)
-  {
-    # the next line causes the source to be generated immediately
-    # and not later (which it normally would)
-    UPDATE_NOW [ $(src).actualize ] ;
-  }
-
-  # we need to construct the path to the globbed directory;
-  # this path would be <current-project>/antora
-  local root = [ path.root html [ $(project).location ] ] ;
-  local files ;
-
-  # actual globbing happens here
-  for local file in [ path.glob-tree $(root) : * ]
-  {
-    # we have to skip directories, because our match expression accepts anything
-    if [ CHECK_IF_FILE $(file) ]
-    {
-      # we construct a list of targets to copy
-      files += [ virtual-target.from-file $(file:D=) : $(file:D) : $(project) ] ;
-    }
-  }
-
-  # we prepend empty usage requirements to the result
-  return [ property-set.empty ] $(files) ;
+    bash -c "rm -rf node_modules"
 }
 
 ###############################################################################
 alias boostdoc ;
 explicit boostdoc ;
-alias boostrelease : install ;
+alias boostrelease : html_ ;
 explicit boostrelease ;


### PR DESCRIPTION
* Removed `install` step as it duplicated generated HTML files and Antora already puts its output in the final destination anyway.
* Deletes subdirectory `node_modules` after Antora generation: this directory has slipped previously in release archives (seemingly, only `bin` directories are automatically located and removed).

Fixes #330.