### PR TITLE
Fix float bugs in reserve_for_insert and min_buckets

### DIFF
--- a/include/boost/unordered/detail/implementation.hpp
+++ b/include/boost/unordered/detail/implementation.hpp
@@ -1,6 +1,6 @@
 // Copyright (C) 2003-2004 Jeremy B. Maitin-Shepard.
 // Copyright (C) 2005-2016 Daniel James
-// Copyright (C) 2022-2024 Joaquin M Lopez Munoz.
+// Copyright (C) 2022-2026 Joaquin M Lopez Munoz.
 // Copyright (C) 2022-2023 Christian Mazakas
 // Copyright (C) 2024 Braden Ganetsky
 //
@@ -1781,7 +1781,7 @@ namespace boost {
 
         static std::size_t min_buckets(std::size_t num_elements, float mlf)
         {
-          std::size_t num_buckets = static_cast<std::size_t>(
+          std::size_t num_buckets = boost::unordered::detail::double_to_size(
             std::ceil(static_cast<float>(num_elements) / mlf));
 
           if (num_buckets == 0 && num_elements > 0) { // mlf == inf

--- a/include/boost/unordered/detail/implementation.hpp
+++ b/include/boost/unordered/detail/implementation.hpp
@@ -2712,8 +2712,9 @@ namespace boost {
       inline void table<Types>::reserve_for_insert(std::size_t num_elements)
       {
         if (num_elements > max_load_) {
-          std::size_t const num_buckets = static_cast<std::size_t>(
-            1.0f + std::ceil(static_cast<float>(num_elements) / mlf_));
+          std::size_t const num_buckets = (std::max)(
+            static_cast<std::size_t>(1.0f + std::ceil(static_cast<float>(num_elements) / mlf_)),
+            static_cast<std::size_t>(bucket_count() + 1));
 
           this->rehash_impl(num_buckets);
         }

--- a/test/unordered/rehash_tests.cpp
+++ b/test/unordered/rehash_tests.cpp
@@ -1,6 +1,7 @@
 
 // Copyright 2006-2009 Daniel James.
 // Copyright 2022-2023 Christian Mazakas.
+// Copyright 2026 Joaquin M Lopez Munoz.
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
@@ -587,6 +588,102 @@ namespace rehash_tests {
     }
   }
 
+  // White-box tests for https://github.com/boostorg/unordered/pull/348
+
+  struct failing_allocator_exception { std::size_t n; };
+
+  template<typename T>
+  struct failing_allocator
+  {
+    using value_type = T;
+
+    failing_allocator() = default;
+    template<typename U> failing_allocator(const failing_allocator<U>&) {}
+
+    T* allocate(std::size_t n) { throw failing_allocator_exception{n}; }
+    void deallocate(T*, std::size_t) { }
+
+    bool operator==(const failing_allocator&) const { return true; }
+    bool operator!=(const failing_allocator&) const { return false; }
+  };
+
+  using test_gh348_table = typename boost::unordered::detail::set<
+    failing_allocator<int>, int, boost::hash<int>, std::equal_to<int>>::table;
+  static std::size_t test_gh348_table_bucket_count = 0;
+
+} // namespace rehash_tests
+
+namespace boost {
+namespace unordered {
+namespace detail {
+
+  template<> 
+  auto ::rehash_tests::test_gh348_table::bucket_count() const ->
+    ::rehash_tests::test_gh348_table::size_type
+  {
+    return ::rehash_tests::test_gh348_table_bucket_count;
+  }
+
+} // namespace detail
+} // namespace unordered
+} // namespace boost
+
+namespace rehash_tests {
+
+  void test_gh348_1(int /* dummy for UNORDERED_TEST */)
+  {
+    using primes = boost::unordered::detail::prime_fmod_size<>;
+    const auto size_t_max = (std::numeric_limits<std::size_t>::max)();
+
+    for(double mlf = 0.1; mlf < 10.0; mlf += 0.1) {
+      for(std::size_t i = 0; i < primes::sizes_len; ++i) {
+        test_gh348_table t;
+        t.mlf_ = (float)mlf;
+        test_gh348_table_bucket_count = 0;
+        auto bc = primes::sizes[i];
+        std::size_t n = boost::unordered::detail::double_to_size(
+          0.9 * static_cast<double>(t.mlf_) * static_cast<double>(bc));
+        if(n == size_t_max) continue;
+        try {
+          t.reserve(n);
+        }
+        catch(const failing_allocator_exception& e) {
+          test_gh348_table_bucket_count = e.n;
+          BOOST_TEST_LE(bc, test_gh348_table_bucket_count);
+        }
+        t.max_load_ = boost::unordered::detail::double_to_size(
+          static_cast<double>(t.mlf_) * 
+          static_cast<double>(test_gh348_table_bucket_count));
+        if(t.max_load_ == size_t_max) continue;
+        try {
+          t.reserve_for_insert(t.max_load_ + 1);
+        }
+        catch(const failing_allocator_exception& e) {
+          if(i == primes::sizes_len - 1) {
+            BOOST_TEST_EQ(test_gh348_table_bucket_count, e.n);
+          }
+          else{
+            BOOST_TEST_LT(test_gh348_table_bucket_count, e.n);
+          }
+        }
+      }
+    }
+  }
+
+  void test_gh348_2(int /* dummy for UNORDERED_TEST */)
+  {
+    for(double mlf = 0.1; mlf < 2.0; mlf += 0.1) {
+      test_gh348_table t;
+      t.mlf_ = (float)mlf;
+      try {
+        t.reserve((std::numeric_limits<std::size_t>::max)());
+      }
+      catch(const failing_allocator_exception& e) {
+        BOOST_TEST_GT(e.n, 1000u);
+      }
+    }
+  }
+
   using test::default_generator;
   using test::generate_collisions;
   using test::limited_range;
@@ -739,6 +836,8 @@ namespace rehash_tests {
      (test_multiset_ptr)(int_multimap_ptr)
      (test_multiset_tracking)(test_multimap_tracking))(
       (default_generator)(generate_collisions)(limited_range)))
+  UNORDERED_TEST(test_gh348_1,((0)))
+  UNORDERED_TEST(test_gh348_2,((0)))
 // clang-format on
 #endif
 } // namespace rehash_tests


### PR DESCRIPTION
## Intro
Hi, I found practically the same bug as in https://github.com/boostorg/multi_index/pull/94. 

`reserve_for_insert` uses floats to calculate the next number of buckets. These can round down and not increase the bucket count, which leads the table being rehashed on multiple subsequent inserts that rely on this method.

The following program demonstrates this.

## Code
```
#include <boost/unordered/unordered_set.hpp>

#include <chrono>
#include <cstddef>
#include <format>
#include <iostream>

using time_unit = std::chrono::milliseconds;

void note_time(time_unit time, std::size_t container_size)
{
    static unsigned long max_ms = 0;
    const double tol = 0.25;

    const unsigned long ms =
        std::chrono::duration_cast<std::chrono::milliseconds>(time).count();

    if (ms > max_ms)
        max_ms = ms;

    if (ms >= 1 && ms >= max_ms * tol)
        std::cout << std::format("container size: {}, insert time: {} ms\n",
                                 container_size, ms);
}

int main()
{
    static constexpr int range1_lo = 201326605, range1_hi = 201326630;
    static constexpr int range2_lo = 402653179, range2_hi = 402653220;

    boost::unordered_set<int> a;
    for (int i = range1_lo; i <= range1_hi; ++i) a.insert(i);
    for (int i = range2_lo; i <= range2_hi; ++i) a.insert(i);

    boost::unordered_set<int> b;
    for (int i = 0; i < 405'000'000; ++i) {
        using clock = std::chrono::steady_clock;
        auto t0 = clock::now();

        if ((i >= range1_lo && i <= range1_hi) ||
            (i >= range2_lo && i <= range2_hi)) {
            b.insert(a.extract(i));
        } else {
            b.insert(i);
        }

        auto t1 = clock::now();
        note_time(std::chrono::duration_cast<time_unit>(t1 - t0), b.size());
    }
}
```

(I'm sorry for it being memory-heavy, it was the simplest way for me to demonstrate.)

### On my machine, with the current implementation, the output is:
container size: 98318, insert time: 1 ms
container size: 196614, insert time: 2 ms
container size: 393242, insert time: 5 ms
container size: 786434, insert time: 11 ms
container size: 1572870, insert time: 22 ms
container size: 3145740, insert time: 46 ms
container size: 6291470, insert time: 101 ms
container size: 12582918, insert time: 180 ms
container size: 25165844, insert time: 355 ms
container size: 50331654, insert time: 729 ms
container size: 100663320, insert time: 1686 ms
_container size: 201326612, insert time: 2113 ms_
**container size: 201326613, insert time: 2138 ms
container size: 201326614, insert time: 2259 ms
container size: 201326615, insert time: 2121 ms
container size: 201326616, insert time: 3139 ms**
_container size: 402653190, insert time: 5819 ms_
**container size: 402653191, insert time: 4343 ms
container size: 402653192, insert time: 4516 ms
container size: 402653193, insert time: 4377 ms
container size: 402653194, insert time: 4263 ms
container size: 402653195, insert time: 4329 ms
container size: 402653196, insert time: 4225 ms
container size: 402653197, insert time: 4229 ms
container size: 402653198, insert time: 4220 ms
container size: 402653199, insert time: 4322 ms
container size: 402653200, insert time: 4181 ms
container size: 402653201, insert time: 9137 ms**

### On my machine, with the the fix, the output is:
container size: 98318, insert time: 1 ms
container size: 196614, insert time: 2 ms
container size: 393242, insert time: 5 ms
container size: 786434, insert time: 11 ms
container size: 1572870, insert time: 23 ms
container size: 3145740, insert time: 48 ms
container size: 6291470, insert time: 93 ms
container size: 12582918, insert time: 183 ms
container size: 25165844, insert time: 363 ms
container size: 50331654, insert time: 719 ms
container size: 100663320, insert time: 1476 ms
container size: 201326612, insert time: 2947 ms
container size: 402653190, insert time: 7719 ms

## The fix
I implemented the fix to mirror https://github.com/boostorg/multi_index/pull/94/changes