### PR TITLE
reformulated SFINAE clauses checking `key_type` completeness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,8 +147,9 @@ jobs:
                 apt-get -o Acquire::Retries=$NET_RETRY_COUNT update
                 apt-get -o Acquire::Retries=$NET_RETRY_COUNT install -y sudo software-properties-common
                 # Need (newer) git, and the older Ubuntu container may require requesting the key manually using port 80
-                apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys E1DD270288B4E6030699E45FA1715D88E1DF1F24
-                for i in {1..${NET_RETRY_COUNT:-3}}; do sudo -E add-apt-repository -y ppa:git-core/ppa && break || sleep 10; done
+                mkdir -p /etc/apt/trusted.gpg.d
+                gpg --no-default-keyring --keyring /etc/apt/trusted.gpg.d/git-core.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys E1DD270288B4E6030699E45FA1715D88E1DF1F24
+                for i in {1..${NET_RETRY_COUNT:-3}}; do sudo -E add-apt-repository -y ppa:git-core/ppa && break || sleep 10; done                
                 apt-get -o Acquire::Retries=$NET_RETRY_COUNT update
                 apt-get -o Acquire::Retries=$NET_RETRY_COUNT install -y g++ python-is-python3 git
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,9 +145,9 @@ jobs:
             fi
             if [ -n "${{matrix.container}}" ] && [ -f "/etc/debian_version" ]; then
                 apt-get -o Acquire::Retries=$NET_RETRY_COUNT update
-                apt-get -o Acquire::Retries=$NET_RETRY_COUNT install -y sudo software-properties-common
+                apt-get -o Acquire::Retries=$NET_RETRY_COUNT install -y sudo software-properties-common dirmngr
                 # Need (newer) git, and the older Ubuntu container may require requesting the key manually using port 80
-                mkdir -p /etc/apt/trusted.gpg.d
+                mkdir -p /etc/apt/trusted.gpg.d ~/.gnupg
                 gpg --no-default-keyring --keyring /etc/apt/trusted.gpg.d/git-core.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys E1DD270288B4E6030699E45FA1715D88E1DF1F24
                 for i in {1..${NET_RETRY_COUNT:-3}}; do sudo -E add-apt-repository -y ppa:git-core/ppa && break || sleep 10; done                
                 apt-get -o Acquire::Retries=$NET_RETRY_COUNT update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,9 @@ jobs:
           - { compiler: gcc-12,    cxxstd: '11,14,17,20', os: 'ubuntu-22.04', install: 'g++-12' }
           - { compiler: gcc-13,    cxxstd: '11,14,17,20', os: 'ubuntu-24.04', install: 'g++-13' }
           - { compiler: gcc-14,    cxxstd: '11,14,17,20', os: 'ubuntu-24.04', install: 'g++-14' }
+          - { compiler: gcc-16,    cxxstd: '11,14,17', container: 'ubuntu:26.04', os: 'ubuntu-latest', install: 'g++-16-multilib' }
+          - { compiler: gcc-16,    cxxstd: '20,23,2c', container: 'ubuntu:26.04', os: 'ubuntu-latest', install: 'g++-16-multilib' }
+
           - { name: "gcc-14 w/ sanitizers (11)", sanitize: yes,
               compiler: gcc-14,    cxxstd: '11',          os: 'ubuntu-24.04', install: 'g++-14', ccache_key: "san1" }
           - { name: "gcc-14 w/ sanitizers (14)", sanitize: yes,
@@ -74,7 +77,6 @@ jobs:
               compiler: gcc-14,    cxxstd: '20',          os: 'ubuntu-24.04', install: 'g++-14 g++-14-multilib', address-model: '32,64', ccache_key: "cov" }
           - { name: "cfoa tsan (gcc-14)", cxxstd: '11,14,17,20,2b', os: 'ubuntu-24.04', install: 'g++-14', compiler: gcc-14,
               targets: 'libs/unordered/test//cfoa_tests', thread-sanitize: yes, ccache_key: "tsan" }
-          - { compiler: gcc-16,    cxxstd: '11,14,17,20,23,2c', container: 'ubuntu:26.04', os: 'ubuntu-latest', install: 'g++-16-multilib' }
 
           # Linux, clang, libc++
           - { compiler: clang-7,    cxxstd: '11,14,17',    os: 'ubuntu-20.04', stdlib: libc++, install: 'clang-7 libc++-7-dev libc++abi-7-dev' }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,9 +72,9 @@ jobs:
               compiler: gcc-14,    cxxstd: '2b',          os: 'ubuntu-24.04', install: 'g++-14', ccache_key: "san2" }
           - { name: Collect coverage, coverage: yes,
               compiler: gcc-14,    cxxstd: '20',          os: 'ubuntu-24.04', install: 'g++-14 g++-14-multilib', address-model: '32,64', ccache_key: "cov" }
-
           - { name: "cfoa tsan (gcc-14)", cxxstd: '11,14,17,20,2b', os: 'ubuntu-24.04', install: 'g++-14', compiler: gcc-14,
               targets: 'libs/unordered/test//cfoa_tests', thread-sanitize: yes, ccache_key: "tsan" }
+          - { compiler: gcc-16,    cxxstd: '11,14,17,20,23,2c', container: 'ubuntu:26.04', os: 'ubuntu-latest', install: 'g++-16-multilib' }
 
           # Linux, clang, libc++
           - { compiler: clang-7,    cxxstd: '11,14,17',    os: 'ubuntu-20.04', stdlib: libc++, install: 'clang-7 libc++-7-dev libc++abi-7-dev' }

