### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/test/cmake_subdir_test/CMakeLists.txt
+++ b/test/cmake_subdir_test/CMakeLists.txt
@@ -22,7 +22,6 @@ move
 mp11
 predef
 preprocessor
-static_assert
 throw_exception
 tuple
 type_traits


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.