--- a/include/boost/unordered/detail/foa/concurrent_table.hpp
+++ b/include/boost/unordered/detail/foa/concurrent_table.hpp
@@ -1,6 +1,6 @@
 /* Fast open-addressing concurrent hash table.
  *
- * Copyright 2023-2024 Joaquin M Lopez Munoz.
+ * Copyright 2023-2026 Joaquin M Lopez Munoz.
  * Copyright 2024 Braden Ganetsky.
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or copy at
@@ -697,9 +697,9 @@ public:
   }
 
   /* Optimizations for maps for (k,v) to avoid eagerly constructing value */
-  template <typename K, typename V>
+  template <typename K, typename V, typename Table = concurrent_table>
   BOOST_FORCEINLINE auto emplace(K&& k, V&& v) ->
-    typename std::enable_if<is_emplace_kv_able<concurrent_table, K>::value,
+    typename std::enable_if<is_emplace_kv_able<Table, K>::value,
       bool>::type
   {
     alloc_cted_or_fwded_key_type<type_policy, Allocator, K&&> x(

--- a/include/boost/unordered/detail/foa/core.hpp
+++ b/include/boost/unordered/detail/foa/core.hpp
@@ -1,6 +1,6 @@
 /* Common base for Boost.Unordered open-addressing tables.
  *
- * Copyright 2022-2025 Joaquin M Lopez Munoz.
+ * Copyright 2022-2026 Joaquin M Lopez Munoz.
  * Copyright 2023 Christian Mazakas.
  * Copyright 2024 Braden Ganetsky.
  * Distributed under the Boost Software License, Version 1.0.
@@ -1349,7 +1349,7 @@ template <typename Container, typename K>
 using is_emplace_kv_able = std::integral_constant<bool,
   is_map<Container>::value &&
     (is_similar<K, typename Container::key_type>::value ||
-      is_complete_and_move_constructible<typename Container::key_type>::value)>;
+      std::is_move_constructible<typename Container::key_type>::value)>;
 
 /* table_core. The TypePolicy template parameter is used to generate
  * instantiations suitable for either maps or sets, and introduces non-standard

--- a/include/boost/unordered/detail/foa/table.hpp
+++ b/include/boost/unordered/detail/foa/table.hpp
@@ -1,6 +1,6 @@
 /* Fast open-addressing hash table.
  *
- * Copyright 2022-2025 Joaquin M Lopez Munoz.
+ * Copyright 2022-2026 Joaquin M Lopez Munoz.
  * Copyright 2023 Christian Mazakas.
  * Copyright 2024 Braden Ganetsky.
  * Distributed under the Boost Software License, Version 1.0.
@@ -422,9 +422,9 @@ public:
   }
 
   /* Optimizations for maps for (k,v) to avoid eagerly constructing value */
-  template <typename K, typename V>
+  template <typename K, typename V, typename Table = table>
   BOOST_FORCEINLINE
-    typename std::enable_if<is_emplace_kv_able<table, K>::value,
+    typename std::enable_if<is_emplace_kv_able<Table, K>::value,
       std::pair<iterator, bool> >::type
     emplace(K&& k, V&& v)
   {

--- a/include/boost/unordered/detail/implementation.hpp
+++ b/include/boost/unordered/detail/implementation.hpp
@@ -1,6 +1,6 @@
 // Copyright (C) 2003-2004 Jeremy B. Maitin-Shepard.
 // Copyright (C) 2005-2016 Daniel James
-// Copyright (C) 2022-2024 Joaquin M Lopez Munoz.
+// Copyright (C) 2022-2026 Joaquin M Lopez Munoz.
 // Copyright (C) 2022-2023 Christian Mazakas
 // Copyright (C) 2024 Braden Ganetsky
 //
@@ -2851,10 +2851,10 @@ namespace boost {
           return no_key();
         }
 
-        template <class Arg1, class Arg2>
+        template <class Arg1, class Arg2, class Key = key_type>
         static typename std::conditional<
           (is_similar<Arg1, key_type>::value ||
-            is_complete_and_move_constructible<key_type>::value),
+            std::is_move_constructible<Key>::value),
           converting_key, no_key>::type
         extract(Arg1 const&, Arg2 const&)
         {

--- a/include/boost/unordered/detail/type_traits.hpp
+++ b/include/boost/unordered/detail/type_traits.hpp
@@ -1,5 +1,6 @@
 // Copyright (C) 2022-2023 Christian Mazakas
 // Copyright (C) 2024 Braden Ganetsky
+// Copyright (C) 2026 Joaquin M Lopez Munoz
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -48,20 +49,6 @@ namespace boost {
       };
 
       template <typename... Ts> using void_t = typename make_void<Ts...>::type;
-
-      template <class T, class = void> struct is_complete : std::false_type
-      {
-      };
-
-      template <class T>
-      struct is_complete<T, void_t<int[sizeof(T)]> > : std::true_type
-      {
-      };
-
-      template <class T>
-      using is_complete_and_move_constructible =
-        typename std::conditional<is_complete<T>::value,
-          std::is_move_constructible<T>, std::false_type>::type;
 
 #if BOOST_WORKAROUND(BOOST_LIBSTDCXX_VERSION, < 50000)
       /* std::is_trivially_default_constructible not provided */


### PR DESCRIPTION
`emplace(K&& k, V&& v)`  overloads were SFINAE-protected for `key_type` move constructibility, additionally supplemented with a check for `key_type` completeness to make `incomplete_test`s pass. SFINAEing on type completeness for an incomplete type `T` and completing `T` later on is IFNDR, and GCC 16 detects this and emits a `sfinae-incomplete` warning.

Solved by transforming `key_type` move constructibility check into a dependent construct.