### PR TITLE
added interoperability with C++20 ranges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,7 +347,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { sys: MINGW32, compiler: gcc, cxxstd: '11,17,20', variant: 'release' }
+          - { sys: MINGW32, compiler: gcc, cxxstd: '11,17,20', variant: 'release', cxxflags: '--param ggc-min-expand=0 --param ggc-min-heapsize=4096' }
           - { sys: MINGW64, compiler: gcc, cxxstd: '11,17,20', variant: 'debug,release' }
 
     needs: [runner-selection]
@@ -383,7 +383,7 @@ jobs:
           B2_SANITIZE: ${{matrix.sanitize}}
           B2_STDLIB: ${{matrix.stdlib}}
           B2_VARIANT: ${{matrix.variant}}
-          B2_JOBS: ${{ matrix.sys == 'MINGW32' && '2' || '' }}
+          B2_CXXFLAGS: ${{ matrix.cxxflags }}
         run: ci/github/install.sh
 
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,6 +383,7 @@ jobs:
           B2_SANITIZE: ${{matrix.sanitize}}
           B2_STDLIB: ${{matrix.stdlib}}
           B2_VARIANT: ${{matrix.variant}}
+          B2_JOBS: ${{ matrix.sys == 'MINGW32' && '2' || '' }}
         run: ci/github/install.sh
 
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,7 +347,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { sys: MINGW32, compiler: gcc, cxxstd: '11,17,20', variant: 'release', cxxflags: '--param ggc-min-expand=0 --param ggc-min-heapsize=4096' }
+          - { sys: MINGW32, compiler: gcc, cxxstd: '11,17,20', variant: 'release', cxxflags: '--param ggc-min-expand=10 --param ggc-min-heapsize=16384' }
           - { sys: MINGW64, compiler: gcc, cxxstd: '11,17,20', variant: 'debug,release' }
 
     needs: [runner-selection]

--- a/doc/modules/ROOT/pages/changes.adoc
+++ b/doc/modules/ROOT/pages/changes.adoc
@@ -6,6 +6,14 @@
 :github-pr-url: https://github.com/boostorg/unordered/pull
 :cpp: C++
 
+== Release 1.92.0
+
+* Added interoperability with pass:[C++20] ranges to all the containers in the library:
+`insert_range` (plus `insert_range_(or|and)_[c]visit` for concurrent containers),
+`std::from_range` construction and associated CTAD deduction guides.
+The `boost::unordered::from_range` construction tag is provided
+as an alternative to pass:[C++23] `std::from_range` or when this is not available.
+
 == Release 1.91.0
 
 * Fixed the returned value of range insertion in concurrent containers

--- a/doc/modules/ROOT/pages/reference/concurrent_flat_map.adoc
+++ b/doc/modules/ROOT/pages/reference/concurrent_flat_map.adoc
@@ -77,6 +77,12 @@ namespace unordered {
     xref:#concurrent_flat_map_copy_constructor_with_allocator[concurrent_flat_map](const concurrent_flat_map& other, const Allocator& a);
     xref:#concurrent_flat_map_move_constructor_with_allocator[concurrent_flat_map](concurrent_flat_map&& other, const Allocator& a);
     xref:#concurrent_flat_map_move_constructor_from_unordered_flat_map[concurrent_flat_map](unordered_flat_map<Key, T, Hash, Pred, Allocator>&& other);
+    template<class FromRangeT, xref:#concurrent_flat_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#concurrent_flat_map_range_constructor[concurrent_flat_map](FromRangeT&&, R&& rg,
+                          size_type n = _implementation-defined_,
+                          const hasher& hf = hasher(),
+                          const key_equal& eql = key_equal(),
+                          const allocator_type& a = allocator_type());
     xref:#concurrent_flat_map_initializer_list_constructor[concurrent_flat_map](std::initializer_list<value_type> il,
                         size_type n = _implementation-defined_
                         const hasher& hf = hasher(),
@@ -89,6 +95,13 @@ namespace unordered {
                           const allocator_type& a);
     template<class InputIterator>
       xref:#concurrent_flat_map_iterator_range_constructor_with_bucket_count_and_hasher[concurrent_flat_map](InputIterator f, InputIterator l, size_type n, const hasher& hf,
+                          const allocator_type& a);
+    template<class FromRangeT, xref:#concurrent_flat_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#concurrent_flat_map_range_constructor_with_allocator[concurrent_flat_map](FromRangeT&&, R&& rg, const allocator_type& a);
+    template<class FromRangeT, xref:#concurrent_flat_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#concurrent_flat_map_range_constructor_with_bucket_count_and_allocator[concurrent_flat_map](FromRangeT&&, R&& rg, size_type n, const allocator_type& a);
+    template<class FromRangeT, xref:#concurrent_flat_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#concurrent_flat_map_range_constructor_with_bucket_count_and_hasher_and_allocator[concurrent_flat_map](FromRangeT&&, R&& rg, size_type n, const hasher& hf,
                           const allocator_type& a);
     xref:#concurrent_flat_map_initializer_list_constructor_with_allocator[concurrent_flat_map](std::initializer_list<value_type> il, const allocator_type& a);
     xref:#concurrent_flat_map_initializer_list_constructor_with_bucket_count_and_allocator[concurrent_flat_map](std::initializer_list<value_type> il, size_type n,
@@ -152,6 +165,8 @@ namespace unordered {
     bool xref:#concurrent_flat_map_move_insert[insert](value_type&& obj);
     bool xref:#concurrent_flat_map_move_insert[insert](init_type&& obj);
     template<class InputIterator> size_type xref:#concurrent_flat_map_insert_iterator_range[insert](InputIterator first, InputIterator last);
+    template<xref:#concurrent_flat_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+      size_type xref:#concurrent_flat_map_insert_range[insert_range](R&& rg);
     size_type xref:#concurrent_flat_map_insert_initializer_list[insert](std::initializer_list<value_type> il);
 
     template<class... Args, class F> bool xref:#concurrent_flat_map_emplace_or_cvisit[emplace_or_visit](Args&&... args, F&& f);
@@ -168,6 +183,10 @@ namespace unordered {
       size_type xref:#concurrent_flat_map_insert_iterator_range_or_visit[insert_or_visit](InputIterator first, InputIterator last, F f);
     template<class InputIterator,class F>
       size_type xref:#concurrent_flat_map_insert_iterator_range_or_visit[insert_or_cvisit](InputIterator first, InputIterator last, F f);
+    template<xref:#concurrent_flat_map_container_compatible_range[__container-compatible-range__]<value_type> R, class F>
+      size_type xref:#concurrent_flat_map_insert_range_or_visit[insert_range_or_visit](R&& rg, F f);
+    template<xref:#concurrent_flat_map_container_compatible_range[__container-compatible-range__]<value_type> R, class F>
+      size_type xref:#concurrent_flat_map_insert_range_or_visit[insert_range_or_cvisit](R&& rg, F f);
     template<class F> size_type xref:#concurrent_flat_map_insert_initializer_list_or_visit[insert_or_visit](std::initializer_list<value_type> il, F f);
     template<class F> size_type xref:#concurrent_flat_map_insert_initializer_list_or_visit[insert_or_cvisit](std::initializer_list<value_type> il, F f);
 
@@ -187,6 +206,10 @@ namespace unordered {
       size_type xref:#concurrent_flat_map_insert_iterator_range_and_visit[insert_and_visit](InputIterator first, InputIterator last, F1 f1, F2 f2);
     template<class InputIterator,class F1, class F2>
       size_type xref:#concurrent_flat_map_insert_iterator_range_and_visit[insert_and_cvisit](InputIterator first, InputIterator last, F1 f1, F2 f2);
+    template<xref:#concurrent_flat_map_container_compatible_range[__container-compatible-range__]<value_type> R, class F1, class F2>
+      size_type xref:#concurrent_flat_map_insert_range_and_visit[insert_range_and_visit](R&& rg, F1 f1, F2 f2);
+    template<xref:#concurrent_flat_map_container_compatible_range[__container-compatible-range__]<value_type> R, class F1, class F2>
+      size_type xref:#concurrent_flat_map_insert_range_and_visit[insert_range_and_cvisit](R&& rg, F1 f1, F2 f2);
     template<class F1, class F2>
       size_type xref:#concurrent_flat_map_insert_initializer_list_and_visit[insert_and_visit](std::initializer_list<value_type> il, F1 f1, F2 f2);
     template<class F1, class F2>
@@ -282,6 +305,17 @@ namespace unordered {
       -> concurrent_flat_map<xref:#concurrent_flat_map_iter_key_type[__iter-key-type__]<InputIterator>, xref:#concurrent_flat_map_iter_mapped_type[__iter-mapped-type__]<InputIterator>, Hash,
                              Pred, Allocator>;
 
+  template<xref:#concurrent_flat_map_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R,
+           class Hash = boost::hash<xref:#concurrent_flat_map_range_key_type[__range-key-type__]<R>>,
+           class Pred = std::equal_to<xref:#concurrent_flat_map_range_key_type[__range-key-type__]<R>>,
+           class Allocator = std::allocator<xref:#concurrent_flat_map_range_to_alloc_type[__range-to-alloc-type__]<R>>>
+    concurrent_flat_map(FromRangeT&&, R&&,
+                        typename xref:#concurrent_flat_map_deduction_guides[__see below__]::size_type = xref:#concurrent_flat_map_deduction_guides[__see below__], Hash = Hash(),
+                        Pred = Pred(), Allocator = Allocator())
+      -> concurrent_flat_map<xref:#concurrent_flat_map_range_key_type[__range-key-type__]<R>, xref:#concurrent_flat_map_range_mapped_type[__range-mapped-type__]<R>,
+                             Hash, Pred,Allocator>;
+
   template<class Key, class T, class Hash = boost::hash<Key>,
            class Pred = std::equal_to<Key>,
            class Allocator = std::allocator<std::pair<const Key, T>>>
@@ -307,6 +341,27 @@ namespace unordered {
                         Allocator)
       -> concurrent_flat_map<xref:#concurrent_flat_map_iter_key_type[__iter-key-type__]<InputIterator>, xref:#concurrent_flat_map_iter_mapped_type[__iter-mapped-type__]<InputIterator>, Hash,
                              std::equal_to<xref:#concurrent_flat_map_iter_key_type[__iter-key-type__]<InputIterator>>, Allocator>;
+
+  template<xref:#concurrent_flat_map_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R, class Allocator>
+    concurrent_flat_map(FromRangeT&&, R&&, typename xref:#concurrent_flat_map_deduction_guides[__see below__]::size_type, Allocator)
+      -> concurrent_flat_map<xref:#concurrent_flat_map_range_key_type[__range-key-type__]<R>, xref:#concurrent_flat_map_range_mapped_type[__range-mapped-type__]<R>,
+                            boost::hash<xref:#concurrent_flat_map_range_key_type[__range-key-type__]<R>>,
+                            std::equal_to<xref:#concurrent_flat_map_range_key_type[__range-key-type__]<R>>, Allocator>;
+
+  template<xref:#concurrent_flat_map_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R, class Allocator>
+    concurrent_flat_map(FromRangeT&&, R&&, Allocator)
+      -> concurrent_flat_map<xref:#concurrent_flat_map_range_key_type[__range-key-type__]<R>, xref:#concurrent_flat_map_range_mapped_type[__range-mapped-type__]<R>,
+                            boost::hash<xref:#concurrent_flat_map_range_key_type[__range-key-type__]<R>>,
+                            std::equal_to<xref:#concurrent_flat_map_range_key_type[__range-key-type__]<R>>, Allocator>;
+
+  template<xref:#concurrent_flat_map_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R, class Hash, class Allocator>
+    concurrent_flat_map(FromRangeT&&, R&&, typename xref:#concurrent_flat_map_deduction_guides[__see below__]::size_type, Hash,
+                       Allocator)
+      -> concurrent_flat_map<xref:#concurrent_flat_map_range_key_type[__range-key-type__]<R>, xref:#concurrent_flat_map_range_mapped_type[__range-mapped-type__]<R>,
+                            Hash, std::equal_to<xref:#concurrent_flat_map_range_key_type[__range-key-type__]<R>>, Allocator>;
 
   template<class Key, class T, class Allocator>
     concurrent_flat_map(std::initializer_list<std::pair<Key, T>>, typename xref:#concurrent_flat_map_deduction_guides[__see below__]::size_type,
@@ -443,6 +498,15 @@ static constexpr size_type bulk_visit_size;
 Chunk size internally used in xref:concurrent_flat_map_bulk_visit[bulk visit] operations.
 
 === Constructors
+
+==== __container-compatible-range__
+[listings,subs="+macros,+quotes"]
+-----
+template<class R, class T>
+  concept container_compatible_range =
+    std::ranges::input_range<R> &&
+    std::convertible_to<std::ranges::range_reference_t<R>, T>; // exposition only
+-----
 
 ==== Default Constructor
 ```c++
@@ -591,6 +655,27 @@ Complexity:;; O(`bucket_count()`)
 
 ---
 
+==== Range Constructor
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#concurrent_flat_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+  concurrent_flat_map(FromRangeT&&, R&& rg,
+                      size_type n = _implementation-defined_,
+                      const hasher& hf = hasher(),
+                      const key_equal& eql = key_equal(),
+                      const allocator_type& a = allocator_type());
+----
+
+Constructs an empty table with at least `n` buckets, using `hf` as the hash function, `eql` as the key equality predicate and `a` as the allocator, and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::concurrent::from_range_t`.
+
+
+[horizontal]
+Requires:;; If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
 ==== Initializer List Constructor
 [source,c++,subs="+quotes"]
 ----
@@ -663,6 +748,58 @@ Requires:;; `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/
 
 ---
 
+==== Range Constructor with Allocator
+
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#concurrent_flat_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+  concurrent_flat_map(FromRangeT&&, R&& rg, const allocator_type& a);
+----
+
+Constructs an empty table using `a` and default hash function and key equality predicate, and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::concurrent::from_range_t`.
+
+[horizontal]
+Requires:;; `hasher` and `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
+==== Range Constructor with Bucket Count and Allocator
+
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#concurrent_flat_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+  concurrent_flat_map(FromRangeT&&, R&& rg, size_type n, const allocator_type& a);
+----
+
+Constructs an empty table with at least `n` buckets, using `a` and default hash function and key equality predicate, and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::concurrent::from_range_t`.
+
+[horizontal]
+Requires:;; `hasher` and `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
+==== Range Constructor with Bucket Count and Hasher and Allocator
+
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#concurrent_flat_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+  concurrent_flat_map(FromRangeT&&, R&& rg, size_type n, const hasher& hf,
+                     const allocator_type& a);
+----
+
+Constructs an empty table with at least `n` buckets, using `hf` as the hash function, `a` as the allocator and default key equality predicate, and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::concurrent::from_range_t`.
+
+[horizontal]
+Requires:;; `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
 ==== initializer_list Constructor with Allocator
 
 ```c++
@@ -696,7 +833,7 @@ concurrent_flat_map(std::initializer_list<value_type> il, size_type n, const has
                     const allocator_type& a);
 ```
 
-Constructs an empty table with at least `n` buckets, using `hf` as the hash function, `a` as the allocator and default key equality predicate,and inserts the elements from `il` into it.
+Constructs an empty table with at least `n` buckets, using `hf` as the hash function, `a` as the allocator and default key equality predicate, and inserts the elements from `il` into it.
 
 [horizontal]
 Requires:;; `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
@@ -1013,6 +1150,24 @@ Returns:;; The number of elements inserted.
 
 ---
 
+==== Insert Range
+[source,c++,subs="+macros,+quotes"]
+----
+template<xref:#concurrent_flat_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+  void insert_range(R&& rg);
+----
+
+Equivalent to
+[listing,subs="+macros,+quotes"]
+-----
+  for(auto&& x: rg) this->xref:#concurrent_flat_map_emplace[emplace](std::forward<decltype(x)>(x));
+-----
+
+[horizontal]
+Returns:;; The number of elements inserted.
+
+---
+
 ==== Insert Initializer List
 ```c++
 size_type insert(std::initializer_list<value_type> il);
@@ -1095,15 +1250,36 @@ only if `std::remove_reference<decltype(obj)>::type` is `value_type`.
 ==== Insert Iterator Range or Visit
 ```c++
 template<class InputIterator,class F>
-    size_type insert_or_visit(InputIterator first, InputIterator last, F f);
+  size_type insert_or_visit(InputIterator first, InputIterator last, F f);
 template<class InputIterator,class F>
-    size_type insert_or_cvisit(InputIterator first, InputIterator last, F f);
+  size_type insert_or_cvisit(InputIterator first, InputIterator last, F f);
 ```
 
 Equivalent to
 [listing,subs="+macros,+quotes"]
 -----
   while(first != last) this->xref:#concurrent_flat_map_emplace_or_cvisit[emplace_or_[c\]visit](*first++, f);
+-----
+
+[horizontal]
+Returns:;; The number of elements inserted.
+
+---
+
+==== Insert Range or Visit
+[source,c++,subs="+macros,+quotes"]
+----
+template<xref:#concurrent_flat_map_container_compatible_range[__container-compatible-range__]<value_type> R, class F>
+  size_type insert_range_or_visit(R&& rg, F f);
+template<xref:#concurrent_flat_map_container_compatible_range[__container-compatible-range__]<value_type> R, class F>
+  size_type insert_range_or_visit(R&& rg, F f);
+----
+
+Equivalent to
+[listing,subs="+macros,+quotes"]
+-----
+  for(auto&& x: rg) 
+    this->xref:#concurrent_flat_map_emplace_or_cvisit[emplace_or_[c\]visit](std::forward<decltype(x)>(x), std::ref(f));
 -----
 
 [horizontal]
@@ -1208,6 +1384,28 @@ Equivalent to
 [listing,subs="+macros,+quotes"]
 -----
   while(first != last) this->xref:#concurrent_flat_map_emplace_and_cvisit[emplace_and_[c\]visit](*first++, f1, f2);
+-----
+
+[horizontal]
+Returns:;; The number of elements inserted.
+
+---
+
+==== Insert Range and Visit
+[source,c++,subs="+macros,+quotes"]
+----
+template<xref:#concurrent_flat_map_container_compatible_range[__container-compatible-range__]<value_type> R, class F1, class F2>
+  size_type insert_range_and_visit(R&& rg, F1 f1, F2 f2);
+template<xref:#concurrent_flat_map_container_compatible_range[__container-compatible-range__]<value_type> R, class F1, class F2>
+  size_type insert_range_and_cvisit(R&& rg, F1 f1, F2 f2);
+----
+
+Equivalent to
+[listing,subs="+macros,+quotes"]
+-----
+  for(auto&& x: rg)
+    this->xref:#concurrent_flat_map_emplace_and_cvisit[emplace_and_[c\]visit](
+      std::forward<decltype(x)>(x), std::ref(f1), std::ref(f2));
 -----
 
 [horizontal]
@@ -1740,6 +1938,42 @@ template<class InputIterator>
   using __iter-to-alloc-type__ = std::pair<
     std::add_const_t<std::tuple_element_t<0, xref:#concurrent_flat_map_iter_value_type[__iter-value-type__]<InputIterator>>>,
     std::tuple_element_t<1, xref:#concurrent_flat_map_iter_value_type[__iter-value-type__]<InputIterator>>>; // exposition only
+-----
+
+==== __convertible-to-from-range_t__
+[listings,subs="+macros,+quotes"]
+-----
+template<typename FromRangeT>
+  concept __convertible-to-from_range_t__ =
+    // first clause not present if std::from_range_t does not exist
+    std::is_convertible_v<FromRangeT, std::from_range_t> ||
+    std::is_convertible_v<FromRangeT, boost::unordered::from_range_t>; // exposition only
+-----
+
+==== __range-key-type__
+[listings,subs="+macros,+quotes"]
+-----
+template<std::ranges::input_range R>
+  using __range-key-type__ =
+    std::remove_cvref_t<
+      std::tuple_element_t<0, std::ranges::range_value_t<R>>>; // exposition only
+-----
+
+==== __range-mapped-type__
+[listings,subs="+macros,+quotes"]
+-----
+template<std::ranges::input_range R>
+  using __range-mapped-type__ =
+    std::remove_cvref_t<
+      std::tuple_element_t<1, std::ranges::range_value_t<R>>>; // exposition only
+-----
+
+==== __range-to-alloc-type__
+[listings,subs="+macros,+quotes"]
+-----
+template<std::ranges::input_range R>
+  using __range-to-alloc-type__ = 
+    std::pair<const xref:#concurrent_flat_map_range_key_type[__range-key-type__]<R>, xref:#concurrent_flat_map_range_mapped_type[__range-mapped-type__]<R>>; // exposition only
 -----
 
 === Equality Comparisons

--- a/doc/modules/ROOT/pages/reference/concurrent_flat_set.adoc
+++ b/doc/modules/ROOT/pages/reference/concurrent_flat_set.adoc
@@ -72,6 +72,12 @@ namespace unordered {
     xref:#concurrent_flat_set_copy_constructor_with_allocator[concurrent_flat_set](const concurrent_flat_set& other, const Allocator& a);
     xref:#concurrent_flat_set_move_constructor_with_allocator[concurrent_flat_set](concurrent_flat_set&& other, const Allocator& a);
     xref:#concurrent_flat_set_move_constructor_from_unordered_flat_set[concurrent_flat_set](unordered_flat_set<Key, Hash, Pred, Allocator>&& other);
+    template<class FromRangeT, xref:#concurrent_flat_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#concurrent_flat_set_range_constructor[concurrent_flat_set](FromRangeT&&, R&& rg,
+                          size_type n = _implementation-defined_,
+                          const hasher& hf = hasher(),
+                          const key_equal& eql = key_equal(),
+                          const allocator_type& a = allocator_type());
     xref:#concurrent_flat_set_initializer_list_constructor[concurrent_flat_set](std::initializer_list<value_type> il,
                         size_type n = _implementation-defined_
                         const hasher& hf = hasher(),
@@ -84,6 +90,13 @@ namespace unordered {
                           const allocator_type& a);
     template<class InputIterator>
       xref:#concurrent_flat_set_iterator_range_constructor_with_bucket_count_and_hasher[concurrent_flat_set](InputIterator f, InputIterator l, size_type n, const hasher& hf,
+                          const allocator_type& a);
+    template<class FromRangeT, xref:#concurrent_flat_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#concurrent_flat_set_range_constructor_with_allocator[concurrent_flat_set](FromRangeT&&, R&& rg, const allocator_type& a);
+    template<class FromRangeT, xref:#concurrent_flat_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#concurrent_flat_set_range_constructor_with_bucket_count_and_allocator[concurrent_flat_set](FromRangeT&&, R&& rg, size_type n, const allocator_type& a);
+    template<class FromRangeT, xref:#concurrent_flat_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#concurrent_flat_set_range_constructor_with_bucket_count_and_hasher_and_allocator[concurrent_flat_set](FromRangeT&&, R&& rg, size_type n, const hasher& hf,
                           const allocator_type& a);
     xref:#concurrent_flat_set_initializer_list_constructor_with_allocator[concurrent_flat_set](std::initializer_list<value_type> il, const allocator_type& a);
     xref:#concurrent_flat_set_initializer_list_constructor_with_bucket_count_and_allocator[concurrent_flat_set](std::initializer_list<value_type> il, size_type n,
@@ -145,6 +158,8 @@ namespace unordered {
     bool xref:#concurrent_flat_set_move_insert[insert](value_type&& obj);
     template<class K> bool xref:#concurrent_flat_set_transparent_insert[insert](K&& k);
     template<class InputIterator> size_type xref:#concurrent_flat_set_insert_iterator_range[insert](InputIterator first, InputIterator last);
+    template<xref:#concurrent_flat_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+      size_type xref:#concurrent_flat_set_insert_range[insert_range](R&& rg);
     size_type xref:#concurrent_flat_set_insert_initializer_list[insert](std::initializer_list<value_type> il);
 
     template<class... Args, class F> bool xref:#concurrent_flat_set_emplace_or_cvisit[emplace_or_visit](Args&&... args, F&& f);
@@ -159,6 +174,10 @@ namespace unordered {
       size_type xref:#concurrent_flat_set_insert_iterator_range_or_visit[insert_or_visit](InputIterator first, InputIterator last, F f);
     template<class InputIterator,class F>
       size_type xref:#concurrent_flat_set_insert_iterator_range_or_visit[insert_or_cvisit](InputIterator first, InputIterator last, F f);
+    template<xref:#concurrent_flat_set_container_compatible_range[__container-compatible-range__]<value_type> R, class F>
+      size_type xref:#concurrent_flat_set_insert_range_or_visit[insert_range_or_visit](R&& rg, F f);
+    template<xref:#concurrent_flat_set_container_compatible_range[__container-compatible-range__]<value_type> R, class F>
+      size_type xref:#concurrent_flat_set_insert_range_or_visit[insert_range_or_cvisit](R&& rg, F f);
     template<class F> size_type xref:#concurrent_flat_set_insert_initializer_list_or_visit[insert_or_visit](std::initializer_list<value_type> il, F f);
     template<class F> size_type xref:#concurrent_flat_set_insert_initializer_list_or_visit[insert_or_cvisit](std::initializer_list<value_type> il, F f);
 
@@ -176,6 +195,10 @@ namespace unordered {
       size_type xref:#concurrent_flat_set_insert_iterator_range_and_visit[insert_and_visit](InputIterator first, InputIterator last, F1 f1, F2 f2);
     template<class InputIterator,class F1, class F2>
       size_type xref:#concurrent_flat_set_insert_iterator_range_and_visit[insert_and_cvisit](InputIterator first, InputIterator last, F1 f1, F2 f2);
+    template<xref:#concurrent_flat_set_container_compatible_range[__container-compatible-range__]<value_type> R, class F1, class F2>
+      size_type xref:#concurrent_flat_set_insert_range_and_visit[insert_range_and_visit](R&& rg, F1 f1, F2 f2);
+    template<xref:#concurrent_flat_set_container_compatible_range[__container-compatible-range__]<value_type> R, class F1, class F2>
+      size_type xref:#concurrent_flat_set_insert_range_and_visit[insert_range_and_cvisit](R&& rg, F1 f1, F2 f2);
     template<class F1, class F2>
       size_type xref:#concurrent_flat_set_insert_initializer_list_and_visit[insert_and_visit](std::initializer_list<value_type> il, F1 f1, F2 f2);
     template<class F1, class F2>
@@ -236,6 +259,16 @@ namespace unordered {
                         Hash = Hash(), Pred = Pred(), Allocator = Allocator())
       -> concurrent_flat_set<xref:#concurrent_flat_set_iter_value_type[__iter-value-type__]<InputIterator>, Hash, Pred, Allocator>;
 
+  template<xref:#concurrent_flat_set_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R,
+           class Hash = boost::hash<std::ranges::range_value_t<R>>,
+           class Pred = std::equal_to<std::ranges::range_value_t<R>>,
+           class Allocator = std::allocator<std::ranges::range_value_t<R>>
+    concurrent_flat_set(FromRangeT&&, R&&,
+                        typename xref:#concurrent_flat_set_deduction_guides[__see below__]::size_type = xref:#concurrent_flat_set_deduction_guides[__see below__], Hash = Hash(),
+                        Pred = Pred(), Allocator = Allocator())
+      -> concurrent_flat_set<std::ranges::range_value_t<R>, Hash, Pred,Allocator>;
+
   template<class T, class Hash = boost::hash<T>, class Pred = std::equal_to<T>,
            class Allocator = std::allocator<T>>
     concurrent_flat_set(std::initializer_list<T>, typename xref:#concurrent_flat_set_deduction_guides[__see below__]::size_type = xref:#concurrent_flat_set_deduction_guides[__see below__],
@@ -259,6 +292,27 @@ namespace unordered {
                         Allocator)
       -> concurrent_flat_set<xref:#concurrent_flat_set_iter_value_type[__iter-value-type__]<InputIterator>, Hash,
                              std::equal_to<xref:#concurrent_flat_set_iter_value_type[__iter-value-type__]<InputIterator>>, Allocator>;
+
+  template<xref:#concurrent_flat_set_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R, class Allocator>
+    concurrent_flat_set(FromRangeT&&, R&&, typename xref:#concurrent_flat_set_deduction_guides[__see below__]::size_type, Allocator)
+      -> concurrent_flat_set<std::ranges::range_value_t<R>,
+                             boost::hash<std::ranges::range_value_t<R>>,
+                             std::equal_to<std::ranges::range_value_t<R>>, Allocator>;
+
+  template<xref:#concurrent_flat_set_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R, class Allocator>
+    concurrent_flat_set(FromRangeT&&, R&&, Allocator)
+      -> concurrent_flat_set<std::ranges::range_value_t<R>, 
+                             boost::hash<std::ranges::range_value_t<R>>,
+                             std::equal_to<std::ranges::range_value_t<R>>, Allocator>;
+
+  template<xref:#concurrent_flat_set_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R, class Hash, class Allocator>
+    concurrent_flat_set(FromRangeT&&, R&&, typename xref:#concurrent_flat_set_deduction_guides[__see below__]::size_type, Hash,
+                        Allocator)
+      -> concurrent_flat_set<std::ranges::range_value_t<R>,
+                             Hash, std::equal_to<std::ranges::range_value_t<R>>, Allocator>;
 
   template<class T, class Allocator>
     concurrent_flat_set(std::initializer_list<T>, typename xref:#concurrent_flat_set_deduction_guides[__see below__]::size_type, Allocator)
@@ -390,6 +444,15 @@ static constexpr size_type bulk_visit_size;
 Chunk size internally used in xref:concurrent_flat_set_bulk_visit[bulk visit] operations.
 
 === Constructors
+
+==== __container-compatible-range__
+[listings,subs="+macros,+quotes"]
+-----
+template<class R, class T>
+  concept container_compatible_range =
+    std::ranges::input_range<R> &&
+    std::convertible_to<std::ranges::range_reference_t<R>, T>; // exposition only
+-----
 
 ==== Default Constructor
 ```c++
@@ -538,6 +601,27 @@ Complexity:;; O(`bucket_count()`)
 
 ---
 
+==== Range Constructor
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#concurrent_flat_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+  concurrent_flat_set(FromRangeT&&, R&& rg,
+                      size_type n = _implementation-defined_,
+                      const hasher& hf = hasher(),
+                      const key_equal& eql = key_equal(),
+                      const allocator_type& a = allocator_type());
+----
+
+Constructs an empty table with at least `n` buckets, using `hf` as the hash function, `eql` as the key equality predicate and `a` as the allocator, and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::concurrent::from_range_t`.
+
+
+[horizontal]
+Requires:;; If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
 ==== Initializer List Constructor
 [source,c++,subs="+quotes"]
 ----
@@ -610,6 +694,58 @@ Requires:;; `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/
 
 ---
 
+==== Range Constructor with Allocator
+
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#concurrent_flat_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+  concurrent_flat_set(FromRangeT&&, R&& rg, const allocator_type& a);
+----
+
+Constructs an empty table using `a` and default hash function and key equality predicate, and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::concurrent::from_range_t`.
+
+[horizontal]
+Requires:;; `hasher` and `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
+==== Range Constructor with Bucket Count and Allocator
+
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#concurrent_flat_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+  concurrent_flat_set(FromRangeT&&, R&& rg, size_type n, const allocator_type& a);
+----
+
+Constructs an empty table with at least `n` buckets, using `a` and default hash function and key equality predicate, and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::concurrent::from_range_t`.
+
+[horizontal]
+Requires:;; `hasher` and `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
+==== Range Constructor with Bucket Count and Hasher and Allocator
+
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#concurrent_flat_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+  concurrent_flat_set(FromRangeT&&, R&& rg, size_type n, const hasher& hf,
+                      const allocator_type& a);
+----
+
+Constructs an empty table with at least `n` buckets, using `hf` as the hash function, `a` as the allocator and default key equality predicate, and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::concurrent::from_range_t`.
+
+[horizontal]
+Requires:;; `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
 ==== initializer_list Constructor with Allocator
 
 ```c++
@@ -643,7 +779,7 @@ concurrent_flat_set(std::initializer_list<value_type> il, size_type n, const has
                     const allocator_type& a);
 ```
 
-Constructs an empty table with at least `n` buckets, using `hf` as the hash function, `a` as the allocator and default key equality predicate,and inserts the elements from `il` into it.
+Constructs an empty table with at least `n` buckets, using `hf` as the hash function, `a` as the allocator and default key equality predicate, and inserts the elements from `il` into it.
 
 [horizontal]
 Requires:;; `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
@@ -963,6 +1099,24 @@ Returns:;; The number of elements inserted.
 
 ---
 
+==== Insert Range
+[source,c++,subs="+macros,+quotes"]
+----
+template<xref:#concurrent_flat_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+  void insert_range(R&& rg);
+----
+
+Equivalent to
+[listing,subs="+macros,+quotes"]
+-----
+  for(auto&& x: rg) this->xref:#concurrent_flat_set_emplace[emplace](std::forward<decltype(x)>(x));
+-----
+
+[horizontal]
+Returns:;; The number of elements inserted.
+
+---
+
 ==== Insert Initializer List
 ```c++
 size_type insert(std::initializer_list<value_type> il);
@@ -1063,6 +1217,27 @@ Equivalent to
 [listing,subs="+macros,+quotes"]
 -----
   while(first != last) this->xref:#concurrent_flat_set_emplace_or_cvisit[emplace_or_[c\]visit](*first++, f);
+-----
+
+[horizontal]
+Returns:;; The number of elements inserted.
+
+---
+
+==== Insert Range or Visit
+[source,c++,subs="+macros,+quotes"]
+----
+template<xref:#concurrent_flat_set_container_compatible_range[__container-compatible-range__]<value_type> R, class F>
+  size_type insert_range_or_visit(R&& rg, F f);
+template<xref:#concurrent_flat_set_container_compatible_range[__container-compatible-range__]<value_type> R, class F>
+  size_type insert_range_or_visit(R&& rg, F f);
+----
+
+Equivalent to
+[listing,subs="+macros,+quotes"]
+-----
+  for(auto&& x: rg) 
+    this->xref:#concurrent_flat_set_emplace_or_cvisit[emplace_or_[c\]visit](std::forward<decltype(x)>(x), std::ref(f));
 -----
 
 [horizontal]
@@ -1177,6 +1352,28 @@ Equivalent to
 [listing,subs="+macros,+quotes"]
 -----
   while(first != last) this->xref:#concurrent_flat_set_emplace_and_cvisit[emplace_and_[c\]visit](*first++, f1, f2);
+-----
+
+[horizontal]
+Returns:;; The number of elements inserted.
+
+---
+
+==== Insert Range and Visit
+[source,c++,subs="+macros,+quotes"]
+----
+template<xref:#concurrent_flat_set_container_compatible_range[__container-compatible-range__]<value_type> R, class F1, class F2>
+  size_type insert_range_and_visit(R&& rg, F1 f1, F2 f2);
+template<xref:#concurrent_flat_set_container_compatible_range[__container-compatible-range__]<value_type> R, class F1, class F2>
+  size_type insert_range_and_cvisit(R&& rg, F1 f1, F2 f2);
+----
+
+Equivalent to
+[listing,subs="+macros,+quotes"]
+-----
+  for(auto&& x: rg)
+    this->xref:#concurrent_flat_set_emplace_and_cvisit[emplace_and_[c\]visit](
+      std::forward<decltype(x)>(x), std::ref(f1), std::ref(f2));
 -----
 
 [horizontal]
@@ -1514,6 +1711,16 @@ of the constructor selected.
 template<class InputIterator>
   using __iter-value-type__ =
     typename std::iterator_traits<InputIterator>::value_type; // exposition only
+-----
+
+==== __convertible-to-from-range_t__
+[listings,subs="+macros,+quotes"]
+-----
+template<typename FromRangeT>
+  concept __convertible-to-from_range_t__ =
+    // first clause not present if std::from_range_t does not exist
+    std::is_convertible_v<FromRangeT, std::from_range_t> ||
+    std::is_convertible_v<FromRangeT, boost::unordered::from_range_t>; // exposition only
 -----
 
 === Equality Comparisons

--- a/doc/modules/ROOT/pages/reference/concurrent_node_map.adoc
+++ b/doc/modules/ROOT/pages/reference/concurrent_node_map.adoc
@@ -80,6 +80,12 @@ namespace unordered {
     xref:#concurrent_node_map_copy_constructor_with_allocator[concurrent_node_map](const concurrent_node_map& other, const Allocator& a);
     xref:#concurrent_node_map_move_constructor_with_allocator[concurrent_node_map](concurrent_node_map&& other, const Allocator& a);
     xref:#concurrent_node_map_move_constructor_from_unordered_node_map[concurrent_node_map](unordered_node_map<Key, T, Hash, Pred, Allocator>&& other);
+    template<class FromRangeT, xref:#concurrent_node_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#concurrent_node_map_range_constructor[concurrent_node_map](FromRangeT&&, R&& rg,
+                          size_type n = _implementation-defined_,
+                          const hasher& hf = hasher(),
+                          const key_equal& eql = key_equal(),
+                          const allocator_type& a = allocator_type());
     xref:#concurrent_node_map_initializer_list_constructor[concurrent_node_map](std::initializer_list<value_type> il,
                         size_type n = _implementation-defined_
                         const hasher& hf = hasher(),
@@ -92,6 +98,13 @@ namespace unordered {
                           const allocator_type& a);
     template<class InputIterator>
       xref:#concurrent_node_map_iterator_range_constructor_with_bucket_count_and_hasher[concurrent_node_map](InputIterator f, InputIterator l, size_type n, const hasher& hf,
+                          const allocator_type& a);
+    template<class FromRangeT, xref:#concurrent_node_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#concurrent_node_map_range_constructor_with_allocator[concurrent_node_map](FromRangeT&&, R&& rg, const allocator_type& a);
+    template<class FromRangeT, xref:#concurrent_node_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#concurrent_node_map_range_constructor_with_bucket_count_and_allocator[concurrent_node_map](FromRangeT&&, R&& rg, size_type n, const allocator_type& a);
+    template<class FromRangeT, xref:#concurrent_node_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#concurrent_node_map_range_constructor_with_bucket_count_and_hasher_and_allocator[concurrent_node_map](FromRangeT&&, R&& rg, size_type n, const hasher& hf,
                           const allocator_type& a);
     xref:#concurrent_node_map_initializer_list_constructor_with_allocator[concurrent_node_map](std::initializer_list<value_type> il, const allocator_type& a);
     xref:#concurrent_node_map_initializer_list_constructor_with_bucket_count_and_allocator[concurrent_node_map](std::initializer_list<value_type> il, size_type n,
@@ -155,6 +168,8 @@ namespace unordered {
     bool xref:#concurrent_node_map_move_insert[insert](value_type&& obj);
     bool xref:#concurrent_node_map_move_insert[insert](init_type&& obj);
     template<class InputIterator> size_type xref:#concurrent_node_map_insert_iterator_range[insert](InputIterator first, InputIterator last);
+    template<xref:#concurrent_node_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+      size_type xref:#concurrent_node_map_insert_range[insert_range](R&& rg);
     size_type xref:#concurrent_node_map_insert_initializer_list[insert](std::initializer_list<value_type> il);
     insert_return_type xref:#concurrent_node_map_insert_node[insert](node_type&& nh);
 
@@ -172,6 +187,10 @@ namespace unordered {
       size_type xref:#concurrent_node_map_insert_iterator_range_or_visit[insert_or_visit](InputIterator first, InputIterator last, F f);
     template<class InputIterator,class F>
       size_type xref:#concurrent_node_map_insert_iterator_range_or_visit[insert_or_cvisit](InputIterator first, InputIterator last, F f);
+    template<xref:#concurrent_node_map_container_compatible_range[__container-compatible-range__]<value_type> R, class F>
+      size_type xref:#concurrent_node_map_insert_range_or_visit[insert_range_or_visit](R&& rg, F f);
+    template<xref:#concurrent_node_map_container_compatible_range[__container-compatible-range__]<value_type> R, class F>
+      size_type xref:#concurrent_node_map_insert_range_or_visit[insert_range_or_cvisit](R&& rg, F f);
     template<class F> size_type xref:#concurrent_node_map_insert_initializer_list_or_visit[insert_or_visit](std::initializer_list<value_type> il, F f);
     template<class F> size_type xref:#concurrent_node_map_insert_initializer_list_or_visit[insert_or_cvisit](std::initializer_list<value_type> il, F f);
     template<class F> insert_return_type xref:#concurrent_node_map_insert_node_or_visit[insert_or_visit](node_type&& nh, F f);
@@ -193,6 +212,10 @@ namespace unordered {
       size_type xref:#concurrent_node_map_insert_iterator_range_and_visit[insert_and_visit](InputIterator first, InputIterator last, F1 f1, F2 f2);
     template<class InputIterator,class F1, class F2>
       size_type xref:#concurrent_node_map_insert_iterator_range_and_visit[insert_and_cvisit](InputIterator first, InputIterator last, F1 f1, F2 f2);
+    template<xref:#concurrent_node_map_container_compatible_range[__container-compatible-range__]<value_type> R, class F1, class F2>
+      size_type xref:#concurrent_node_map_insert_range_and_visit[insert_range_and_visit](R&& rg, F1 f1, F2 f2);
+    template<xref:#concurrent_node_map_container_compatible_range[__container-compatible-range__]<value_type> R, class F1, class F2>
+      size_type xref:#concurrent_node_map_insert_range_and_visit[insert_range_and_cvisit](R&& rg, F1 f1, F2 f2);
     template<class F1, class F2>
       size_type xref:#concurrent_node_map_insert_initializer_list_and_visit[insert_and_visit](std::initializer_list<value_type> il, F1 f1, F2 f2);
     template<class F1, class F2>
@@ -300,6 +323,17 @@ namespace unordered {
       -> concurrent_node_map<xref:#concurrent_node_map_iter_key_type[__iter-key-type__]<InputIterator>, xref:#concurrent_node_map_iter_mapped_type[__iter-mapped-type__]<InputIterator>, Hash,
                              Pred, Allocator>;
 
+  template<xref:#concurrent_node_map_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R,
+           class Hash = boost::hash<xref:#concurrent_node_map_range_key_type[__range-key-type__]<R>>,
+           class Pred = std::equal_to<xref:#concurrent_node_map_range_key_type[__range-key-type__]<R>>,
+           class Allocator = std::allocator<xref:#concurrent_node_map_range_to_alloc_type[__range-to-alloc-type__]<R>>>
+    concurrent_node_map(FromRangeT&&, R&&,
+                        typename xref:#concurrent_node_map_deduction_guides[__see below__]::size_type = xref:#concurrent_node_map_deduction_guides[__see below__], Hash = Hash(),
+                        Pred = Pred(), Allocator = Allocator())
+      -> concurrent_node_map<xref:#concurrent_node_map_range_key_type[__range-key-type__]<R>, xref:#concurrent_node_map_range_mapped_type[__range-mapped-type__]<R>,
+                             Hash, Pred,Allocator>;
+
   template<class Key, class T, class Hash = boost::hash<Key>,
            class Pred = std::equal_to<Key>,
            class Allocator = std::allocator<std::pair<const Key, T>>>
@@ -325,6 +359,27 @@ namespace unordered {
                         Allocator)
       -> concurrent_node_map<xref:#concurrent_node_map_iter_key_type[__iter-key-type__]<InputIterator>, xref:#concurrent_node_map_iter_mapped_type[__iter-mapped-type__]<InputIterator>, Hash,
                              std::equal_to<xref:#concurrent_node_map_iter_key_type[__iter-key-type__]<InputIterator>>, Allocator>;
+
+  template<xref:#concurrent_node_map_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R, class Allocator>
+    concurrent_node_map(FromRangeT&&, R&&, typename xref:#concurrent_node_map_deduction_guides[__see below__]::size_type, Allocator)
+      -> concurrent_node_map<xref:#concurrent_node_map_range_key_type[__range-key-type__]<R>, xref:#concurrent_node_map_range_mapped_type[__range-mapped-type__]<R>,
+                            boost::hash<xref:#concurrent_node_map_range_key_type[__range-key-type__]<R>>,
+                            std::equal_to<xref:#concurrent_node_map_range_key_type[__range-key-type__]<R>>, Allocator>;
+
+  template<xref:#concurrent_node_map_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R, class Allocator>
+    concurrent_node_map(FromRangeT&&, R&&, Allocator)
+      -> concurrent_node_map<xref:#concurrent_node_map_range_key_type[__range-key-type__]<R>, xref:#concurrent_node_map_range_mapped_type[__range-mapped-type__]<R>,
+                            boost::hash<xref:#concurrent_node_map_range_key_type[__range-key-type__]<R>>,
+                            std::equal_to<xref:#concurrent_node_map_range_key_type[__range-key-type__]<R>>, Allocator>;
+
+  template<xref:#concurrent_node_map_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R, class Hash, class Allocator>
+    concurrent_node_map(FromRangeT&&, R&&, typename xref:#concurrent_node_map_deduction_guides[__see below__]::size_type, Hash,
+                       Allocator)
+      -> concurrent_node_map<xref:#concurrent_node_map_range_key_type[__range-key-type__]<R>, xref:#concurrent_node_map_range_mapped_type[__range-mapped-type__]<R>,
+                            Hash, std::equal_to<xref:#concurrent_node_map_range_key_type[__range-key-type__]<R>>, Allocator>;
 
   template<class Key, class T, class Allocator>
     concurrent_node_map(std::initializer_list<std::pair<Key, T>>, typename xref:#concurrent_node_map_deduction_guides[__see below__]::size_type,
@@ -496,6 +551,15 @@ Chunk size internally used in xref:concurrent_node_map_bulk_visit[bulk visit] op
 
 === Constructors
 
+==== __container-compatible-range__
+[listings,subs="+macros,+quotes"]
+-----
+template<class R, class T>
+  concept container_compatible_range =
+    std::ranges::input_range<R> &&
+    std::convertible_to<std::ranges::range_reference_t<R>, T>; // exposition only
+-----
+
 ==== Default Constructor
 ```c++
 concurrent_node_map();
@@ -643,6 +707,27 @@ Complexity:;; O(`bucket_count()`)
 
 ---
 
+==== Range Constructor
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#concurrent_node_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+  concurrent_node_map(FromRangeT&&, R&& rg,
+                      size_type n = _implementation-defined_,
+                      const hasher& hf = hasher(),
+                      const key_equal& eql = key_equal(),
+                      const allocator_type& a = allocator_type());
+----
+
+Constructs an empty table with at least `n` buckets, using `hf` as the hash function, `eql` as the key equality predicate and `a` as the allocator, and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::concurrent::from_range_t`.
+
+
+[horizontal]
+Requires:;; If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
 ==== Initializer List Constructor
 [source,c++,subs="+quotes"]
 ----
@@ -709,6 +794,58 @@ Requires:;; `hasher`, `key_equal` need to be https://en.cppreference.com/w/cpp/n
 ----
 
 Constructs an empty table with at least `n` buckets, using `hf` as the hash function, `a` as the allocator, with the default key equality predicate, and inserts the elements from `[f, l)` into it.
+
+[horizontal]
+Requires:;; `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
+==== Range Constructor with Allocator
+
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#concurrent_node_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+  concurrent_node_map(FromRangeT&&, R&& rg, const allocator_type& a);
+----
+
+Constructs an empty table using `a` and default hash function and key equality predicate, and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::concurrent::from_range_t`.
+
+[horizontal]
+Requires:;; `hasher` and `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
+==== Range Constructor with Bucket Count and Allocator
+
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#concurrent_node_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+  concurrent_node_map(FromRangeT&&, R&& rg, size_type n, const allocator_type& a);
+----
+
+Constructs an empty table with at least `n` buckets, using `a` and default hash function and key equality predicate, and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::concurrent::from_range_t`.
+
+[horizontal]
+Requires:;; `hasher` and `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
+==== Range Constructor with Bucket Count and Hasher and Allocator
+
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#concurrent_node_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+  concurrent_node_map(FromRangeT&&, R&& rg, size_type n, const hasher& hf,
+                     const allocator_type& a);
+----
+
+Constructs an empty table with at least `n` buckets, using `hf` as the hash function, `a` as the allocator and default key equality predicate, and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::concurrent::from_range_t`.
 
 [horizontal]
 Requires:;; `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
@@ -1059,6 +1196,24 @@ Returns:;; The number of elements inserted.
 
 ---
 
+==== Insert Range
+[source,c++,subs="+macros,+quotes"]
+----
+template<xref:#concurrent_node_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+  void insert_range(R&& rg);
+----
+
+Equivalent to
+[listing,subs="+macros,+quotes"]
+-----
+  for(auto&& x: rg) this->xref:#concurrent_node_map_emplace[emplace](std::forward<decltype(x)>(x));
+-----
+
+[horizontal]
+Returns:;; The number of elements inserted.
+
+---
+
 ==== Insert Initializer List
 ```c++
 size_type insert(std::initializer_list<value_type> il);
@@ -1163,6 +1318,27 @@ Equivalent to
 [listing,subs="+macros,+quotes"]
 -----
   while(first != last) this->xref:#concurrent_node_map_emplace_or_cvisit[emplace_or_[c\]visit](*first++, f);
+-----
+
+[horizontal]
+Returns:;; The number of elements inserted.
+
+---
+
+==== Insert Range or Visit
+[source,c++,subs="+macros,+quotes"]
+----
+template<xref:#concurrent_node_map_container_compatible_range[__container-compatible-range__]<value_type> R, class F>
+  size_type insert_range_or_visit(R&& rg, F f);
+template<xref:#concurrent_node_map_container_compatible_range[__container-compatible-range__]<value_type> R, class F>
+  size_type insert_range_or_visit(R&& rg, F f);
+----
+
+Equivalent to
+[listing,subs="+macros,+quotes"]
+-----
+  for(auto&& x: rg) 
+    this->xref:#concurrent_node_map_emplace_or_cvisit[emplace_or_[c\]visit](std::forward<decltype(x)>(x), std::ref(f));
 -----
 
 [horizontal]
@@ -1282,6 +1458,28 @@ Equivalent to
 [listing,subs="+macros,+quotes"]
 -----
   while(first != last) this->xref:#concurrent_node_map_emplace_and_cvisit[emplace_and_[c\]visit](*first++, f1, f2);
+-----
+
+[horizontal]
+Returns:;; The number of elements inserted.
+
+---
+
+==== Insert Range and Visit
+[source,c++,subs="+macros,+quotes"]
+----
+template<xref:#concurrent_node_map_container_compatible_range[__container-compatible-range__]<value_type> R, class F1, class F2>
+  size_type insert_range_and_visit(R&& rg, F1 f1, F2 f2);
+template<xref:#concurrent_node_map_container_compatible_range[__container-compatible-range__]<value_type> R, class F1, class F2>
+  size_type insert_range_and_cvisit(R&& rg, F1 f1, F2 f2);
+----
+
+Equivalent to
+[listing,subs="+macros,+quotes"]
+-----
+  for(auto&& x: rg)
+    this->xref:#concurrent_node_map_emplace_and_cvisit[emplace_and_[c\]visit](
+      std::forward<decltype(x)>(x), std::ref(f1), std::ref(f2));
 -----
 
 [horizontal]
@@ -1856,6 +2054,42 @@ template<class InputIterator>
   using __iter-to-alloc-type__ = std::pair<
     std::add_const_t<std::tuple_element_t<0, xref:#concurrent_node_map_iter_value_type[__iter-value-type__]<InputIterator>>>,
     std::tuple_element_t<1, xref:#concurrent_node_map_iter_value_type[__iter-value-type__]<InputIterator>>>; // exposition only
+-----
+
+==== __convertible-to-from-range_t__
+[listings,subs="+macros,+quotes"]
+-----
+template<typename FromRangeT>
+  concept __convertible-to-from_range_t__ =
+    // first clause not present if std::from_range_t does not exist
+    std::is_convertible_v<FromRangeT, std::from_range_t> ||
+    std::is_convertible_v<FromRangeT, boost::unordered::from_range_t>; // exposition only
+-----
+
+==== __range-key-type__
+[listings,subs="+macros,+quotes"]
+-----
+template<std::ranges::input_range R>
+  using __range-key-type__ =
+    std::remove_cvref_t<
+      std::tuple_element_t<0, std::ranges::range_value_t<R>>>; // exposition only
+-----
+
+==== __range-mapped-type__
+[listings,subs="+macros,+quotes"]
+-----
+template<std::ranges::input_range R>
+  using __range-mapped-type__ =
+    std::remove_cvref_t<
+      std::tuple_element_t<1, std::ranges::range_value_t<R>>>; // exposition only
+-----
+
+==== __range-to-alloc-type__
+[listings,subs="+macros,+quotes"]
+-----
+template<std::ranges::input_range R>
+  using __range-to-alloc-type__ = 
+    std::pair<const xref:#concurrent_node_map_range_key_type[__range-key-type__]<R>, xref:#concurrent_node_map_range_mapped_type[__range-mapped-type__]<R>>; // exposition only
 -----
 
 === Equality Comparisons

--- a/doc/modules/ROOT/pages/reference/concurrent_node_set.adoc
+++ b/doc/modules/ROOT/pages/reference/concurrent_node_set.adoc
@@ -75,6 +75,12 @@ namespace unordered {
     xref:#concurrent_node_set_copy_constructor_with_allocator[concurrent_node_set](const concurrent_node_set& other, const Allocator& a);
     xref:#concurrent_node_set_move_constructor_with_allocator[concurrent_node_set](concurrent_node_set&& other, const Allocator& a);
     xref:#concurrent_node_set_move_constructor_from_unordered_node_set[concurrent_node_set](unordered_node_set<Key, Hash, Pred, Allocator>&& other);
+    template<class FromRangeT, xref:#concurrent_node_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#concurrent_node_set_range_constructor[concurrent_node_set](FromRangeT&&, R&& rg,
+                          size_type n = _implementation-defined_,
+                          const hasher& hf = hasher(),
+                          const key_equal& eql = key_equal(),
+                          const allocator_type& a = allocator_type());
     xref:#concurrent_node_set_initializer_list_constructor[concurrent_node_set](std::initializer_list<value_type> il,
                         size_type n = _implementation-defined_
                         const hasher& hf = hasher(),
@@ -87,6 +93,13 @@ namespace unordered {
                           const allocator_type& a);
     template<class InputIterator>
       xref:#concurrent_node_set_iterator_range_constructor_with_bucket_count_and_hasher[concurrent_node_set](InputIterator f, InputIterator l, size_type n, const hasher& hf,
+                          const allocator_type& a);
+    template<class FromRangeT, xref:#concurrent_node_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#concurrent_node_set_range_constructor_with_allocator[concurrent_node_set](FromRangeT&&, R&& rg, const allocator_type& a);
+    template<class FromRangeT, xref:#concurrent_node_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#concurrent_node_set_range_constructor_with_bucket_count_and_allocator[concurrent_node_set](FromRangeT&&, R&& rg, size_type n, const allocator_type& a);
+    template<class FromRangeT, xref:#concurrent_node_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#concurrent_node_set_range_constructor_with_bucket_count_and_hasher_and_allocator[concurrent_node_set](FromRangeT&&, R&& rg, size_type n, const hasher& hf,
                           const allocator_type& a);
     xref:#concurrent_node_set_initializer_list_constructor_with_allocator[concurrent_node_set](std::initializer_list<value_type> il, const allocator_type& a);
     xref:#concurrent_node_set_initializer_list_constructor_with_bucket_count_and_allocator[concurrent_node_set](std::initializer_list<value_type> il, size_type n,
@@ -148,6 +161,8 @@ namespace unordered {
     bool xref:#concurrent_node_set_move_insert[insert](value_type&& obj);
     template<class K> bool xref:#concurrent_node_set_transparent_insert[insert](K&& k);
     template<class InputIterator> size_type xref:#concurrent_node_set_insert_iterator_range[insert](InputIterator first, InputIterator last);
+    template<xref:#concurrent_node_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+      size_type xref:#concurrent_node_set_insert_range[insert_range](R&& rg);
     size_type xref:#concurrent_node_set_insert_initializer_list[insert](std::initializer_list<value_type> il);
     insert_return_type xref:#concurrent_node_set_insert_node[insert](node_type&& nh);
 
@@ -163,6 +178,10 @@ namespace unordered {
       size_type xref:#concurrent_node_set_insert_iterator_range_or_visit[insert_or_visit](InputIterator first, InputIterator last, F f);
     template<class InputIterator,class F>
       size_type xref:#concurrent_node_set_insert_iterator_range_or_visit[insert_or_cvisit](InputIterator first, InputIterator last, F f);
+    template<xref:#concurrent_node_set_container_compatible_range[__container-compatible-range__]<value_type> R, class F>
+      size_type xref:#concurrent_node_set_insert_range_or_visit[insert_range_or_visit](R&& rg, F f);
+    template<xref:#concurrent_node_set_container_compatible_range[__container-compatible-range__]<value_type> R, class F>
+      size_type xref:#concurrent_node_set_insert_range_or_visit[insert_range_or_cvisit](R&& rg, F f);
     template<class F> size_type xref:#concurrent_node_set_insert_initializer_list_or_visit[insert_or_visit](std::initializer_list<value_type> il, F f);
     template<class F> size_type xref:#concurrent_node_set_insert_initializer_list_or_visit[insert_or_cvisit](std::initializer_list<value_type> il, F f);
     template<class F> insert_return_type xref:#concurrent_node_set_insert_node_or_visit[insert_or_visit](node_type&& nh, F f);
@@ -182,6 +201,10 @@ namespace unordered {
       size_type xref:#concurrent_node_set_insert_iterator_range_and_visit[insert_and_visit](InputIterator first, InputIterator last, F1 f1, F2 f2);
     template<class InputIterator,class F1, class F2>
       size_type xref:#concurrent_node_set_insert_iterator_range_and_visit[insert_and_cvisit](InputIterator first, InputIterator last, F1 f1, F2 f2);
+    template<xref:#concurrent_node_set_container_compatible_range[__container-compatible-range__]<value_type> R, class F1, class F2>
+      size_type xref:#concurrent_node_set_insert_range_and_visit[insert_range_and_visit](R&& rg, F1 f1, F2 f2);
+    template<xref:#concurrent_node_set_container_compatible_range[__container-compatible-range__]<value_type> R, class F1, class F2>
+      size_type xref:#concurrent_node_set_insert_range_and_visit[insert_range_and_cvisit](R&& rg, F1 f1, F2 f2);
     template<class F1, class F2>
       size_type xref:#concurrent_node_set_insert_initializer_list_and_visit[insert_and_visit](std::initializer_list<value_type> il, F1 f1, F2 f2);
     template<class F1, class F2>
@@ -253,6 +276,16 @@ namespace unordered {
                         Hash = Hash(), Pred = Pred(), Allocator = Allocator())
       -> concurrent_node_set<xref:#concurrent_node_set_iter_value_type[__iter-value-type__]<InputIterator>, Hash, Pred, Allocator>;
 
+  template<xref:#concurrent_node_set_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R,
+           class Hash = boost::hash<std::ranges::range_value_t<R>>,
+           class Pred = std::equal_to<std::ranges::range_value_t<R>>,
+           class Allocator = std::allocator<std::ranges::range_value_t<R>>
+    concurrent_node_set(FromRangeT&&, R&&,
+                        typename xref:#concurrent_node_set_deduction_guides[__see below__]::size_type = xref:#concurrent_node_set_deduction_guides[__see below__], Hash = Hash(),
+                        Pred = Pred(), Allocator = Allocator())
+      -> concurrent_node_set<std::ranges::range_value_t<R>, Hash, Pred,Allocator>;
+
   template<class T, class Hash = boost::hash<T>, class Pred = std::equal_to<T>,
            class Allocator = std::allocator<T>>
     concurrent_node_set(std::initializer_list<T>, typename xref:#concurrent_node_set_deduction_guides[__see below__]::size_type = xref:#concurrent_node_set_deduction_guides[__see below__],
@@ -277,6 +310,26 @@ namespace unordered {
       -> concurrent_node_set<xref:#concurrent_node_set_iter_value_type[__iter-value-type__]<InputIterator>, Hash,
                              std::equal_to<xref:#concurrent_node_set_iter_value_type[__iter-value-type__]<InputIterator>>, Allocator>;
 
+  template<xref:#concurrent_node_set_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R, class Allocator>
+    concurrent_node_set(FromRangeT&&, R&&, typename xref:#concurrent_node_set_deduction_guides[__see below__]::size_type, Allocator)
+      -> concurrent_node_set<std::ranges::range_value_t<R>,
+                             boost::hash<std::ranges::range_value_t<R>>,
+                             std::equal_to<std::ranges::range_value_t<R>>, Allocator>;
+
+  template<xref:#concurrent_node_set_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R, class Allocator>
+    concurrent_node_set(FromRangeT&&, R&&, Allocator)
+      -> concurrent_node_set<std::ranges::range_value_t<R>, 
+                             boost::hash<std::ranges::range_value_t<R>>,
+                             std::equal_to<std::ranges::range_value_t<R>>, Allocator>;
+
+  template<xref:#concurrent_node_set_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R, class Hash, class Allocator>
+    concurrent_node_set(FromRangeT&&, R&&, typename xref:#concurrent_node_set_deduction_guides[__see below__]::size_type, Hash,
+                        Allocator)
+      -> concurrent_node_set<std::ranges::range_value_t<R>,
+                             Hash, std::equal_to<std::ranges::range_value_t<R>>, Allocator>;
   template<class T, class Allocator>
     concurrent_node_set(std::initializer_list<T>, typename xref:#concurrent_node_set_deduction_guides[__see below__]::size_type, Allocator)
       -> concurrent_node_set<T, boost::hash<T>, std::equal_to<T>, Allocator>;
@@ -441,6 +494,15 @@ Chunk size internally used in xref:concurrent_node_set_bulk_visit[bulk visit] op
 
 === Constructors
 
+==== __container-compatible-range__
+[listings,subs="+macros,+quotes"]
+-----
+template<class R, class T>
+  concept container_compatible_range =
+    std::ranges::input_range<R> &&
+    std::convertible_to<std::ranges::range_reference_t<R>, T>; // exposition only
+-----
+
 ==== Default Constructor
 ```c++
 concurrent_node_set();
@@ -588,6 +650,27 @@ Complexity:;; O(`bucket_count()`)
 
 ---
 
+==== Range Constructor
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#concurrent_node_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+  concurrent_node_set(FromRangeT&&, R&& rg,
+                      size_type n = _implementation-defined_,
+                      const hasher& hf = hasher(),
+                      const key_equal& eql = key_equal(),
+                      const allocator_type& a = allocator_type());
+----
+
+Constructs an empty table with at least `n` buckets, using `hf` as the hash function, `eql` as the key equality predicate and `a` as the allocator, and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::concurrent::from_range_t`.
+
+
+[horizontal]
+Requires:;; If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
 ==== Initializer List Constructor
 [source,c++,subs="+quotes"]
 ----
@@ -654,6 +737,58 @@ Requires:;; `hasher`, `key_equal` need to be https://en.cppreference.com/w/cpp/n
 ----
 
 Constructs an empty table with at least `n` buckets, using `hf` as the hash function, `a` as the allocator, with the default key equality predicate, and inserts the elements from `[f, l)` into it.
+
+[horizontal]
+Requires:;; `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
+==== Range Constructor with Allocator
+
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#concurrent_node_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+  concurrent_node_set(FromRangeT&&, R&& rg, const allocator_type& a);
+----
+
+Constructs an empty table using `a` and default hash function and key equality predicate, and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::concurrent::from_range_t`.
+
+[horizontal]
+Requires:;; `hasher` and `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
+==== Range Constructor with Bucket Count and Allocator
+
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#concurrent_node_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+  concurrent_node_set(FromRangeT&&, R&& rg, size_type n, const allocator_type& a);
+----
+
+Constructs an empty table with at least `n` buckets, using `a` and default hash function and key equality predicate, and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::concurrent::from_range_t`.
+
+[horizontal]
+Requires:;; `hasher` and `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
+==== Range Constructor with Bucket Count and Hasher and Allocator
+
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#concurrent_node_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+  concurrent_node_set(FromRangeT&&, R&& rg, size_type n, const hasher& hf,
+                      const allocator_type& a);
+----
+
+Constructs an empty table with at least `n` buckets, using `hf` as the hash function, `a` as the allocator and default key equality predicate, and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::concurrent::from_range_t`.
 
 [horizontal]
 Requires:;; `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
@@ -1008,6 +1143,25 @@ Returns:;; The number of elements inserted.
 
 ---
 
+==== Insert Range
+[source,c++,subs="+macros,+quotes"]
+----
+template<xref:#concurrent_node_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+  void insert_range(R&& rg);
+----
+
+Equivalent to
+[listing,subs="+macros,+quotes"]
+-----
+  for(auto&& x: rg) this->xref:#concurrent_node_set_emplace[emplace](std::forward<decltype(x)>(x));
+-----
+
+[horizontal]
+Returns:;; The number of elements inserted.
+
+---
+
+
 ==== Insert Initializer List
 ```c++
 size_type insert(std::initializer_list<value_type> il);
@@ -1121,6 +1275,27 @@ Equivalent to
 [listing,subs="+macros,+quotes"]
 -----
   while(first != last) this->xref:#concurrent_node_set_emplace_or_cvisit[emplace_or_[c\]visit](*first++, f);
+-----
+
+[horizontal]
+Returns:;; The number of elements inserted.
+
+---
+
+==== Insert Range or Visit
+[source,c++,subs="+macros,+quotes"]
+----
+template<xref:#concurrent_node_set_container_compatible_range[__container-compatible-range__]<value_type> R, class F>
+  size_type insert_range_or_visit(R&& rg, F f);
+template<xref:#concurrent_node_set_container_compatible_range[__container-compatible-range__]<value_type> R, class F>
+  size_type insert_range_or_visit(R&& rg, F f);
+----
+
+Equivalent to
+[listing,subs="+macros,+quotes"]
+-----
+  for(auto&& x: rg) 
+    this->xref:#concurrent_node_set_emplace_or_cvisit[emplace_or_[c\]visit](std::forward<decltype(x)>(x), std::ref(f));
 -----
 
 [horizontal]
@@ -1250,6 +1425,28 @@ Equivalent to
 [listing,subs="+macros,+quotes"]
 -----
   while(first != last) this->xref:#concurrent_node_set_emplace_and_cvisit[emplace_and_[c\]visit](*first++, f1, f2);
+-----
+
+[horizontal]
+Returns:;; The number of elements inserted.
+
+---
+
+==== Insert Range and Visit
+[source,c++,subs="+macros,+quotes"]
+----
+template<xref:#concurrent_node_set_container_compatible_range[__container-compatible-range__]<value_type> R, class F1, class F2>
+  size_type insert_range_and_visit(R&& rg, F1 f1, F2 f2);
+template<xref:#concurrent_node_set_container_compatible_range[__container-compatible-range__]<value_type> R, class F1, class F2>
+  size_type insert_range_and_cvisit(R&& rg, F1 f1, F2 f2);
+----
+
+Equivalent to
+[listing,subs="+macros,+quotes"]
+-----
+  for(auto&& x: rg)
+    this->xref:#concurrent_node_set_emplace_and_cvisit[emplace_and_[c\]visit](
+      std::forward<decltype(x)>(x), std::ref(f1), std::ref(f2));
 -----
 
 [horizontal]
@@ -1637,6 +1834,16 @@ of the constructor selected.
 template<class InputIterator>
   using __iter-value-type__ =
     typename std::iterator_traits<InputIterator>::value_type; // exposition only
+-----
+
+==== __convertible-to-from-range_t__
+[listings,subs="+macros,+quotes"]
+-----
+template<typename FromRangeT>
+  concept __convertible-to-from_range_t__ =
+    // first clause not present if std::from_range_t does not exist
+    std::is_convertible_v<FromRangeT, std::from_range_t> ||
+    std::is_convertible_v<FromRangeT, boost::unordered::from_range_t>; // exposition only
 -----
 
 === Equality Comparisons

--- a/doc/modules/ROOT/pages/reference/header_concurrent_flat_map.adoc
+++ b/doc/modules/ROOT/pages/reference/header_concurrent_flat_map.adoc
@@ -19,6 +19,10 @@ namespace unordered {
            class Allocator = std::allocator<std::pair<const Key, T>>>
   class xref:reference/concurrent_flat_map.adoc#concurrent_flat_map[concurrent_flat_map];
 
+  // Tag for construction from ranges (pass:[C++20] and up)
+  struct from_range_t { explicit from_range_t() = default; };
+  inline constexpr from_range_t from_range{};
+
   // Equality Comparisons
   template<class Key, class T, class Hash, class Pred, class Alloc>
     bool xref:reference/concurrent_flat_map.adoc#concurrent_flat_map_operator[operator++==++](const concurrent_flat_map<Key, T, Hash, Pred, Alloc>& x,
@@ -39,7 +43,7 @@ namespace unordered {
     typename concurrent_flat_map<K, T, H, P, A>::size_type
       xref:reference/concurrent_flat_map.adoc#concurrent_flat_map_erase_if[erase_if](concurrent_flat_map<K, T, H, P, A>& c, Predicate pred);
 
-  // Pmr aliases (C++17 and up)
+  // Pmr aliases (pass:[C++17] and up)
   namespace pmr {
     template<class Key,
              class T,

--- a/doc/modules/ROOT/pages/reference/header_concurrent_flat_set.adoc
+++ b/doc/modules/ROOT/pages/reference/header_concurrent_flat_set.adoc
@@ -18,6 +18,10 @@ namespace unordered {
            class Allocator = std::allocator<Key>>
   class xref:reference/concurrent_flat_set.adoc#concurrent_flat_set[concurrent_flat_set];
 
+  // Tag for construction from ranges (pass:[C++20] and up)
+  struct from_range_t { explicit from_range_t() = default; };
+  inline constexpr from_range_t from_range{};
+
   // Equality Comparisons
   template<class Key, class Hash, class Pred, class Alloc>
     bool xref:reference/concurrent_flat_set.adoc#concurrent_flat_set_operator[operator++==++](const concurrent_flat_set<Key, Hash, Pred, Alloc>& x,
@@ -38,7 +42,7 @@ namespace unordered {
     typename concurrent_flat_set<K, H, P, A>::size_type
       xref:reference/concurrent_flat_set.adoc#concurrent_flat_set_erase_if[erase_if](concurrent_flat_set<K, H, P, A>& c, Predicate pred);
 
-  // Pmr aliases (C++17 and up)
+  // Pmr aliases (pass:[C++17] and up)
   namespace pmr {
     template<class Key,
              class Hash = boost::hash<Key>,

--- a/doc/modules/ROOT/pages/reference/header_concurrent_node_map.adoc
+++ b/doc/modules/ROOT/pages/reference/header_concurrent_node_map.adoc
@@ -19,6 +19,10 @@ namespace unordered {
            class Allocator = std::allocator<std::pair<const Key, T>>>
   class xref:reference/concurrent_node_map.adoc#concurrent_node_map[concurrent_node_map];
 
+  // Tag for construction from ranges (pass:[C++20] and up)
+  struct from_range_t { explicit from_range_t() = default; };
+  inline constexpr from_range_t from_range{};
+
   // Equality Comparisons
   template<class Key, class T, class Hash, class Pred, class Alloc>
     bool xref:reference/concurrent_node_map.adoc#concurrent_node_map_operator[operator++==++](const concurrent_node_map<Key, T, Hash, Pred, Alloc>& x,
@@ -39,7 +43,7 @@ namespace unordered {
     typename concurrent_node_map<K, T, H, P, A>::size_type
       xref:reference/concurrent_node_map.adoc#concurrent_node_map_erase_if[erase_if](concurrent_node_map<K, T, H, P, A>& c, Predicate pred);
 
-  // Pmr aliases (C++17 and up)
+  // Pmr aliases (pass:[C++17] and up)
   namespace pmr {
     template<class Key,
              class T,

--- a/doc/modules/ROOT/pages/reference/header_concurrent_node_set.adoc
+++ b/doc/modules/ROOT/pages/reference/header_concurrent_node_set.adoc
@@ -18,6 +18,10 @@ namespace unordered {
            class Allocator = std::allocator<Key>>
   class xref:reference/concurrent_node_set.adoc#concurrent_node_set[concurrent_node_set];
 
+  // Tag for construction from ranges (pass:[C++20] and up)
+  struct from_range_t { explicit from_range_t() = default; };
+  inline constexpr from_range_t from_range{};
+
   // Equality Comparisons
   template<class Key, class Hash, class Pred, class Alloc>
     bool xref:reference/concurrent_node_set.adoc#concurrent_node_set_operator[operator++==++](const concurrent_node_set<Key, Hash, Pred, Alloc>& x,
@@ -38,7 +42,7 @@ namespace unordered {
     typename concurrent_node_set<K, H, P, A>::size_type
       xref:reference/concurrent_node_set.adoc#concurrent_node_set_erase_if[erase_if](concurrent_node_set<K, H, P, A>& c, Predicate pred);
 
-  // Pmr aliases (C++17 and up)
+  // Pmr aliases (pass:[C++17] and up)
   namespace pmr {
     template<class Key,
              class Hash = boost::hash<Key>,

--- a/doc/modules/ROOT/pages/reference/header_unordered_flat_map.adoc
+++ b/doc/modules/ROOT/pages/reference/header_unordered_flat_map.adoc
@@ -19,6 +19,10 @@ namespace unordered {
            class Allocator = std::allocator<std::pair<const Key, T>>>
   class xref:reference/unordered_flat_map.adoc#unordered_flat_map[unordered_flat_map];
 
+  // Tag for construction from ranges (pass:[C++20] and up)
+  struct from_range_t { explicit from_range_t() = default; };
+  inline constexpr from_range_t from_range{};
+
   // Equality Comparisons
   template<class Key, class T, class Hash, class Pred, class Alloc>
     bool xref:reference/unordered_flat_map.adoc#unordered_flat_map_operator_2[operator++==++](const unordered_flat_map<Key, T, Hash, Pred, Alloc>& x,
@@ -39,7 +43,7 @@ namespace unordered {
     typename unordered_flat_map<K, T, H, P, A>::size_type
       xref:reference/unordered_flat_map.adoc#unordered_flat_map_erase_if[erase_if](unordered_flat_map<K, T, H, P, A>& c, Predicate pred);
 
-  // Pmr aliases (C++17 and up)
+  // Pmr aliases (pass:[C++17] and up)
   namespace pmr {
     template<class Key,
              class T,

--- a/doc/modules/ROOT/pages/reference/header_unordered_flat_set.adoc
+++ b/doc/modules/ROOT/pages/reference/header_unordered_flat_set.adoc
@@ -18,6 +18,10 @@ namespace unordered {
            class Allocator = std::allocator<Key>>
   class xref:reference/unordered_flat_set.adoc#unordered_flat_set[unordered_flat_set];
 
+  // Tag for construction from ranges (pass:[C++20] and up)
+  struct from_range_t { explicit from_range_t() = default; };
+  inline constexpr from_range_t from_range{};
+
   // Equality Comparisons
   template<class Key, class Hash, class Pred, class Alloc>
     bool xref:reference/unordered_flat_set.adoc#unordered_flat_set_operator[operator++==++](const unordered_flat_set<Key, Hash, Pred, Alloc>& x,
@@ -38,7 +42,7 @@ namespace unordered {
     typename unordered_flat_set<K, H, P, A>::size_type
       xref:reference/unordered_flat_set.adoc#unordered_flat_set_erase_if[erase_if](unordered_flat_set<K, H, P, A>& c, Predicate pred);
 
-  // Pmr aliases (C++17 and up)
+  // Pmr aliases (pass:[C++17] and up)
   namespace pmr {
     template<class Key,
              class Hash = boost::hash<Key>,

--- a/doc/modules/ROOT/pages/reference/header_unordered_map.adoc
+++ b/doc/modules/ROOT/pages/reference/header_unordered_map.adoc
@@ -20,6 +20,10 @@ namespace unordered {
            class Allocator = std::allocator<std::pair<const Key, T>>>
   class xref:reference/unordered_map.adoc#unordered_map[unordered_map];
 
+  // Tag for construction from ranges (pass:[C++20] and up)
+  struct from_range_t { explicit from_range_t() = default; };
+  inline constexpr from_range_t from_range{};
+
   // Equality Comparisons
   template<class Key, class T, class Hash, class Pred, class Alloc>
     bool xref:reference/unordered_map.adoc#unordered_map_operator_2[operator++==++](const unordered_map<Key, T, Hash, Pred, Alloc>& x,
@@ -67,7 +71,7 @@ namespace unordered {
     typename unordered_multimap<K, T, H, P, A>::size_type
       xref:reference/unordered_multimap.adoc#unordered_multimap_erase_if[erase_if](unordered_multimap<K, T, H, P, A>& c, Predicate pred);
 
-  // Pmr aliases (C++17 and up)
+  // Pmr aliases (pass:[C++17] and up)
   namespace pmr {
     template<class Key,
              class T,

--- a/doc/modules/ROOT/pages/reference/header_unordered_node_map.adoc
+++ b/doc/modules/ROOT/pages/reference/header_unordered_node_map.adoc
@@ -19,6 +19,10 @@ namespace unordered {
            class Allocator = std::allocator<std::pair<const Key, T>>>
   class xref:reference/unordered_node_map.adoc#unordered_node_map[unordered_node_map];
 
+  // Tag for construction from ranges (pass:[C++20] and up)
+  struct from_range_t { explicit from_range_t() = default; };
+  inline constexpr from_range_t from_range{};
+
   // Equality Comparisons
   template<class Key, class T, class Hash, class Pred, class Alloc>
     bool xref:reference/unordered_node_map.adoc#unordered_node_map_operator_2[operator++==++](const unordered_node_map<Key, T, Hash, Pred, Alloc>& x,
@@ -39,7 +43,7 @@ namespace unordered {
     typename unordered_node_map<K, T, H, P, A>::size_type
       xref:reference/unordered_node_map.adoc#unordered_node_map_erase_if[erase_if](unordered_node_map<K, T, H, P, A>& c, Predicate pred);
 
-  // Pmr aliases (C++17 and up)
+  // Pmr aliases (pass:[C++17] and up)
   namespace pmr {
     template<class Key,
              class T,

--- a/doc/modules/ROOT/pages/reference/header_unordered_node_set.adoc
+++ b/doc/modules/ROOT/pages/reference/header_unordered_node_set.adoc
@@ -18,6 +18,10 @@ namespace unordered {
            class Allocator = std::allocator<Key>>
   class xref:reference/unordered_node_set.adoc#unordered_node_set[unordered_node_set];
 
+  // Tag for construction from ranges (pass:[C++20] and up)
+  struct from_range_t { explicit from_range_t() = default; };
+  inline constexpr from_range_t from_range{};
+
   // Equality Comparisons
   template<class Key, class Hash, class Pred, class Alloc>
     bool xref:reference/unordered_node_set.adoc#unordered_node_set_operator[operator++==++](const unordered_node_set<Key, Hash, Pred, Alloc>& x,
@@ -38,7 +42,7 @@ namespace unordered {
     typename unordered_node_set<K, H, P, A>::size_type
       xref:reference/unordered_node_set.adoc#unordered_node_set_erase_if[erase_if](unordered_node_set<K, H, P, A>& c, Predicate pred);
 
-  // Pmr aliases (C++17 and up)
+  // Pmr aliases (pass:[C++17] and up)
   namespace pmr {
     template<class Key,
              class Hash = boost::hash<Key>,

--- a/doc/modules/ROOT/pages/reference/header_unordered_set.adoc
+++ b/doc/modules/ROOT/pages/reference/header_unordered_set.adoc
@@ -19,6 +19,10 @@ namespace unordered {
            class Allocator = std::allocator<Key>>
   class xref:reference/unordered_set.adoc#unordered_set[unordered_set];
 
+  // Tag for construction from ranges (pass:[C++20] and up)
+  struct from_range_t { explicit from_range_t() = default; };
+  inline constexpr from_range_t from_range{};
+
   // Equality Comparisons
   template<class Key, class Hash, class Pred, class Alloc>
     bool xref:reference/unordered_set.adoc#unordered_set_operator[operator++==++](const unordered_set<Key, Hash, Pred, Alloc>& x,
@@ -65,7 +69,7 @@ namespace unordered {
     typename unordered_multiset<K, H, P, A>::size_type
       xref:reference/unordered_multiset.adoc#unordered_multiset_erase_if[erase_if](unordered_multiset<K, H, P, A>& c, Predicate pred);
 
-  // Pmr aliases (C++17 and up)
+  // Pmr aliases (pass:[C++17] and up)
   namespace pmr {
     template<class Key,
              class Hash = boost::hash<Key>,

--- a/doc/modules/ROOT/pages/reference/unordered_flat_map.adoc
+++ b/doc/modules/ROOT/pages/reference/unordered_flat_map.adoc
@@ -82,6 +82,12 @@ namespace unordered {
     xref:#unordered_flat_map_copy_constructor_with_allocator[unordered_flat_map](const unordered_flat_map& other, const Allocator& a);
     xref:#unordered_flat_map_move_constructor_with_allocator[unordered_flat_map](unordered_flat_map&& other, const Allocator& a);
     xref:#unordered_flat_map_move_constructor_from_concurrent_flat_map[unordered_flat_map](concurrent_flat_map<Key, T, Hash, Pred, Allocator>&& other);
+    template<class FromRangeT, xref:#unordered_flat_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#unordered_flat_map_range_constructor[unordered_flat_map](FromRangeT&&, R&& rg,
+                         size_type n = _implementation-defined_,
+                         const hasher& hf = hasher(),
+                         const key_equal& eql = key_equal(),
+                         const allocator_type& a = allocator_type());
     xref:#unordered_flat_map_initializer_list_constructor[unordered_flat_map](std::initializer_list<value_type> il,
                        size_type n = _implementation-defined_
                        const hasher& hf = hasher(),
@@ -93,6 +99,13 @@ namespace unordered {
       xref:#unordered_flat_map_iterator_range_constructor_with_bucket_count_and_allocator[unordered_flat_map](InputIterator f, InputIterator l, size_type n, const allocator_type& a);
     template<class InputIterator>
       xref:#unordered_flat_map_iterator_range_constructor_with_bucket_count_and_hasher[unordered_flat_map](InputIterator f, InputIterator l, size_type n, const hasher& hf,
+                         const allocator_type& a);
+    template<class FromRangeT, xref:#unordered_flat_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#unordered_flat_map_range_constructor_with_allocator[unordered_flat_map](FromRangeT&&, R&& rg, const allocator_type& a);
+    template<class FromRangeT, xref:#unordered_flat_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#unordered_flat_map_range_constructor_with_bucket_count_and_allocator[unordered_flat_map](FromRangeT&&, R&& rg, size_type n, const allocator_type& a);
+    template<class FromRangeT, xref:#unordered_flat_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#unordered_flat_map_range_constructor_with_bucket_count_and_hasher_and_allocator[unordered_flat_map](FromRangeT&&, R&& rg, size_type n, const hasher& hf,
                          const allocator_type& a);
     xref:#unordered_flat_map_initializer_list_constructor_with_allocator[unordered_flat_map](std::initializer_list<value_type> il, const allocator_type& a);
     xref:#unordered_flat_map_initializer_list_constructor_with_bucket_count_and_allocator[unordered_flat_map](std::initializer_list<value_type> il, size_type n,
@@ -133,6 +146,8 @@ namespace unordered {
     iterator       xref:#unordered_flat_map_move_insert_with_hint[insert](const_iterator hint, value_type&& obj);
     iterator       xref:#unordered_flat_map_copy_insert_with_hint[insert](const_iterator hint, init_type&& obj);
     template<class InputIterator> void xref:#unordered_flat_map_insert_iterator_range[insert](InputIterator first, InputIterator last);
+    template<xref:#unordered_flat_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+      void xref:#unordered_flat_map_insert_range[insert_range](R&& rg);
     void xref:#unordered_flat_map_insert_initializer_list[insert](std::initializer_list<value_type>);
 
     template<class... Args>
@@ -235,6 +250,17 @@ namespace unordered {
       -> unordered_flat_map<xref:#unordered_flat_map_iter_key_type[__iter-key-type__]<InputIterator>, xref:#unordered_flat_map_iter_mapped_type[__iter-mapped-type__]<InputIterator>, Hash,
                             Pred, Allocator>;
 
+  template<xref:#unordered_flat_map_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R,
+           class Hash = boost::hash<xref:#unordered_flat_map_range_key_type[__range-key-type__]<R>>,
+           class Pred = std::equal_to<xref:#unordered_flat_map_range_key_type[__range-key-type__]<R>>,
+           class Allocator = std::allocator<xref:#unordered_flat_map_range_to_alloc_type[__range-to-alloc-type__]<R>>>
+    unordered_flat_map(FromRangeT&&, R&&,
+                       typename xref:#unordered_flat_map_deduction_guides[__see below__]::size_type = xref:#unordered_flat_map_deduction_guides[__see below__], Hash = Hash(),
+                       Pred = Pred(), Allocator = Allocator())
+      -> unordered_flat_map<xref:#unordered_flat_map_range_key_type[__range-key-type__]<R>, xref:#unordered_flat_map_range_mapped_type[__range-mapped-type__]<R>,
+                            Hash, Pred,Allocator>;
+
   template<class Key, class T, class Hash = boost::hash<Key>,
            class Pred = std::equal_to<Key>,
            class Allocator = std::allocator<std::pair<const Key, T>>>
@@ -260,6 +286,27 @@ namespace unordered {
                        Allocator)
       -> unordered_flat_map<xref:#unordered_flat_map_iter_key_type[__iter-key-type__]<InputIterator>, xref:#unordered_flat_map_iter_mapped_type[__iter-mapped-type__]<InputIterator>, Hash,
                             std::equal_to<xref:#unordered_flat_map_iter_key_type[__iter-key-type__]<InputIterator>>, Allocator>;
+
+  template<xref:#unordered_flat_map_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R, class Allocator>
+    unordered_flat_map(FromRangeT&&, R&&, typename xref:#unordered_flat_map_deduction_guides[__see below__]::size_type, Allocator)
+      -> unordered_flat_map<xref:#unordered_flat_map_range_key_type[__range-key-type__]<R>, xref:#unordered_flat_map_range_mapped_type[__range-mapped-type__]<R>,
+                            boost::hash<xref:#unordered_flat_map_range_key_type[__range-key-type__]<R>>,
+                            std::equal_to<xref:#unordered_flat_map_range_key_type[__range-key-type__]<R>>, Allocator>;
+
+  template<xref:#unordered_flat_map_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R, class Allocator>
+    unordered_flat_map(FromRangeT&&, R&&, Allocator)
+      -> unordered_flat_map<xref:#unordered_flat_map_range_key_type[__range-key-type__]<R>, xref:#unordered_flat_map_range_mapped_type[__range-mapped-type__]<R>,
+                            boost::hash<xref:#unordered_flat_map_range_key_type[__range-key-type__]<R>>,
+                            std::equal_to<xref:#unordered_flat_map_range_key_type[__range-key-type__]<R>>, Allocator>;
+
+  template<xref:#unordered_flat_map_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R, class Hash, class Allocator>
+    unordered_flat_map(FromRangeT&&, R&&, typename xref:#unordered_flat_map_deduction_guides[__see below__]::size_type, Hash,
+                       Allocator)
+      -> unordered_flat_map<xref:#unordered_flat_map_range_key_type[__range-key-type__]<R>, xref:#unordered_flat_map_range_mapped_type[__range-mapped-type__]<R>,
+                            Hash, std::equal_to<xref:#unordered_flat_map_range_key_type[__range-key-type__]<R>>, Allocator>;
 
   template<class Key, class T, class Allocator>
     unordered_flat_map(std::initializer_list<std::pair<Key, T>>, typename xref:#unordered_flat_map_deduction_guides[__see below__]::size_type,
@@ -357,6 +404,15 @@ A constant iterator whose value type is `value_type`.
 The iterator category is at least a forward iterator.
 
 === Constructors
+
+==== __container-compatible-range__
+[listings,subs="+macros,+quotes"]
+-----
+template<class R, class T>
+  concept container_compatible_range =
+    std::ranges::input_range<R> &&
+    std::convertible_to<std::ranges::range_reference_t<R>, T>; // exposition only
+-----
 
 ==== Default Constructor
 ```c++
@@ -496,6 +552,27 @@ Concurrency:;; Blocking on `other`.
 
 ---
 
+==== Range Constructor
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#unordered_flat_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+  unordered_flat_map(FromRangeT&&, R&& rg,
+                     size_type n = _implementation-defined_,
+                     const hasher& hf = hasher(),
+                     const key_equal& eql = key_equal(),
+                     const allocator_type& a = allocator_type());
+----
+
+Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `eql` as the key equality predicate and `a` as the allocator, and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::unordered::from_range_t`.
+
+
+[horizontal]
+Requires:;; If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
 ==== Initializer List Constructor
 [source,c++,subs="+quotes"]
 ----
@@ -506,7 +583,7 @@ unordered_flat_map(std::initializer_list<value_type> il,
               const allocator_type& a = allocator_type());
 ----
 
-Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `eql` as the key equality predicate and `a`, and inserts the elements from `il` into it.
+Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `eql` as the key equality predicate and `a` as the allocator, and inserts the elements from `il` into it.
 
 [horizontal]
 Requires:;; If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
@@ -562,6 +639,58 @@ Requires:;; `hasher`, `key_equal` need to be https://en.cppreference.com/w/cpp/n
 ----
 
 Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `a` as the allocator, with the default key equality predicate, and inserts the elements from `[f, l)` into it.
+
+[horizontal]
+Requires:;; `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
+==== Range Constructor with Allocator
+
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#unordered_flat_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+  unordered_flat_map(FromRangeT&&, R&& rg, const allocator_type& a);
+----
+
+Constructs an empty container using `a` and default hash function and key equality predicate, and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::unordered::from_range_t`.
+
+[horizontal]
+Requires:;; `hasher` and `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
+==== Range Constructor with Bucket Count and Allocator
+
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#unordered_flat_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+  unordered_flat_map(FromRangeT&&, R&& rg, size_type n, const allocator_type& a);
+----
+
+Constructs an empty container with at least `n` buckets, using `a` and default hash function and key equality predicate, and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::unordered::from_range_t`.
+
+[horizontal]
+Requires:;; `hasher` and `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
+==== Range Constructor with Bucket Count and Hasher and Allocator
+
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#unordered_flat_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+  unordered_flat_map(FromRangeT&&, R&& rg, size_type n, const hasher& hf,
+                    const allocator_type& a);
+----
+
+Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `a` as the allocator and default key equality predicate, and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::unordered::from_range_t`.
 
 [horizontal]
 Requires:;; `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
@@ -879,6 +1008,22 @@ Inserts a range of elements into the container. Elements are inserted if and onl
 
 [horizontal]
 Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into the container from `*first`.
+Throws:;; When inserting a single element, if an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; Can invalidate iterators, pointers and references, but only if the insert causes the load to be greater than the maximum load.
+
+---
+
+==== Insert Range
+[source,c++,subs="+macros,+quotes"]
+----
+template<xref:#unordered_flat_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+  void insert_range(R&& rg);
+----
+
+Inserts a range of elements into the container. Elements are inserted if and only if there is no element in the container with an equivalent key.
+
+[horizontal]
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into the container from `*std::ranges​::​begin(rg)`.
 Throws:;; When inserting a single element, if an exception is thrown by an operation other than a call to `hasher` the function has no effect.
 Notes:;; Can invalidate iterators, pointers and references, but only if the insert causes the load to be greater than the maximum load.
 
@@ -1443,6 +1588,42 @@ template<class InputIterator>
   using __iter-to-alloc-type__ = std::pair<
     std::add_const_t<std::tuple_element_t<0, xref:#unordered_flat_map_iter_value_type[__iter-value-type__]<InputIterator>>>,
     std::tuple_element_t<1, xref:#unordered_flat_map_iter_value_type[__iter-value-type__]<InputIterator>>>; // exposition only
+-----
+
+==== __convertible-to-from-range_t__
+[listings,subs="+macros,+quotes"]
+-----
+template<typename FromRangeT>
+  concept __convertible-to-from_range_t__ =
+    // first clause not present if std::from_range_t does not exist
+    std::is_convertible_v<FromRangeT, std::from_range_t> ||
+    std::is_convertible_v<FromRangeT, boost::unordered::from_range_t>; // exposition only
+-----
+
+==== __range-key-type__
+[listings,subs="+macros,+quotes"]
+-----
+template<std::ranges::input_range R>
+  using __range-key-type__ =
+    std::remove_cvref_t<
+      std::tuple_element_t<0, std::ranges::range_value_t<R>>>; // exposition only
+-----
+
+==== __range-mapped-type__
+[listings,subs="+macros,+quotes"]
+-----
+template<std::ranges::input_range R>
+  using __range-mapped-type__ =
+    std::remove_cvref_t<
+      std::tuple_element_t<1, std::ranges::range_value_t<R>>>; // exposition only
+-----
+
+==== __range-to-alloc-type__
+[listings,subs="+macros,+quotes"]
+-----
+template<std::ranges::input_range R>
+  using __range-to-alloc-type__ = 
+    std::pair<const xref:#unordered_flat_map_range_key_type[__range-key-type__]<R>, xref:#unordered_flat_map_range_mapped_type[__range-mapped-type__]<R>>; // exposition only
 -----
 
 === Equality Comparisons

--- a/doc/modules/ROOT/pages/reference/unordered_flat_set.adoc
+++ b/doc/modules/ROOT/pages/reference/unordered_flat_set.adoc
@@ -76,6 +76,12 @@ namespace unordered {
     explicit xref:#unordered_flat_set_allocator_constructor[unordered_flat_set](const Allocator& a);
     xref:#unordered_flat_set_copy_constructor_with_allocator[unordered_flat_set](const unordered_flat_set& other, const Allocator& a);
     xref:#unordered_flat_set_move_constructor_from_concurrent_flat_set[unordered_flat_set](concurrent_flat_set<Key, Hash, Pred, Allocator>&& other);
+    template<class FromRangeT, xref:#unordered_flat_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#unordered_flat_set_range_constructor[unordered_flat_set](FromRangeT&&, R&& rg,
+                         size_type n = _implementation-defined_,
+                         const hasher& hf = hasher(),
+                         const key_equal& eql = key_equal(),
+                         const allocator_type& a = allocator_type());
     xref:#unordered_flat_set_initializer_list_constructor[unordered_flat_set](std::initializer_list<value_type> il,
                        size_type n = _implementation-defined_
                        const hasher& hf = hasher(),
@@ -87,6 +93,13 @@ namespace unordered {
       xref:#unordered_flat_set_iterator_range_constructor_with_bucket_count_and_allocator[unordered_flat_set](InputIterator f, InputIterator l, size_type n, const allocator_type& a);
     template<class InputIterator>
       xref:#unordered_flat_set_iterator_range_constructor_with_bucket_count_and_hasher[unordered_flat_set](InputIterator f, InputIterator l, size_type n, const hasher& hf,
+                         const allocator_type& a);
+    template<class FromRangeT, xref:#unordered_flat_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#unordered_flat_set_range_constructor_with_allocator[unordered_flat_set](FromRangeT&&, R&& rg, const allocator_type& a);
+    template<class FromRangeT, xref:#unordered_flat_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#unordered_flat_set_range_constructor_with_bucket_count_and_allocator[unordered_flat_set](FromRangeT&&, R&& rg, size_type n, const allocator_type& a);
+    template<class FromRangeT, xref:#unordered_flat_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#unordered_flat_set_range_constructor_with_bucket_count_and_hasher_and_allocator[unordered_flat_set](FromRangeT&&, R&& rg, size_type n, const hasher& hf,
                          const allocator_type& a);
     xref:#unordered_flat_set_initializer_list_constructor_with_allocator[unordered_flat_set](std::initializer_list<value_type> il, const allocator_type& a);
     xref:#unordered_flat_set_initializer_list_constructor_with_bucket_count_and_allocator[unordered_flat_set](std::initializer_list<value_type> il, size_type n,
@@ -125,6 +138,8 @@ namespace unordered {
     iterator xref:#unordered_flat_set_move_insert_with_hint[insert](const_iterator hint, value_type&& obj);
     template<class K> iterator xref:#unordered_flat_set_transparent_insert_with_hint[insert](const_iterator hint, K&& k);
     template<class InputIterator> void xref:#unordered_flat_set_insert_iterator_range[insert](InputIterator first, InputIterator last);
+    template<xref:#unordered_flat_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+      void xref:#unordered_flat_set_insert_range[insert_range](R&& rg);
     void xref:#unordered_flat_set_insert_initializer_list[insert](std::initializer_list<value_type>);
 
     _convertible-to-iterator_     xref:#unordered_flat_set_erase_by_position[erase](iterator position);
@@ -192,6 +207,16 @@ namespace unordered {
                        Hash = Hash(), Pred = Pred(), Allocator = Allocator())
       -> unordered_flat_set<xref:#unordered_flat_set_iter_value_type[__iter-value-type__]<InputIterator>, Hash, Pred, Allocator>;
 
+  template<xref:#unordered_flat_set_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R,
+           class Hash = boost::hash<std::ranges::range_value_t<R>>,
+           class Pred = std::equal_to<std::ranges::range_value_t<R>>,
+           class Allocator = std::allocator<std::ranges::range_value_t<R>>
+    unordered_flat_set(FromRangeT&&, R&&,
+                       typename xref:#unordered_flat_set_deduction_guides[__see below__]::size_type = xref:#unordered_flat_set_deduction_guides[__see below__], Hash = Hash(),
+                       Pred = Pred(), Allocator = Allocator())
+      -> unordered_flat_set<std::ranges::range_value_t<R>, Hash, Pred,Allocator>;
+
   template<class T, class Hash = boost::hash<T>, class Pred = std::equal_to<T>,
            class Allocator = std::allocator<T>>
     unordered_flat_set(std::initializer_list<T>, typename xref:#unordered_flat_set_deduction_guides[__see below__]::size_type = xref:#unordered_flat_set_deduction_guides[__see below__],
@@ -215,6 +240,27 @@ namespace unordered {
                        Allocator)
       -> unordered_flat_set<xref:#unordered_flat_set_iter_value_type[__iter-value-type__]<InputIterator>, Hash,
                             std::equal_to<xref:#unordered_flat_set_iter_value_type[__iter-value-type__]<InputIterator>>, Allocator>;
+
+  template<xref:#unordered_flat_set_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R, class Allocator>
+    unordered_flat_set(FromRangeT&&, R&&, typename xref:#unordered_flat_set_deduction_guides[__see below__]::size_type, Allocator)
+      -> unordered_flat_set<std::ranges::range_value_t<R>,
+                            boost::hash<std::ranges::range_value_t<R>>,
+                            std::equal_to<std::ranges::range_value_t<R>>, Allocator>;
+
+  template<xref:#unordered_flat_set_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R, class Allocator>
+    unordered_flat_set(FromRangeT&&, R&&, Allocator)
+      -> unordered_flat_set<std::ranges::range_value_t<R>, 
+                            boost::hash<std::ranges::range_value_t<R>>,
+                            std::equal_to<std::ranges::range_value_t<R>>, Allocator>;
+
+  template<xref:#unordered_flat_set_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R, class Hash, class Allocator>
+    unordered_flat_set(FromRangeT&&, R&&, typename xref:#unordered_flat_set_deduction_guides[__see below__]::size_type, Hash,
+                       Allocator)
+      -> unordered_flat_set<std::ranges::range_value_t<R>,
+                            Hash, std::equal_to<std::ranges::range_value_t<R>>, Allocator>;
 
   template<class T, class Allocator>
     unordered_flat_set(std::initializer_list<T>, typename xref:#unordered_flat_set_deduction_guides[__see below__]::size_type, Allocator)
@@ -306,6 +352,15 @@ A constant iterator whose value type is `value_type`.
 The iterator category is at least a forward iterator.
 
 === Constructors
+
+==== __container-compatible-range__
+[listings,subs="+macros,+quotes"]
+-----
+template<class R, class T>
+  concept container_compatible_range =
+    std::ranges::input_range<R> &&
+    std::convertible_to<std::ranges::range_reference_t<R>, T>; // exposition only
+-----
 
 ==== Default Constructor
 ```c++
@@ -445,6 +500,27 @@ Concurrency:;; Blocking on `other`.
 
 ---
 
+==== Range Constructor
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#unordered_flat_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+  unordered_flat_set(FromRangeT&&, R&& rg,
+                     size_type n = _implementation-defined_,
+                     const hasher& hf = hasher(),
+                     const key_equal& eql = key_equal(),
+                     const allocator_type& a = allocator_type());
+----
+
+Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `eql` as the key equality predicate and `a` as the allocator, and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::unordered::from_range_t`.
+
+
+[horizontal]
+Requires:;; If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
 ==== Initializer List Constructor
 [source,c++,subs="+quotes"]
 ----
@@ -455,7 +531,7 @@ unordered_flat_set(std::initializer_list<value_type> il,
               const allocator_type& a = allocator_type());
 ----
 
-Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `eql` as the key equality predicate and `a`, and inserts the elements from `il` into it.
+Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `eql` as the key equality predicate and `a` as the allocator, and inserts the elements from `il` into it.
 
 [horizontal]
 Requires:;; If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
@@ -517,6 +593,58 @@ Requires:;; `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/
 
 ---
 
+==== Range Constructor with Allocator
+
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#unordered_flat_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+  unordered_flat_set(FromRangeT&&, R&& rg, const allocator_type& a);
+----
+
+Constructs an empty container using `a` and default hash function and key equality predicate, and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::unordered::from_range_t`.
+
+[horizontal]
+Requires:;; `hasher` and `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
+==== Range Constructor with Bucket Count and Allocator
+
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#unordered_flat_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+  unordered_flat_set(FromRangeT&&, R&& rg, size_type n, const allocator_type& a);
+----
+
+Constructs an empty container with at least `n` buckets, using `a` and default hash function and key equality predicate, and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::unordered::from_range_t`.
+
+[horizontal]
+Requires:;; `hasher` and `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
+==== Range Constructor with Bucket Count and Hasher and Allocator
+
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#unordered_flat_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+  unordered_flat_set(FromRangeT&&, R&& rg, size_type n, const hasher& hf,
+                     const allocator_type& a);
+----
+
+Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `a` as the allocator and default key equality predicate, and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::unordered::from_range_t`.
+
+[horizontal]
+Requires:;; `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
 ==== initializer_list Constructor with Allocator
 
 ```c++
@@ -550,7 +678,7 @@ unordered_flat_set(std::initializer_list<value_type> il, size_type n, const hash
                    const allocator_type& a);
 ```
 
-Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `a` as the allocator and default key equality predicate,and inserts the elements from `il` into it.
+Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `a` as the allocator and default key equality predicate, and inserts the elements from `il` into it.
 
 [horizontal]
 Requires:;; `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
@@ -852,6 +980,22 @@ Inserts a range of elements into the container. Elements are inserted if and onl
 
 [horizontal]
 Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into the container from `*first`.
+Throws:;; When inserting a single element, if an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; Can invalidate iterators, pointers and references, but only if the insert causes the load to be greater than the maximum load.
+
+---
+
+==== Insert Range
+[source,c++,subs="+macros,+quotes"]
+----
+template<xref:#unordered_flat_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+  void insert_range(R&& rg);
+----
+
+Inserts a range of elements into the container. Elements are inserted if and only if there is no element in the container with an equivalent key.
+
+[horizontal]
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into the container from `*std::ranges​::​begin(rg)`.
 Throws:;; When inserting a single element, if an exception is thrown by an operation other than a call to `hasher` the function has no effect.
 Notes:;; Can invalidate iterators, pointers and references, but only if the insert causes the load to be greater than the maximum load.
 
@@ -1192,6 +1336,16 @@ of the constructor selected.
 template<class InputIterator>
   using __iter-value-type__ =
     typename std::iterator_traits<InputIterator>::value_type; // exposition only
+-----
+
+==== __convertible-to-from-range_t__
+[listings,subs="+macros,+quotes"]
+-----
+template<typename FromRangeT>
+  concept __convertible-to-from_range_t__ =
+    // first clause not present if std::from_range_t does not exist
+    std::is_convertible_v<FromRangeT, std::from_range_t> ||
+    std::is_convertible_v<FromRangeT, boost::unordered::from_range_t>; // exposition only
 -----
 
 === Equality Comparisons

--- a/doc/modules/ROOT/pages/reference/unordered_map.adoc
+++ b/doc/modules/ROOT/pages/reference/unordered_map.adoc
@@ -61,8 +61,14 @@ namespace unordered {
     explicit xref:#unordered_map_allocator_constructor[unordered_map](const Allocator& a);
     xref:#unordered_map_copy_constructor_with_allocator[unordered_map](const unordered_map& other, const Allocator& a);
     xref:#unordered_map_move_constructor_with_allocator[unordered_map](unordered_map&& other, const Allocator& a);
+    template<class FromRangeT, xref:#unordered_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#unordered_map_range_constructor[unordered_map](FromRangeT&&, R&& rg,
+                    size_type n = _implementation-defined_,
+                    const hasher& hf = hasher(),
+                    const key_equal& eql = key_equal(),
+                    const allocator_type& a = allocator_type());
     xref:#unordered_map_initializer_list_constructor[unordered_map](std::initializer_list<value_type> il,
-                  size_type n = _implementation-defined_
+                  size_type n = _implementation-defined_,
                   const hasher& hf = hasher(),
                   const key_equal& eql = key_equal(),
                   const allocator_type& a = allocator_type());
@@ -72,6 +78,13 @@ namespace unordered {
       xref:#unordered_map_iterator_range_constructor_with_bucket_count_and_allocator[unordered_map](InputIterator f, InputIterator l, size_type n, const allocator_type& a);
     template<class InputIterator>
       xref:#unordered_map_iterator_range_constructor_with_bucket_count_and_hasher[unordered_map](InputIterator f, InputIterator l, size_type n, const hasher& hf,
+                    const allocator_type& a);
+    template<class FromRangeT, xref:#unordered_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#unordered_map_range_constructor_with_allocator[unordered_map](FromRangeT&&, R&& rg, const allocator_type& a);
+    template<class FromRangeT, xref:#unordered_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#unordered_map_range_constructor_with_bucket_count_and_allocator[unordered_map](FromRangeT&&, R&& rg, size_type n, const allocator_type& a);
+    template<class FromRangeT, xref:#unordered_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#unordered_map_range_constructor_with_bucket_count_and_hasher_and_allocator[unordered_map](FromRangeT&&, R&& rg, size_type n, const hasher& hf,
                     const allocator_type& a);
     xref:#unordered_map_initializer_list_constructor_with_allocator[unordered_map](std::initializer_list<value_type> il, const allocator_type& a);
     xref:#unordered_map_initializer_list_constructor_with_bucket_count_and_allocator[unordered_map](std::initializer_list<value_type> il, size_type n, const allocator_type& a);
@@ -109,6 +122,8 @@ namespace unordered {
     iterator       xref:#unordered_map_move_insert_with_hint[insert](const_iterator hint, value_type&& obj);
     template<class P> iterator xref:#unordered_map_emplace_insert_with_hint[insert](const_iterator hint, P&& obj);
     template<class InputIterator> void xref:#unordered_map_insert_iterator_range[insert](InputIterator first, InputIterator last);
+    template<xref:#unordered_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+      void xref:#unordered_map_insert_range[insert_range](R&& rg);
     void xref:#unordered_map_insert_initializer_list[insert](std::initializer_list<value_type>);
 
     template<class... Args>
@@ -231,8 +246,19 @@ namespace unordered {
            class Allocator = std::allocator<xref:#unordered_map_iter_to_alloc_type[__iter-to-alloc-type__]<InputIterator>>>
     unordered_map(InputIterator, InputIterator, typename xref:#unordered_map_deduction_guides[__see below__]::size_type = xref:#unordered_map_deduction_guides[__see below__],
                   Hash = Hash(), Pred = Pred(), Allocator = Allocator())
-      -> unordered_map<xref:#unordered_map_iter_key_type[__iter-key-type__]<InputIterator>, xref:#unordered_map_iter_mapped_type[__iter-mapped-type__]<InputIterator>, Hash, Pred,
-                       Allocator>;
+      -> unordered_map<xref:#unordered_map_iter_key_type[__iter-key-type__]<InputIterator>, xref:#unordered_map_iter_mapped_type[__iter-mapped-type__]<InputIterator>, 
+                       Hash, Pred, Allocator>;
+
+  template<xref:#unordered_map_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R,
+           class Hash = boost::hash<xref:#unordered_map_range_key_type[__range-key-type__]<R>>,
+           class Pred = std::equal_to<xref:#unordered_map_range_key_type[__range-key-type__]<R>>,
+           class Allocator = std::allocator<xref:#unordered_map_range_to_alloc_type[__range-to-alloc-type__]<R>>>
+    unordered_map(FromRangeT&&, R&&,
+                  typename xref:#unordered_map_deduction_guides[__see below__]::size_type = xref:#unordered_map_deduction_guides[__see below__], Hash = Hash(),
+                  Pred = Pred(), Allocator = Allocator())
+      -> unordered_map<xref:#unordered_map_range_key_type[__range-key-type__]<R>, xref:#unordered_map_range_mapped_type[__range-mapped-type__]<R>,
+                       Hash, Pred,Allocator>;
 
   template<class Key, class T, class Hash = boost::hash<Key>,
            class Pred = std::equal_to<Key>,
@@ -258,6 +284,27 @@ namespace unordered {
     unordered_map(InputIterator, InputIterator, typename xref:#unordered_map_deduction_guides[__see below__]::size_type, Hash, Allocator)
       -> unordered_map<xref:#unordered_map_iter_key_type[__iter-key-type__]<InputIterator>, xref:#unordered_map_iter_mapped_type[__iter-mapped-type__]<InputIterator>, Hash,
                        std::equal_to<xref:#unordered_map_iter_key_type[__iter-key-type__]<InputIterator>>, Allocator>;
+
+  template<xref:#unordered_map_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R, class Allocator>
+    unordered_map(FromRangeT&&, R&&, typename xref:#unordered_map_deduction_guides[__see below__]::size_type, Allocator)
+      -> unordered_map<xref:#unordered_map_range_key_type[__range-key-type__]<R>, xref:#unordered_map_range_mapped_type[__range-mapped-type__]<R>,
+                       boost::hash<xref:#unordered_map_range_key_type[__range-key-type__]<R>>,
+                       std::equal_to<xref:#unordered_map_range_key_type[__range-key-type__]<R>>, Allocator>;
+
+  template<xref:#unordered_map_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R, class Allocator>
+    unordered_map(FromRangeT&&, R&&, Allocator)
+      -> unordered_map<xref:#unordered_map_range_key_type[__range-key-type__]<R>, xref:#unordered_map_range_mapped_type[__range-mapped-type__]<R>,
+                       boost::hash<xref:#unordered_map_range_key_type[__range-key-type__]<R>>,
+                       std::equal_to<xref:#unordered_map_range_key_type[__range-key-type__]<R>>, Allocator>;
+
+  template<xref:#unordered_map_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R, class Hash, class Allocator>
+    unordered_map(FromRangeT&&, R&&, typename xref:#unordered_map_deduction_guides[__see below__]::size_type, Hash,
+                  Allocator)
+      -> unordered_map<xref:#unordered_map_range_key_type[__range-key-type__]<R>, xref:#unordered_map_range_mapped_type[__range-mapped-type__]<R>,
+                       Hash, std::equal_to<xref:#unordered_map_range_key_type[__range-key-type__]<R>>, Allocator>;
 
   template<class Key, class T, class Allocator>
     unordered_map(std::initializer_list<std::pair<Key, T>>, typename xref:#unordered_map_deduction_guides[__see below__]::size_type,
@@ -397,6 +444,15 @@ with `Iterator` = `iterator` and `NodeType` = `node_type`.
 
 === Constructors
 
+==== __container-compatible-range__
+[listings,subs="+macros,+quotes"]
+-----
+template<class R, class T>
+  concept container_compatible_range =
+    std::ranges::input_range<R> &&
+    std::convertible_to<std::ranges::range_reference_t<R>, T>; // exposition only
+-----
+
 ==== Default Constructor
 ```c++
 unordered_map();
@@ -519,11 +575,32 @@ Requires:;; `value_type` is move insertable.
 
 ---
 
+==== Range Constructor
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#unordered_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+  unordered_map(FromRangeT&&, R&& rg,
+                size_type n = _implementation-defined_,
+                const hasher& hf = hasher(),
+                const key_equal& eql = key_equal(),
+                const allocator_type& a = allocator_type());
+----
+
+Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `eql` as the key equality predicate, `a` as the allocator and a maximum load factor of `1.0` and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::unordered::from_range_t`.
+
+
+[horizontal]
+Requires:;; If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
 ==== Initializer List Constructor
 [source,c++,subs="+quotes"]
 ----
 unordered_map(std::initializer_list<value_type> il,
-              size_type n = _implementation-defined_
+              size_type n = _implementation-defined_,
               const hasher& hf = hasher(),
               const key_equal& eql = key_equal(),
               const allocator_type& a = allocator_type());
@@ -585,6 +662,58 @@ Requires:;; `hasher`, `key_equal` need to be https://en.cppreference.com/w/cpp/n
 ----
 
 Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `a` as the allocator, with the default key equality predicate and a maximum load factor of `1.0` and inserts the elements from `[f, l)` into it.
+
+[horizontal]
+Requires:;; `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
+==== Range Constructor with Allocator
+
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#unordered_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+  unordered_map(FromRangeT&&, R&& rg, const allocator_type& a);
+----
+
+Constructs an empty container using `a` as the allocator and a maximum load factor of 1.0 and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::unordered::from_range_t`.
+
+[horizontal]
+Requires:;; `hasher` and `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
+==== Range Constructor with Bucket Count and Allocator
+
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#unordered_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+  unordered_map(FromRangeT&&, R&& rg, size_type n, const allocator_type& a);
+----
+
+Constructs an empty container with at least `n` buckets, using `a` as the allocator and a maximum load factor of 1.0 and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::unordered::from_range_t`.
+
+[horizontal]
+Requires:;; `hasher` and `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
+==== Range Constructor with Bucket Count and Hasher and Allocator
+
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#unordered_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+  unordered_map(FromRangeT&&, R&& rg, size_type n, const hasher& hf,
+                const allocator_type& a);
+----
+
+Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `a` as the allocator and a maximum load factor of 1.0 and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::unordered::from_range_t`.
 
 [horizontal]
 Requires:;; `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
@@ -937,6 +1066,24 @@ Inserts a range of elements into the container. Elements are inserted if and onl
 
 [horizontal]
 Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `*first`.
+Throws:;; When inserting a single element, if an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated.
+
+---
+
+==== Insert Range
+[source,c++,subs="+macros,+quotes"]
+----
+template<xref:#unordered_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+  void insert_range(R&& rg);
+----
+
+Inserts a range of elements into the container. Elements are inserted if and only if there is no element in the container with an equivalent key.
+
+[horizontal]
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into the container from `*std::ranges​::​begin(rg)`.
 Throws:;; When inserting a single element, if an exception is thrown by an operation other than a call to `hasher` the function has no effect.
 Notes:;; Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
 +
@@ -1695,6 +1842,42 @@ template<class InputIterator>
   using __iter-to-alloc-type__ = std::pair<
     std::add_const_t<std::tuple_element_t<0, xref:#unordered_map_iter_value_type[__iter-value-type__]<InputIterator>>>,
     std::tuple_element_t<1, xref:#unordered_map_iter_value_type[__iter-value-type__]<InputIterator>>>; // exposition only
+-----
+
+==== __convertible-to-from-range_t__
+[listings,subs="+macros,+quotes"]
+-----
+template<typename FromRangeT>
+  concept __convertible-to-from_range_t__ =
+    // first clause not present if std::from_range_t does not exist
+    std::is_convertible_v<FromRangeT, std::from_range_t> ||
+    std::is_convertible_v<FromRangeT, boost::unordered::from_range_t>; // exposition only
+-----
+
+==== __range-key-type__
+[listings,subs="+macros,+quotes"]
+-----
+template<std::ranges::input_range R>
+  using __range-key-type__ =
+    std::remove_cvref_t<
+      std::tuple_element_t<0, std::ranges::range_value_t<R>>>; // exposition only
+-----
+
+==== __range-mapped-type__
+[listings,subs="+macros,+quotes"]
+-----
+template<std::ranges::input_range R>
+  using __range-mapped-type__ =
+    std::remove_cvref_t<
+      std::tuple_element_t<1, std::ranges::range_value_t<R>>>; // exposition only
+-----
+
+==== __range-to-alloc-type__
+[listings,subs="+macros,+quotes"]
+-----
+template<std::ranges::input_range R>
+  using __range-to-alloc-type__ = 
+    std::pair<const xref:#unordered_map_range_key_type[__range-key-type__]<R>, xref:#unordered_map_range_mapped_type[__range-mapped-type__]<R>>; // exposition only
 -----
 
 === Equality Comparisons

--- a/doc/modules/ROOT/pages/reference/unordered_multimap.adoc
+++ b/doc/modules/ROOT/pages/reference/unordered_multimap.adoc
@@ -60,6 +60,12 @@ namespace unordered {
     explicit xref:#unordered_multimap_allocator_constructor[unordered_multimap](const Allocator& a);
     xref:#unordered_multimap_copy_constructor_with_allocator[unordered_multimap](const unordered_multimap& other, const Allocator& a);
     xref:#unordered_multimap_move_constructor_with_allocator[unordered_multimap](unordered_multimap&& other, const Allocator& a);
+    template<class FromRangeT, xref:#unordered_multimap_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#unordered_multimap_range_constructor[unordered_multimap](FromRangeT&&, R&& rg,
+                    size_type n = _implementation-defined_,
+                    const hasher& hf = hasher(),
+                    const key_equal& eql = key_equal(),
+                    const allocator_type& a = allocator_type());
     xref:#unordered_multimap_initializer_list_constructor[unordered_multimap](std::initializer_list<value_type> il,
                        size_type n = _implementation-defined_,
                        const hasher& hf = hasher(),
@@ -72,6 +78,13 @@ namespace unordered {
     template<class InputIterator>
       xref:#unordered_multimap_iterator_range_constructor_with_bucket_count_and_hasher[unordered_multimap](InputIterator f, InputIterator l, size_type n, const hasher& hf,
                          const allocator_type& a);
+    template<class FromRangeT, xref:#unordered_multimap_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#unordered_multimap_range_constructor_with_allocator[unordered_multimap](FromRangeT&&, R&& rg, const allocator_type& a);
+    template<class FromRangeT, xref:#unordered_multimap_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#unordered_multimap_range_constructor_with_bucket_count_and_allocator[unordered_multimap](FromRangeT&&, R&& rg, size_type n, const allocator_type& a);
+    template<class FromRangeT, xref:#unordered_multimap_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#unordered_multimap_range_constructor_with_bucket_count_and_hasher_and_allocator[unordered_multimap](FromRangeT&&, R&& rg, size_type n, const hasher& hf,
+                    const allocator_type& a);
     xref:#unordered_multimap_initializer_list_constructor_with_allocator[unordered_multimap](std::initializer_list<value_type> il, const allocator_type& a);
     xref:#unordered_multimap_initializer_list_constructor_with_bucket_count_and_allocator[unordered_multimap](std::initializer_list<value_type> il, size_type n,
                        const allocator_type& a);
@@ -109,6 +122,8 @@ namespace unordered {
     iterator xref:#unordered_multimap_move_insert_with_hint[insert](const_iterator hint, value_type&& obj);
     template<class P> iterator xref:#unordered_multimap_emplace_insert_with_hint[insert](const_iterator hint, P&& obj);
     template<class InputIterator> void xref:#unordered_multimap_insert_iterator_range[insert](InputIterator first, InputIterator last);
+    template<xref:#unordered_multimap_container_compatible_range[__container-compatible-range__]<value_type> R>
+      void xref:#unordered_multimap_insert_range[insert_range](R&& rg);
     void xref:#unordered_multimap_insert_initializer_list[insert](std::initializer_list<value_type> il);
 
     node_type xref:#unordered_multimap_extract_by_iterator[extract](const_iterator position);
@@ -200,6 +215,17 @@ namespace unordered {
       -> unordered_multimap<xref:#unordered_multimap_iter_key_type[__iter-key-type__]<InputIterator>, xref:#unordered_multimap_iter_mapped_type[__iter-mapped-type__]<InputIterator>, Hash,
                             Pred, Allocator>;
 
+  template<xref:#unordered_multimap_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R,
+           class Hash = boost::hash<xref:#unordered_multimap_range_key_type[__range-key-type__]<R>>,
+           class Pred = std::equal_to<xref:#unordered_multimap_range_key_type[__range-key-type__]<R>>,
+           class Allocator = std::allocator<xref:#unordered_multimap_range_to_alloc_type[__range-to-alloc-type__]<R>>>
+    unordered_multimap(FromRangeT&&, R&&,
+                       typename xref:#unordered_multimap_deduction_guides[__see below__]::size_type = xref:#unordered_multimap_deduction_guides[__see below__], Hash = Hash(),
+                       Pred = Pred(), Allocator = Allocator())
+      -> unordered_multimap<xref:#unordered_multimap_range_key_type[__range-key-type__]<R>, xref:#unordered_multimap_range_mapped_type[__range-mapped-type__]<R>,
+                       Hash, Pred,Allocator>;
+
   template<class Key, class T, class Hash = boost::hash<Key>,
            class Pred = std::equal_to<Key>,
            class Allocator = std::allocator<std::pair<const Key, T>>>
@@ -225,6 +251,27 @@ namespace unordered {
                        Allocator)
       -> unordered_multimap<xref:#unordered_multimap_iter_key_type[__iter-key-type__]<InputIterator>, xref:#unordered_multimap_iter_mapped_type[__iter-mapped-type__]<InputIterator>, Hash,
                             std::equal_to<xref:#unordered_multimap_iter_key_type[__iter-key-type__]<InputIterator>>, Allocator>;
+
+  template<xref:#unordered_multimap_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R, class Allocator>
+    unordered_multimap(FromRangeT&&, R&&, typename xref:#unordered_multimap_deduction_guides[__see below__]::size_type, Allocator)
+      -> unordered_multimap<xref:#unordered_multimap_range_key_type[__range-key-type__]<R>, xref:#unordered_multimap_range_mapped_type[__range-mapped-type__]<R>,
+                            boost::hash<xref:#unordered_multimap_range_key_type[__range-key-type__]<R>>,
+                            std::equal_to<xref:#unordered_multimap_range_key_type[__range-key-type__]<R>>, Allocator>;
+
+  template<xref:#unordered_multimap_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R, class Allocator>
+    unordered_multimap(FromRangeT&&, R&&, Allocator)
+      -> unordered_multimap<xref:#unordered_multimap_range_key_type[__range-key-type__]<R>, xref:#unordered_multimap_range_mapped_type[__range-mapped-type__]<R>,
+                            boost::hash<xref:#unordered_multimap_range_key_type[__range-key-type__]<R>>,
+                            std::equal_to<xref:#unordered_multimap_range_key_type[__range-key-type__]<R>>, Allocator>;
+
+  template<xref:#unordered_multimap_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R, class Hash, class Allocator>
+    unordered_multimap(FromRangeT&&, R&&, typename xref:#unordered_multimap_deduction_guides[__see below__]::size_type, Hash,
+                       Allocator)
+      -> unordered_multimap<xref:#unordered_multimap_range_key_type[__range-key-type__]<R>, xref:#unordered_multimap_range_mapped_type[__range-mapped-type__]<R>,
+                            Hash, std::equal_to<xref:#unordered_multimap_range_key_type[__range-key-type__]<R>>, Allocator>;
 
   template<class Key, class T, class Allocator>
     unordered_multimap(std::initializer_list<std::pair<Key, T>>, typename xref:#unordered_multimap_deduction_guides[__see below__]::size_type,
@@ -340,6 +387,15 @@ See node_handle_map for details.
 ---
 
 === Constructors
+
+==== __container-compatible-range__
+[listings,subs="+macros,+quotes"]
+-----
+template<class R, class T>
+  concept container_compatible_range =
+    std::ranges::input_range<R> &&
+    std::convertible_to<std::ranges::range_reference_t<R>, T>; // exposition only
+-----
 
 ==== Default Constructor
 ```c++
@@ -463,6 +519,27 @@ Requires:;; `value_type` is move insertable.
 
 ---
 
+==== Range Constructor
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#unordered_multimap_container_compatible_range[__container-compatible-range__]<value_type> R>
+  unordered_multimap(FromRangeT&&, R&& rg,
+                size_type n = _implementation-defined_,
+                const hasher& hf = hasher(),
+                const key_equal& eql = key_equal(),
+                const allocator_type& a = allocator_type());
+----
+
+Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `eql` as the key equality predicate, `a` as the allocator and a maximum load factor of `1.0` and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::unordered::from_range_t`.
+
+
+[horizontal]
+Requires:;; If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
 ==== Initializer List Constructor
 [source,c++,subs="+quotes"]
 ----
@@ -528,6 +605,58 @@ template<class InputIterator>
 ----
 
 Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `a` as the allocator, with the default key equality predicate and a maximum load factor of `1.0` and inserts the elements from `[f, l)` into it.
+
+[horizontal]
+Requires:;; `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
+==== Range Constructor with Allocator
+
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#unordered_multimap_container_compatible_range[__container-compatible-range__]<value_type> R>
+  unordered_multimap(FromRangeT&&, R&& rg, const allocator_type& a);
+----
+
+Constructs an empty container using `a` as the allocator and a maximum load factor of 1.0 and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::unordered::from_range_t`.
+
+[horizontal]
+Requires:;; `hasher` and `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
+==== Range Constructor with Bucket Count and Allocator
+
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#unordered_multimap_container_compatible_range[__container-compatible-range__]<value_type> R>
+  unordered_multimap(FromRangeT&&, R&& rg, size_type n, const allocator_type& a);
+----
+
+Constructs an empty container with at least `n` buckets, using `a` as the allocator and a maximum load factor of 1.0 and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::unordered::from_range_t`.
+
+[horizontal]
+Requires:;; `hasher` and `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
+==== Range Constructor with Bucket Count and Hasher and Allocator
+
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#unordered_multimap_container_compatible_range[__container-compatible-range__]<value_type> R>
+  unordered_multimap(FromRangeT&&, R&& rg, size_type n, const hasher& hf,
+                const allocator_type& a);
+----
+
+Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `a` as the allocator and a maximum load factor of 1.0 and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::unordered::from_range_t`.
 
 [horizontal]
 Requires:;; `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
@@ -873,6 +1002,25 @@ Notes:;; Can invalidate iterators, but only if the insert causes the load factor
 Pointers and references to elements are never invalidated.
 
 ---
+
+==== Insert Range
+[source,c++,subs="+macros,+quotes"]
+----
+template<xref:#unordered_multimap_container_compatible_range[__container-compatible-range__]<value_type> R>
+  void insert_range(R&& rg);
+----
+
+Inserts a range of elements into the container.
+
+[horizontal]
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into the container from `*std::ranges​::​begin(rg)`.
+Throws:;; When inserting a single element, if an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated.
+
+---
+
 
 ==== Insert Initializer List
 ```c++
@@ -1412,6 +1560,42 @@ template<class InputIterator>
   using __iter-to-alloc-type__ = std::pair<
     std::add_const_t<std::tuple_element_t<0, xref:#unordered_multimap_iter_value_type[__iter-value-type__]<InputIterator>>>,
     std::tuple_element_t<1, xref:#unordered_multimap_iter_value_type[__iter-value-type__]<InputIterator>>>; // exposition only
+-----
+
+==== __convertible-to-from-range_t__
+[listings,subs="+macros,+quotes"]
+-----
+template<typename FromRangeT>
+  concept __convertible-to-from_range_t__ =
+    // first clause not present if std::from_range_t does not exist
+    std::is_convertible_v<FromRangeT, std::from_range_t> ||
+    std::is_convertible_v<FromRangeT, boost::unordered::from_range_t>; // exposition only
+-----
+
+==== __range-key-type__
+[listings,subs="+macros,+quotes"]
+-----
+template<std::ranges::input_range R>
+  using __range-key-type__ =
+    std::remove_cvref_t<
+      std::tuple_element_t<0, std::ranges::range_value_t<R>>>; // exposition only
+-----
+
+==== __range-mapped-type__
+[listings,subs="+macros,+quotes"]
+-----
+template<std::ranges::input_range R>
+  using __range-mapped-type__ =
+    std::remove_cvref_t<
+      std::tuple_element_t<1, std::ranges::range_value_t<R>>>; // exposition only
+-----
+
+==== __range-to-alloc-type__
+[listings,subs="+macros,+quotes"]
+-----
+template<std::ranges::input_range R>
+  using __range-to-alloc-type__ = 
+    std::pair<const xref:#unordered_multimap_range_key_type[__range-key-type__]<R>, xref:#unordered_multimap_range_mapped_type[__range-mapped-type__]<R>>; // exposition only
 -----
 
 === Equality Comparisons

--- a/doc/modules/ROOT/pages/reference/unordered_multiset.adoc
+++ b/doc/modules/ROOT/pages/reference/unordered_multiset.adoc
@@ -58,6 +58,12 @@ namespace unordered {
     explicit xref:#unordered_multiset_allocator_constructor[unordered_multiset](const Allocator& a);
     xref:#unordered_multiset_copy_constructor_with_allocator[unordered_multiset](const unordered_multiset& other, const Allocator& a);
     xref:#unordered_multiset_move_constructor_with_allocator[unordered_multiset](unordered_multiset&& other, const Allocator& a);
+    template<class FromRangeT, xref:#unordered_multiset_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#unordered_multiset_range_constructor[unordered_multiset](FromRangeT&&, R&& rg,
+                         size_type n = _implementation-defined_,
+                         const hasher& hf = hasher(),
+                         const key_equal& eql = key_equal(),
+                         const allocator_type& a = allocator_type());
     xref:#unordered_multiset_initializer_list_constructor[unordered_multiset](std::initializer_list<value_type> il,
                        size_type n = _implementation-defined_,
                        const hasher& hf = hasher(),
@@ -69,6 +75,13 @@ namespace unordered {
       xref:#unordered_multiset_iterator_range_constructor_with_bucket_count_and_allocator[unordered_multiset](InputIterator f, InputIterator l, size_type n, const allocator_type& a);
     template<class InputIterator>
       xref:#unordered_multiset_iterator_range_constructor_with_bucket_count_and_hasher[unordered_multiset](InputIterator f, InputIterator l, size_type n, const hasher& hf,
+                         const allocator_type& a);
+    template<class FromRangeT, xref:#unordered_multiset_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#unordered_multiset_range_constructor_with_allocator[unordered_multiset](FromRangeT&&, R&& rg, const allocator_type& a);
+    template<class FromRangeT, xref:#unordered_multiset_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#unordered_multiset_range_constructor_with_bucket_count_and_allocator[unordered_multiset](FromRangeT&&, R&& rg, size_type n, const allocator_type& a);
+    template<class FromRangeT, xref:#unordered_multiset_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#unordered_multiset_range_constructor_with_bucket_count_and_hasher_and_allocator[unordered_multiset](FromRangeT&&, R&& rg, size_type n, const hasher& hf,
                          const allocator_type& a);
     xref:#unordered_multiset_initializer_list_constructor_with_allocator[unordered_multiset](std::initializer_list<value_type> il, const allocator_type& a);
     xref:#unordered_multiset_initializer_list_constructor_with_bucket_count_and_allocator[unordered_multiset](std::initializer_list<value_type> il, size_type n,
@@ -105,6 +118,8 @@ namespace unordered {
     iterator xref:#unordered_multiset_copy_insert_with_hint[insert](const_iterator hint, const value_type& obj);
     iterator xref:#unordered_multiset_move_insert_with_hint[insert](const_iterator hint, value_type&& obj);
     template<class InputIterator> void xref:#unordered_multiset_insert_iterator_range[insert](InputIterator first, InputIterator last);
+    template<xref:#unordered_multiset_container_compatible_range[__container-compatible-range__]<value_type> R>
+      void xref:#unordered_multiset_insert_range[insert_range](R&& rg);
     void xref:#unordered_multiset_insert_initializer_list[insert](std::initializer_list<value_type> il);
 
     node_type xref:#unordered_multiset_extract_by_iterator[extract](const_iterator position);
@@ -195,6 +210,16 @@ namespace unordered {
                        Hash = Hash(), Pred = Pred(), Allocator = Allocator())
       -> unordered_multiset<xref:#unordered_multiset_iter_value_type[__iter-value-type__]<InputIterator>, Hash, Pred, Allocator>;
 
+  template<xref:#unordered_multiset_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R,
+           class Hash = boost::hash<std::ranges::range_value_t<R>>,
+           class Pred = std::equal_to<std::ranges::range_value_t<R>>,
+           class Allocator = std::allocator<std::ranges::range_value_t<R>>
+    unordered_multiset(FromRangeT&&, R&&,
+                       typename xref:#unordered_multiset_deduction_guides[__see below__]::size_type = xref:#unordered_multiset_deduction_guides[__see below__], Hash = Hash(),
+                       Pred = Pred(), Allocator = Allocator())
+      -> unordered_multiset<std::ranges::range_value_t<R>, Hash, Pred,Allocator>;
+
   template<class T, class Hash = boost::hash<T>, class Pred = std::equal_to<T>,
            class Allocator = std::allocator<T>>
     unordered_multiset(std::initializer_list<T>, typename xref:#unordered_multiset_deduction_guides[__see below__]::size_type = xref:#unordered_multiset_deduction_guides[__see below__],
@@ -218,6 +243,27 @@ namespace unordered {
                        Allocator)
       -> unordered_multiset<xref:#unordered_multiset_iter_value_type[__iter-value-type__]<InputIterator>, Hash,
                             std::equal_to<xref:#unordered_multiset_iter_value_type[__iter-value-type__]<InputIterator>>, Allocator>;
+
+  template<xref:#unordered_multiset_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R, class Allocator>
+    unordered_multiset(FromRangeT&&, R&&, typename xref:#unordered_multiset_deduction_guides[__see below__]::size_type, Allocator)
+      -> unordered_multiset<std::ranges::range_value_t<R>,
+                            boost::hash<std::ranges::range_value_t<R>>,
+                            std::equal_to<std::ranges::range_value_t<R>>, Allocator>;
+
+  template<xref:#unordered_multiset_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R, class Allocator>
+    unordered_multiset(FromRangeT&&, R&&, Allocator)
+      -> unordered_multiset<std::ranges::range_value_t<R>, 
+                            boost::hash<std::ranges::range_value_t<R>>,
+                            std::equal_to<std::ranges::range_value_t<R>>, Allocator>;
+
+  template<xref:#unordered_multiset_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R, class Hash, class Allocator>
+    unordered_multiset(FromRangeT&&, R&&, typename xref:#unordered_multiset_deduction_guides[__see below__]::size_type, Hash,
+                       Allocator)
+      -> unordered_multiset<std::ranges::range_value_t<R>,
+                            Hash, std::equal_to<std::ranges::range_value_t<R>>, Allocator>;
 
   template<class T, class Allocator>
     unordered_multiset(std::initializer_list<T>, typename xref:#unordered_multiset_deduction_guides[__see below__]::size_type, Allocator)
@@ -328,6 +374,15 @@ See node_handle_set for details.
 ---
 
 === Constructors
+
+==== __container-compatible-range__
+[listings,subs="+macros,+quotes"]
+-----
+template<class R, class T>
+  concept container_compatible_range =
+    std::ranges::input_range<R> &&
+    std::convertible_to<std::ranges::range_reference_t<R>, T>; // exposition only
+-----
 
 ==== Default Constructor
 ```c++
@@ -451,6 +506,27 @@ Requires:;; `value_type` is move insertable.
 
 ---
 
+==== Range Constructor
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#unordered_multiset_container_compatible_range[__container-compatible-range__]<value_type> R>
+  unordered_multiset(FromRangeT&&, R&& rg,
+                size_type n = _implementation-defined_,
+                const hasher& hf = hasher(),
+                const key_equal& eql = key_equal(),
+                const allocator_type& a = allocator_type());
+----
+
+Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `eql` as the key equality predicate, `a` as the allocator and a maximum load factor of `1.0` and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::unordered::from_range_t`.
+
+
+[horizontal]
+Requires:;; If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
 ==== Initializer List Constructor
 [source,c++,subs="+quotes"]
 ----
@@ -517,6 +593,58 @@ template<class InputIterator>
 ----
 
 Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `a` as the allocator, with the default key equality predicate and a maximum load factor of `1.0` and inserts the elements from `[f, l)` into it.
+
+[horizontal]
+Requires:;; `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
+==== Range Constructor with Allocator
+
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#unordered_multiset_container_compatible_range[__container-compatible-range__]<value_type> R>
+  unordered_multiset(FromRangeT&&, R&& rg, const allocator_type& a);
+----
+
+Constructs an empty container using `a` as the allocator and a maximum load factor of 1.0 and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::unordered::from_range_t`.
+
+[horizontal]
+Requires:;; `hasher` and `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
+==== Range Constructor with Bucket Count and Allocator
+
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#unordered_multiset_container_compatible_range[__container-compatible-range__]<value_type> R>
+  unordered_multiset(FromRangeT&&, R&& rg, size_type n, const allocator_type& a);
+----
+
+Constructs an empty container with at least `n` buckets, using `a` as the allocator and a maximum load factor of 1.0 and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::unordered::from_range_t`.
+
+[horizontal]
+Requires:;; `hasher` and `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
+==== Range Constructor with Bucket Count and Hasher and Allocator
+
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#unordered_multiset_container_compatible_range[__container-compatible-range__]<value_type> R>
+  unordered_multiset(FromRangeT&&, R&& rg, size_type n, const hasher& hf,
+                     const allocator_type& a);
+----
+
+Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `a` as the allocator and a maximum load factor of 1.0 and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::unordered::from_range_t`.
 
 [horizontal]
 Requires:;; `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
@@ -831,12 +959,30 @@ Pointers and references to elements are never invalidated.
 
 ---
 
+==== Insert Range
+[source,c++,subs="+macros,+quotes"]
+----
+template<xref:#unordered_multiset_container_compatible_range[__container-compatible-range__]<value_type> R>
+  void insert_range(R&& rg);
+----
+
+Inserts a range of elements into the container. 
+
+[horizontal]
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into the container from `*std::ranges​::​begin(rg)`.
+Throws:;; When inserting a single element, if an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated.
+
+---
+
 ==== Insert Initializer List
 ```c++
 void insert(std::initializer_list<value_type> il);
 ```
 
-Inserts a range of elements into the container. Elements are inserted if and only if there is no element in the container with an equivalent key.
+Inserts a range of elements into the container. 
 
 [horizontal]
 Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/CopyInsertable[CopyInsertable^] into the container.
@@ -1344,6 +1490,16 @@ of the constructor selected.
 template<class InputIterator>
   using __iter-value-type__ =
     typename std::iterator_traits<InputIterator>::value_type; // exposition only
+-----
+
+==== __convertible-to-from-range_t__
+[listings,subs="+macros,+quotes"]
+-----
+template<typename FromRangeT>
+  concept __convertible-to-from_range_t__ =
+    // first clause not present if std::from_range_t does not exist
+    std::is_convertible_v<FromRangeT, std::from_range_t> ||
+    std::is_convertible_v<FromRangeT, boost::unordered::from_range_t>; // exposition only
 -----
 
 === Equality Comparisons

--- a/doc/modules/ROOT/pages/reference/unordered_node_map.adoc
+++ b/doc/modules/ROOT/pages/reference/unordered_node_map.adoc
@@ -81,6 +81,12 @@ namespace unordered {
     xref:#unordered_node_map_copy_constructor_with_allocator[unordered_node_map](const unordered_node_map& other, const Allocator& a);
     xref:#unordered_node_map_move_constructor_with_allocator[unordered_node_map](unordered_node_map&& other, const Allocator& a);
     xref:#unordered_node_map_move_constructor_from_concurrent_node_map[unordered_node_map](concurrent_node_map<Key, T, Hash, Pred, Allocator>&& other);
+    template<class FromRangeT, xref:#unordered_node_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#unordered_node_map_range_constructor[unordered_node_map](FromRangeT&&, R&& rg,
+                         size_type n = _implementation-defined_,
+                         const hasher& hf = hasher(),
+                         const key_equal& eql = key_equal(),
+                         const allocator_type& a = allocator_type());
     xref:#unordered_node_map_initializer_list_constructor[unordered_node_map](std::initializer_list<value_type> il,
                        size_type n = _implementation-defined_
                        const hasher& hf = hasher(),
@@ -92,6 +98,13 @@ namespace unordered {
       xref:#unordered_node_map_iterator_range_constructor_with_bucket_count_and_allocator[unordered_node_map](InputIterator f, InputIterator l, size_type n, const allocator_type& a);
     template<class InputIterator>
       xref:#unordered_node_map_iterator_range_constructor_with_bucket_count_and_hasher[unordered_node_map](InputIterator f, InputIterator l, size_type n, const hasher& hf,
+                         const allocator_type& a);
+    template<class FromRangeT, xref:#unordered_node_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#unordered_node_map_range_constructor_with_allocator[unordered_node_map](FromRangeT&&, R&& rg, const allocator_type& a);
+    template<class FromRangeT, xref:#unordered_node_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#unordered_node_map_range_constructor_with_bucket_count_and_allocator[unordered_node_map](FromRangeT&&, R&& rg, size_type n, const allocator_type& a);
+    template<class FromRangeT, xref:#unordered_node_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#unordered_node_map_range_constructor_with_bucket_count_and_hasher_and_allocator[unordered_node_map](FromRangeT&&, R&& rg, size_type n, const hasher& hf,
                          const allocator_type& a);
     xref:#unordered_node_map_initializer_list_constructor_with_allocator[unordered_node_map](std::initializer_list<value_type> il, const allocator_type& a);
     xref:#unordered_node_map_initializer_list_constructor_with_bucket_count_and_allocator[unordered_node_map](std::initializer_list<value_type> il, size_type n,
@@ -132,6 +145,8 @@ namespace unordered {
     iterator       xref:#unordered_node_map_move_insert_with_hint[insert](const_iterator hint, value_type&& obj);
     iterator       xref:#unordered_node_map_copy_insert_with_hint[insert](const_iterator hint, init_type&& obj);
     template<class InputIterator> void xref:#unordered_node_map_insert_iterator_range[insert](InputIterator first, InputIterator last);
+    template<xref:#unordered_node_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+      void xref:#unordered_node_map_insert_range[insert_range](R&& rg);
     void xref:#unordered_node_map_insert_initializer_list[insert](std::initializer_list<value_type>);
     insert_return_type xref:#unordered_node_map_insert_node[insert](node_type&& nh);
     iterator xref:#unordered_node_map_insert_node_with_hint[insert](const_iterator hint, node_type&& nh);
@@ -239,6 +254,17 @@ namespace unordered {
       -> unordered_node_map<xref:#unordered_node_map_iter_key_type[__iter-key-type__]<InputIterator>, xref:#unordered_node_map_iter_mapped_type[__iter-mapped-type__]<InputIterator>, Hash,
                             Pred, Allocator>;
 
+  template<xref:#unordered_node_map_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R,
+           class Hash = boost::hash<xref:#unordered_node_map_range_key_type[__range-key-type__]<R>>,
+           class Pred = std::equal_to<xref:#unordered_node_map_range_key_type[__range-key-type__]<R>>,
+           class Allocator = std::allocator<xref:#unordered_node_map_range_to_alloc_type[__range-to-alloc-type__]<R>>>
+    unordered_node_map(FromRangeT&&, R&&,
+                       typename xref:#unordered_node_map_deduction_guides[__see below__]::size_type = xref:#unordered_node_map_deduction_guides[__see below__], Hash = Hash(),
+                       Pred = Pred(), Allocator = Allocator())
+      -> unordered_node_map<xref:#unordered_node_map_range_key_type[__range-key-type__]<R>, xref:#unordered_node_map_range_mapped_type[__range-mapped-type__]<R>,
+                            Hash, Pred,Allocator>;
+
   template<class Key, class T, class Hash = boost::hash<Key>,
            class Pred = std::equal_to<Key>,
            class Allocator = std::allocator<std::pair<const Key, T>>>
@@ -264,6 +290,27 @@ namespace unordered {
                        Allocator)
       -> unordered_node_map<xref:#unordered_node_map_iter_key_type[__iter-key-type__]<InputIterator>, xref:#unordered_node_map_iter_mapped_type[__iter-mapped-type__]<InputIterator>, Hash,
                             std::equal_to<xref:#unordered_node_map_iter_key_type[__iter-key-type__]<InputIterator>>, Allocator>;
+
+  template<xref:#unordered_node_map_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R, class Allocator>
+    unordered_node_map(FromRangeT&&, R&&, typename xref:#unordered_node_map_deduction_guides[__see below__]::size_type, Allocator)
+      -> unordered_node_map<xref:#unordered_node_map_range_key_type[__range-key-type__]<R>, xref:#unordered_node_map_range_mapped_type[__range-mapped-type__]<R>,
+                            boost::hash<xref:#unordered_node_map_range_key_type[__range-key-type__]<R>>,
+                            std::equal_to<xref:#unordered_node_map_range_key_type[__range-key-type__]<R>>, Allocator>;
+
+  template<xref:#unordered_node_map_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R, class Allocator>
+    unordered_node_map(FromRangeT&&, R&&, Allocator)
+      -> unordered_node_map<xref:#unordered_node_map_range_key_type[__range-key-type__]<R>, xref:#unordered_node_map_range_mapped_type[__range-mapped-type__]<R>,
+                            boost::hash<xref:#unordered_node_map_range_key_type[__range-key-type__]<R>>,
+                            std::equal_to<xref:#unordered_node_map_range_key_type[__range-key-type__]<R>>, Allocator>;
+
+  template<xref:#unordered_node_map_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R, class Hash, class Allocator>
+    unordered_node_map(FromRangeT&&, R&&, typename xref:#unordered_node_map_deduction_guides[__see below__]::size_type, Hash,
+                       Allocator)
+      -> unordered_node_map<xref:#unordered_node_map_range_key_type[__range-key-type__]<R>, xref:#unordered_node_map_range_mapped_type[__range-mapped-type__]<R>,
+                            Hash, std::equal_to<xref:#unordered_node_map_range_key_type[__range-key-type__]<R>>, Allocator>;
 
   template<class Key, class T, class Allocator>
     unordered_node_map(std::initializer_list<std::pair<Key, T>>, typename xref:#unordered_node_map_deduction_guides[__see below__]::size_type,
@@ -394,6 +441,15 @@ with `Iterator` = `iterator` and `NodeType` = `node_type`.
 ---
 
 === Constructors
+
+==== __container-compatible-range__
+[listings,subs="+macros,+quotes"]
+-----
+template<class R, class T>
+  concept container_compatible_range =
+    std::ranges::input_range<R> &&
+    std::convertible_to<std::ranges::range_reference_t<R>, T>; // exposition only
+-----
 
 ==== Default Constructor
 ```c++
@@ -530,6 +586,27 @@ Concurrency:;; Blocking on `other`.
 
 ---
 
+==== Range Constructor
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#unordered_node_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+  unordered_node_map(FromRangeT&&, R&& rg,
+                     size_type n = _implementation-defined_,
+                     const hasher& hf = hasher(),
+                     const key_equal& eql = key_equal(),
+                     const allocator_type& a = allocator_type());
+----
+
+Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `eql` as the key equality predicate and `a` as the allocator, and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::unordered::from_range_t`.
+
+
+[horizontal]
+Requires:;; If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
 ==== Initializer List Constructor
 [source,c++,subs="+quotes"]
 ----
@@ -540,7 +617,7 @@ unordered_node_map(std::initializer_list<value_type> il,
               const allocator_type& a = allocator_type());
 ----
 
-Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `eql` as the key equality predicate and `a`, and inserts the elements from `il` into it.
+Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `eql` as the key equality predicate and `a` as the allocator, and inserts the elements from `il` into it.
 
 [horizontal]
 Requires:;; If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
@@ -596,6 +673,58 @@ Requires:;; `hasher`, `key_equal` need to be https://en.cppreference.com/w/cpp/n
 ----
 
 Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `a` as the allocator, with the default key equality predicate, and inserts the elements from `[f, l)` into it.
+
+[horizontal]
+Requires:;; `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
+==== Range Constructor with Allocator
+
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#unordered_node_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+  unordered_node_map(FromRangeT&&, R&& rg, const allocator_type& a);
+----
+
+Constructs an empty container using `a` and default hash function and key equality predicate, and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::unordered::from_range_t`.
+
+[horizontal]
+Requires:;; `hasher` and `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
+==== Range Constructor with Bucket Count and Allocator
+
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#unordered_node_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+  unordered_node_map(FromRangeT&&, R&& rg, size_type n, const allocator_type& a);
+----
+
+Constructs an empty container with at least `n` buckets, using `a` and default hash function and key equality predicate, and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::unordered::from_range_t`.
+
+[horizontal]
+Requires:;; `hasher` and `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
+==== Range Constructor with Bucket Count and Hasher and Allocator
+
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#unordered_node_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+  unordered_node_map(FromRangeT&&, R&& rg, size_type n, const hasher& hf,
+                    const allocator_type& a);
+----
+
+Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `a` as the allocator and default key equality predicate, and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::unordered::from_range_t`.
 
 [horizontal]
 Requires:;; `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
@@ -913,6 +1042,22 @@ Inserts a range of elements into the container. Elements are inserted if and onl
 
 [horizontal]
 Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into the container from `*first`.
+Throws:;; When inserting a single element, if an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; Can invalidate iterators, but only if the insert causes the load to be greater than the maximum load.
+
+---
+
+==== Insert Range
+[source,c++,subs="+macros,+quotes"]
+----
+template<xref:#unordered_node_map_container_compatible_range[__container-compatible-range__]<value_type> R>
+  void insert_range(R&& rg);
+----
+
+Inserts a range of elements into the container. Elements are inserted if and only if there is no element in the container with an equivalent key.
+
+[horizontal]
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into the container from `*std::ranges​::​begin(rg)`.
 Throws:;; When inserting a single element, if an exception is thrown by an operation other than a call to `hasher` the function has no effect.
 Notes:;; Can invalidate iterators, but only if the insert causes the load to be greater than the maximum load.
 
@@ -1547,6 +1692,42 @@ template<class InputIterator>
   using __iter-to-alloc-type__ = std::pair<
     std::add_const_t<std::tuple_element_t<0, xref:#unordered_node_map_iter_value_type[__iter-value-type__]<InputIterator>>>,
     std::tuple_element_t<1, xref:#unordered_node_map_iter_value_type[__iter-value-type__]<InputIterator>>>; // exposition only
+-----
+
+==== __convertible-to-from-range_t__
+[listings,subs="+macros,+quotes"]
+-----
+template<typename FromRangeT>
+  concept __convertible-to-from_range_t__ =
+    // first clause not present if std::from_range_t does not exist
+    std::is_convertible_v<FromRangeT, std::from_range_t> ||
+    std::is_convertible_v<FromRangeT, boost::unordered::from_range_t>; // exposition only
+-----
+
+==== __range-key-type__
+[listings,subs="+macros,+quotes"]
+-----
+template<std::ranges::input_range R>
+  using __range-key-type__ =
+    std::remove_cvref_t<
+      std::tuple_element_t<0, std::ranges::range_value_t<R>>>; // exposition only
+-----
+
+==== __range-mapped-type__
+[listings,subs="+macros,+quotes"]
+-----
+template<std::ranges::input_range R>
+  using __range-mapped-type__ =
+    std::remove_cvref_t<
+      std::tuple_element_t<1, std::ranges::range_value_t<R>>>; // exposition only
+-----
+
+==== __range-to-alloc-type__
+[listings,subs="+macros,+quotes"]
+-----
+template<std::ranges::input_range R>
+  using __range-to-alloc-type__ = 
+    std::pair<const xref:#unordered_node_map_range_key_type[__range-key-type__]<R>, xref:#unordered_node_map_range_mapped_type[__range-mapped-type__]<R>>; // exposition only
 -----
 
 === Equality Comparisons

--- a/doc/modules/ROOT/pages/reference/unordered_node_set.adoc
+++ b/doc/modules/ROOT/pages/reference/unordered_node_set.adoc
@@ -76,6 +76,12 @@ namespace unordered {
     xref:#unordered_node_set_copy_constructor_with_allocator[unordered_node_set](const unordered_node_set& other, const Allocator& a);
     xref:#unordered_node_set_move_constructor_with_allocator[unordered_node_set](unordered_node_set&& other, const Allocator& a);
     xref:#unordered_node_set_move_constructor_from_concurrent_node_set[unordered_node_set](concurrent_node_set<Key, Hash, Pred, Allocator>&& other);
+    template<class FromRangeT, xref:#unordered_node_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#unordered_node_set_range_constructor[unordered_node_set](FromRangeT&&, R&& rg,
+                         size_type n = _implementation-defined_,
+                         const hasher& hf = hasher(),
+                         const key_equal& eql = key_equal(),
+                         const allocator_type& a = allocator_type());
     xref:#unordered_node_set_initializer_list_constructor[unordered_node_set](std::initializer_list<value_type> il,
                        size_type n = _implementation-defined_
                        const hasher& hf = hasher(),
@@ -87,6 +93,13 @@ namespace unordered {
       xref:#unordered_node_set_iterator_range_constructor_with_bucket_count_and_allocator[unordered_node_set](InputIterator f, InputIterator l, size_type n, const allocator_type& a);
     template<class InputIterator>
       xref:#unordered_node_set_iterator_range_constructor_with_bucket_count_and_hasher[unordered_node_set](InputIterator f, InputIterator l, size_type n, const hasher& hf,
+                         const allocator_type& a);
+    template<class FromRangeT, xref:#unordered_node_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#unordered_node_set_range_constructor_with_allocator[unordered_node_set](FromRangeT&&, R&& rg, const allocator_type& a);
+    template<class FromRangeT, xref:#unordered_node_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#unordered_node_set_range_constructor_with_bucket_count_and_allocator[unordered_node_set](FromRangeT&&, R&& rg, size_type n, const allocator_type& a);
+    template<class FromRangeT, xref:#unordered_node_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#unordered_node_set_range_constructor_with_bucket_count_and_hasher_and_allocator[unordered_node_set](FromRangeT&&, R&& rg, size_type n, const hasher& hf,
                          const allocator_type& a);
     xref:#unordered_node_set_initializer_list_constructor_with_allocator[unordered_node_set](std::initializer_list<value_type> il, const allocator_type& a);
     xref:#unordered_node_set_initializer_list_constructor_with_bucket_count_and_allocator[unordered_node_set](std::initializer_list<value_type> il, size_type n,
@@ -125,6 +138,8 @@ namespace unordered {
     iterator xref:#unordered_node_set_move_insert_with_hint[insert](const_iterator hint, value_type&& obj);
     template<class K> iterator xref:#unordered_node_set_transparent_insert_with_hint[insert](const_iterator hint, K&& k);
     template<class InputIterator> void xref:#unordered_node_set_insert_iterator_range[insert](InputIterator first, InputIterator last);
+    template<xref:#unordered_node_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+      void xref:#unordered_node_set_insert_range[insert_range](R&& rg);
     void xref:#unordered_node_set_insert_initializer_list[insert](std::initializer_list<value_type>);
     insert_return_type xref:#unordered_node_set_insert_node[insert](node_type&& nh);
     iterator xref:#unordered_node_set_insert_node_with_hint[insert](const_iterator hint, node_type&& nh);
@@ -197,6 +212,16 @@ namespace unordered {
                        Hash = Hash(), Pred = Pred(), Allocator = Allocator())
       -> unordered_node_set<xref:#unordered_node_set_iter_value_type[__iter-value-type__]<InputIterator>, Hash, Pred, Allocator>;
 
+  template<xref:#unordered_node_set_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R,
+           class Hash = boost::hash<std::ranges::range_value_t<R>>,
+           class Pred = std::equal_to<std::ranges::range_value_t<R>>,
+           class Allocator = std::allocator<std::ranges::range_value_t<R>>
+    unordered_node_set(FromRangeT&&, R&&,
+                       typename xref:#unordered_node_set_deduction_guides[__see below__]::size_type = xref:#unordered_node_set_deduction_guides[__see below__], Hash = Hash(),
+                       Pred = Pred(), Allocator = Allocator())
+      -> unordered_node_set<std::ranges::range_value_t<R>, Hash, Pred,Allocator>;
+
   template<class T, class Hash = boost::hash<T>, class Pred = std::equal_to<T>,
            class Allocator = std::allocator<T>>
     unordered_node_set(std::initializer_list<T>, typename xref:#unordered_node_set_deduction_guides[__see below__]::size_type = xref:#unordered_node_set_deduction_guides[__see below__],
@@ -220,6 +245,27 @@ namespace unordered {
                        Allocator)
       -> unordered_node_set<xref:#unordered_node_set_iter_value_type[__iter-value-type__]<InputIterator>, Hash,
                             std::equal_to<xref:#unordered_node_set_iter_value_type[__iter-value-type__]<InputIterator>>, Allocator>;
+
+  template<xref:#unordered_node_set_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R, class Allocator>
+    unordered_node_set(FromRangeT&&, R&&, typename xref:#unordered_node_set_deduction_guides[__see below__]::size_type, Allocator)
+      -> unordered_node_set<std::ranges::range_value_t<R>,
+                            boost::hash<std::ranges::range_value_t<R>>,
+                            std::equal_to<std::ranges::range_value_t<R>>, Allocator>;
+
+  template<xref:#unordered_node_set_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R, class Allocator>
+    unordered_node_set(FromRangeT&&, R&&, Allocator)
+      -> unordered_node_set<std::ranges::range_value_t<R>, 
+                            boost::hash<std::ranges::range_value_t<R>>,
+                            std::equal_to<std::ranges::range_value_t<R>>, Allocator>;
+
+  template<xref:#unordered_node_set_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R, class Hash, class Allocator>
+    unordered_node_set(FromRangeT&&, R&&, typename xref:#unordered_node_set_deduction_guides[__see below__]::size_type, Hash,
+                       Allocator)
+      -> unordered_node_set<std::ranges::range_value_t<R>,
+                            Hash, std::equal_to<std::ranges::range_value_t<R>>, Allocator>;
 
   template<class T, class Allocator>
     unordered_node_set(std::initializer_list<T>, typename xref:#unordered_node_set_deduction_guides[__see below__]::size_type, Allocator)
@@ -344,6 +390,15 @@ with `Iterator` = `iterator` and `NodeType` = `node_type`.
 ---
 
 === Constructors
+
+==== __container-compatible-range__
+[listings,subs="+macros,+quotes"]
+-----
+template<class R, class T>
+  concept container_compatible_range =
+    std::ranges::input_range<R> &&
+    std::convertible_to<std::ranges::range_reference_t<R>, T>; // exposition only
+-----
 
 ==== Default Constructor
 ```c++
@@ -483,6 +538,27 @@ Concurrency:;; Blocking on `other`.
 
 ---
 
+==== Range Constructor
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#unordered_node_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+  unordered_node_set(FromRangeT&&, R&& rg,
+                     size_type n = _implementation-defined_,
+                     const hasher& hf = hasher(),
+                     const key_equal& eql = key_equal(),
+                     const allocator_type& a = allocator_type());
+----
+
+Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `eql` as the key equality predicate and `a` as the allocator, and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::unordered::from_range_t`.
+
+
+[horizontal]
+Requires:;; If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
 ==== Initializer List Constructor
 [source,c++,subs="+quotes"]
 ----
@@ -555,6 +631,58 @@ Requires:;; `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/
 
 ---
 
+==== Range Constructor with Allocator
+
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#unordered_node_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+  unordered_node_set(FromRangeT&&, R&& rg, const allocator_type& a);
+----
+
+Constructs an empty container using `a` and default hash function and key equality predicate, and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::unordered::from_range_t`.
+
+[horizontal]
+Requires:;; `hasher` and `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
+==== Range Constructor with Bucket Count and Allocator
+
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#unordered_node_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+  unordered_node_set(FromRangeT&&, R&& rg, size_type n, const allocator_type& a);
+----
+
+Constructs an empty container with at least `n` buckets, using `a` and default hash function and key equality predicate, and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::unordered::from_range_t`.
+
+[horizontal]
+Requires:;; `hasher` and `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
+==== Range Constructor with Bucket Count and Hasher and Allocator
+
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#unordered_node_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+  unordered_node_set(FromRangeT&&, R&& rg, size_type n, const hasher& hf,
+                     const allocator_type& a);
+----
+
+Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `a` as the allocator and default key equality predicate, and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::unordered::from_range_t`.
+
+[horizontal]
+Requires:;; `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
 ==== initializer_list Constructor with Allocator
 
 ```c++
@@ -588,7 +716,7 @@ unordered_node_set(std::initializer_list<value_type> il, size_type n, const hash
                    const allocator_type& a);
 ```
 
-Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `a` as the allocator and default key equality predicate,and inserts the elements from `il` into it.
+Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `a` as the allocator and default key equality predicate, and inserts the elements from `il` into it.
 
 [horizontal]
 Requires:;; `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
@@ -890,6 +1018,22 @@ Inserts a range of elements into the container. Elements are inserted if and onl
 
 [horizontal]
 Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into the container from `*first`.
+Throws:;; When inserting a single element, if an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; Can invalidate iterators, but only if the insert causes the load to be greater than the maximum load.
+
+---
+
+==== Insert Range
+[source,c++,subs="+macros,+quotes"]
+----
+template<xref:#unordered_node_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+  void insert_range(R&& rg);
+----
+
+Inserts a range of elements into the container. Elements are inserted if and only if there is no element in the container with an equivalent key.
+
+[horizontal]
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into the container from `*std::ranges​::​begin(rg)`.
 Throws:;; When inserting a single element, if an exception is thrown by an operation other than a call to `hasher` the function has no effect.
 Notes:;; Can invalidate iterators, but only if the insert causes the load to be greater than the maximum load.
 
@@ -1300,6 +1444,16 @@ of the constructor selected.
 template<class InputIterator>
   using __iter-value-type__ =
     typename std::iterator_traits<InputIterator>::value_type; // exposition only
+-----
+
+==== __convertible-to-from-range_t__
+[listings,subs="+macros,+quotes"]
+-----
+template<typename FromRangeT>
+  concept __convertible-to-from_range_t__ =
+    // first clause not present if std::from_range_t does not exist
+    std::is_convertible_v<FromRangeT, std::from_range_t> ||
+    std::is_convertible_v<FromRangeT, boost::unordered::from_range_t>; // exposition only
 -----
 
 === Equality Comparisons

--- a/doc/modules/ROOT/pages/reference/unordered_set.adoc
+++ b/doc/modules/ROOT/pages/reference/unordered_set.adoc
@@ -59,6 +59,12 @@ namespace unordered {
     explicit xref:#unordered_set_allocator_constructor[unordered_set](const Allocator& a);
     xref:#unordered_set_copy_constructor_with_allocator[unordered_set](const unordered_set& other, const Allocator& a);
     xref:#unordered_set_move_constructor_with_allocator[unordered_set](unordered_set&& other, const Allocator& a);
+    template<class FromRangeT, xref:#unordered_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#unordered_set_range_constructor[unordered_set](FromRangeT&&, R&& rg,
+                    size_type n = _implementation-defined_,
+                    const hasher& hf = hasher(),
+                    const key_equal& eql = key_equal(),
+                    const allocator_type& a = allocator_type());
     xref:#unordered_set_initializer_list_constructor[unordered_set](std::initializer_list<value_type> il,
                   size_type n = _implementation-defined_,
                   const hasher& hf = hasher(),
@@ -70,6 +76,13 @@ namespace unordered {
       xref:#unordered_set_iterator_range_constructor_with_bucket_count_and_allocator[unordered_set](InputIterator f, InputIterator l, size_type n, const allocator_type& a);
     template<class InputIterator>
       xref:#unordered_set_iterator_range_constructor_with_bucket_count_and_hasher[unordered_set](InputIterator f, InputIterator l, size_type n, const hasher& hf,
+                    const allocator_type& a);
+    template<class FromRangeT, xref:#unordered_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#unordered_set_range_constructor_with_allocator[unordered_set](FromRangeT&&, R&& rg, const allocator_type& a);
+    template<class FromRangeT, xref:#unordered_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#unordered_set_range_constructor_with_bucket_count_and_allocator[unordered_set](FromRangeT&&, R&& rg, size_type n, const allocator_type& a);
+    template<class FromRangeT, xref:#unordered_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+      xref:#unordered_set_range_constructor_with_bucket_count_and_hasher_and_allocator[unordered_set](FromRangeT&&, R&& rg, size_type n, const hasher& hf,
                     const allocator_type& a);
     xref:#unordered_set_initializer_list_constructor_with_allocator[unordered_set](std::initializer_list<value_type> il, const allocator_type& a);
     xref:#unordered_set_initializer_list_constructor_with_bucket_count_and_allocator[unordered_set](std::initializer_list<value_type> il, size_type n, const allocator_type& a);
@@ -107,6 +120,8 @@ namespace unordered {
     iterator xref:#unordered_set_move_insert_with_hint[insert](const_iterator hint, value_type&& obj);
     template<class K> iterator xref:#unordered_set_transparent_insert_with_hint[insert](const_iterator hint, K&& k);
     template<class InputIterator> void xref:#unordered_set_insert_iterator_range[insert](InputIterator first, InputIterator last);
+    template<xref:#unordered_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+      void xref:#unordered_set_insert_range[insert_range](R&& rg);
     void xref:#unordered_set_insert_initializer_list[insert](std::initializer_list<value_type>);
 
     node_type xref:#unordered_set_extract_by_iterator[extract](const_iterator position);
@@ -197,6 +212,16 @@ namespace unordered {
                   Hash = Hash(), Pred = Pred(), Allocator = Allocator())
       -> unordered_set<xref:#unordered_set_iter_value_type[__iter-value-type__]<InputIterator>, Hash, Pred, Allocator>;
 
+  template<xref:#unordered_set_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R,
+           class Hash = boost::hash<std::ranges::range_value_t<R>>,
+           class Pred = std::equal_to<std::ranges::range_value_t<R>>,
+           class Allocator = std::allocator<std::ranges::range_value_t<R>>
+    unordered_set(FromRangeT&&, R&&,
+                  typename xref:#unordered_set_deduction_guides[__see below__]::size_type = xref:#unordered_set_deduction_guides[__see below__], Hash = Hash(),
+                  Pred = Pred(), Allocator = Allocator())
+      -> unordered_set<std::ranges::range_value_t<R>, Hash, Pred,Allocator>;
+
   template<class T, class Hash = boost::hash<T>, class Pred = std::equal_to<T>,
            class Allocator = std::allocator<T>>
     unordered_set(std::initializer_list<T>, typename xref:#unordered_set_deduction_guides[__see below__]::size_type = xref:#unordered_set_deduction_guides[__see below__],
@@ -219,6 +244,27 @@ namespace unordered {
     unordered_set(InputIterator, InputIterator, typename xref:#unordered_set_deduction_guides[__see below__]::size_type, Hash, Allocator)
       -> unordered_set<xref:#unordered_set_iter_value_type[__iter-value-type__]<InputIterator>, Hash,
                        std::equal_to<xref:#unordered_set_iter_value_type[__iter-value-type__]<InputIterator>>, Allocator>;
+
+  template<xref:#unordered_set_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R, class Allocator>
+    unordered_set(FromRangeT&&, R&&, typename xref:#unordered_set_deduction_guides[__see below__]::size_type, Allocator)
+      -> unordered_set<std::ranges::range_value_t<R>,
+                       boost::hash<std::ranges::range_value_t<R>>,
+                       std::equal_to<std::ranges::range_value_t<R>>, Allocator>;
+
+  template<xref:#unordered_set_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R, class Allocator>
+    unordered_set(FromRangeT&&, R&&, Allocator)
+      -> unordered_set<std::ranges::range_value_t<R>, 
+                       boost::hash<std::ranges::range_value_t<R>>,
+                       std::equal_to<std::ranges::range_value_t<R>>, Allocator>;
+
+  template<xref:#unordered_set_convertible_to_from_range_t[__convertible-to-from-range_t__] FromRangeT,
+           std::ranges::input_range R, class Hash, class Allocator>
+    unordered_set(FromRangeT&&, R&&, typename xref:#unordered_set_deduction_guides[__see below__]::size_type, Hash,
+                  Allocator)
+      -> unordered_set<std::ranges::range_value_t<R>,
+                       Hash, std::equal_to<std::ranges::range_value_t<R>>, Allocator>;
 
   template<class T, class Allocator>
     unordered_set(std::initializer_list<T>, typename xref:#unordered_set_deduction_guides[__see below__]::size_type, Allocator)
@@ -353,6 +399,16 @@ with `Iterator` = `iterator` and `NodeType` = `node_type`.
 
 === Constructors
 
+==== __container-compatible-range__
+[listings,subs="+macros,+quotes"]
+-----
+template<class R, class T>
+  concept container_compatible_range =
+    std::ranges::input_range<R> &&
+    std::convertible_to<std::ranges::range_reference_t<R>, T>; // exposition only
+-----
+
+
 ==== Default Constructor
 ```c++
 unordered_set();
@@ -475,6 +531,27 @@ Requires:;; `value_type` is move insertable.
 
 ---
 
+==== Range Constructor
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#unordered_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+  unordered_set(FromRangeT&&, R&& rg,
+                size_type n = _implementation-defined_,
+                const hasher& hf = hasher(),
+                const key_equal& eql = key_equal(),
+                const allocator_type& a = allocator_type());
+----
+
+Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `eql` as the key equality predicate, `a` as the allocator and a maximum load factor of `1.0` and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::unordered::from_range_t`.
+
+
+[horizontal]
+Requires:;; If the defaults are used, `hasher`, `key_equal` and `allocator_type` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
 ==== Initializer List Constructor
 [source,c++,subs="+quotes"]
 ----
@@ -541,6 +618,58 @@ template<class InputIterator>
 ----
 
 Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `a` as the allocator, with the default key equality predicate and a maximum load factor of `1.0` and inserts the elements from `[f, l)` into it.
+
+[horizontal]
+Requires:;; `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
+==== Range Constructor with Allocator
+
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#unordered_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+  unordered_set(FromRangeT&&, R&& rg, const allocator_type& a);
+----
+
+Constructs an empty container using `a` as the allocator and a maximum load factor of 1.0 and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::unordered::from_range_t`.
+
+[horizontal]
+Requires:;; `hasher` and `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
+==== Range Constructor with Bucket Count and Allocator
+
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#unordered_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+  unordered_set(FromRangeT&&, R&& rg, size_type n, const allocator_type& a);
+----
+
+Constructs an empty container with at least `n` buckets, using `a` as the allocator and a maximum load factor of 1.0 and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::unordered::from_range_t`.
+
+[horizontal]
+Requires:;; `hasher` and `key_equal` need to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
+
+---
+
+==== Range Constructor with Bucket Count and Hasher and Allocator
+
+[source,c++,subs="+macros,+quotes"]
+----
+template<class FromRangeT, xref:#unordered_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+  unordered_set(FromRangeT&&, R&& rg, size_type n, const hasher& hf,
+                const allocator_type& a);
+----
+
+Constructs an empty container with at least `n` buckets, using `hf` as the hash function, `a` as the allocator and a maximum load factor of 1.0 and inserts the elements from `rg` into it.
+
+Only participates in overload resolution if `FromRangeT` is convertible to `std::from_range_t` or `boost::unordered::from_range_t`.
 
 [horizontal]
 Requires:;; `key_equal` needs to be https://en.cppreference.com/w/cpp/named_req/DefaultConstructible[DefaultConstructible^].
@@ -897,6 +1026,24 @@ Inserts a range of elements into the container. Elements are inserted if and onl
 
 [horizontal]
 Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into `X` from `*first`.
+Throws:;; When inserting a single element, if an exception is thrown by an operation other than a call to `hasher` the function has no effect.
+Notes:;; Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
++
+Pointers and references to elements are never invalidated.
+
+---
+
+==== Insert Range
+[source,c++,subs="+macros,+quotes"]
+----
+template<xref:#unordered_set_container_compatible_range[__container-compatible-range__]<value_type> R>
+  void insert_range(R&& rg);
+----
+
+Inserts a range of elements into the container. Elements are inserted if and only if there is no element in the container with an equivalent key.
+
+[horizontal]
+Requires:;; `value_type` is https://en.cppreference.com/w/cpp/named_req/EmplaceConstructible[EmplaceConstructible^] into the container from `*std::ranges​::​begin(rg)`.
 Throws:;; When inserting a single element, if an exception is thrown by an operation other than a call to `hasher` the function has no effect.
 Notes:;; Can invalidate iterators, but only if the insert causes the load factor to be greater to or equal to the maximum load factor. +
 +
@@ -1422,6 +1569,16 @@ of the constructor selected.
 template<class InputIterator>
   using __iter-value-type__ =
     typename std::iterator_traits<InputIterator>::value_type; // exposition only
+-----
+
+==== __convertible-to-from-range_t__
+[listings,subs="+macros,+quotes"]
+-----
+template<typename FromRangeT>
+  concept __convertible-to-from_range_t__ =
+    // first clause not present if std::from_range_t does not exist
+    std::is_convertible_v<FromRangeT, std::from_range_t> ||
+    std::is_convertible_v<FromRangeT, boost::unordered::from_range_t>; // exposition only
 -----
 
 === Equality Comparisons

--- a/include/boost/unordered/concurrent_flat_map.hpp
+++ b/include/boost/unordered/concurrent_flat_map.hpp
@@ -17,6 +17,7 @@
 #include <boost/unordered/detail/concurrent_static_asserts.hpp>
 #include <boost/unordered/detail/foa/concurrent_table.hpp>
 #include <boost/unordered/detail/foa/flat_map_types.hpp>
+#include <boost/unordered/detail/ranges_support.hpp>
 #include <boost/unordered/detail/type_traits.hpp>
 #include <boost/unordered/unordered_flat_map_fwd.hpp>
 
@@ -102,6 +103,21 @@ namespace boost {
         this->insert(f, l);
       }
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<value_type> R
+      >
+      concurrent_flat_map(FromRangeT&&, R&& rg,
+        size_type n = detail::foa::default_bucket_count,
+        const hasher& hf = hasher(), const key_equal& eql = key_equal(),
+        const allocator_type& a = allocator_type())
+          : table_(n, hf, eql, a)
+      {
+        this->insert_range(std::forward<R>(rg));
+      }
+#endif
+
       concurrent_flat_map(concurrent_flat_map const& rhs)
           : table_(rhs.table_,
               boost::allocator_select_on_container_copy_construction(
@@ -120,6 +136,19 @@ namespace boost {
           : concurrent_flat_map(f, l, 0, hasher(), key_equal(), a)
       {
       }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<value_type> R
+      >
+      concurrent_flat_map(
+        FromRangeT&& fr, R&& rg, allocator_type const& a)
+          : concurrent_flat_map(
+            fr, std::forward<R>(rg), 0, hasher(), key_equal(), a)
+      {
+      }
+#endif
 
       explicit concurrent_flat_map(allocator_type const& a)
           : table_(detail::foa::default_bucket_count, hasher(), key_equal(), a)
@@ -170,6 +199,29 @@ namespace boost {
           : concurrent_flat_map(f, l, n, hf, key_equal(), a)
       {
       }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<value_type> R
+      >
+      concurrent_flat_map(
+        FromRangeT&& fr, R&& rg, size_type n, const allocator_type& a)
+          : concurrent_flat_map(
+            fr, std::forward<R>(rg), n, hasher(), key_equal(), a)
+      {
+      }
+
+      template<
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<value_type> R
+      >
+      concurrent_flat_map(FromRangeT&& fr, R&& rg, size_type n,
+        const hasher& hf, const allocator_type& a)
+          : concurrent_flat_map(fr, std::forward<R>(rg), n, hf, key_equal(), a)
+      {
+      }
+#endif
 
       concurrent_flat_map(
         std::initializer_list<value_type> il, const allocator_type& a)
@@ -429,6 +481,20 @@ namespace boost {
         }
         return count_elements;
       }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<detail::container_compatible_range<value_type> R>
+      size_type insert_range(R&& rg)
+      {
+        size_type count_elements = 0;
+        auto first = std::ranges::begin(rg);
+        auto last = std::ranges::end(rg);
+        while (first != last) {
+          if (table_.emplace(*first++)) ++count_elements;
+        }
+        return count_elements;
+      }
+#endif
 
       size_type insert(std::initializer_list<value_type> ilist)
       {
@@ -980,6 +1046,27 @@ namespace boost {
         boost::unordered::detail::iter_val_t<InputIterator>, Hash, Pred,
         Allocator>;
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+    template <
+      boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Hash =
+        boost::hash<boost::unordered::detail::range_key_t<R> >,
+      class Pred =
+        std::equal_to<boost::unordered::detail::range_key_t<R> >,
+      class Allocator = std::allocator<
+        boost::unordered::detail::range_to_alloc_t<R> >,
+      class = std::enable_if_t<detail::is_hash_v<Hash> >,
+      class = std::enable_if_t<detail::is_pred_v<Pred> >,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    concurrent_flat_map(FromRangeT&&, R&&,
+      std::size_t = boost::unordered::detail::foa::default_bucket_count,
+      Hash = Hash(), Pred = Pred(), Allocator = Allocator())
+      -> concurrent_flat_map<boost::unordered::detail::range_key_t<R>,
+        boost::unordered::detail::range_mapped_t<R>, Hash, Pred,
+        Allocator>;
+#endif
+
     template <class Key, class T,
       class Hash = boost::hash<std::remove_const_t<Key> >,
       class Pred = std::equal_to<std::remove_const_t<Key> >,
@@ -1026,6 +1113,42 @@ namespace boost {
         boost::unordered::detail::iter_val_t<InputIterator>, Hash,
         std::equal_to<boost::unordered::detail::iter_key_t<InputIterator> >,
         Allocator>;
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+    template <boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Allocator,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    concurrent_flat_map(FromRangeT&&, R&&, std::size_t, Allocator)
+      -> concurrent_flat_map<boost::unordered::detail::range_key_t<R>,
+        boost::unordered::detail::range_mapped_t<R>,
+        boost::hash<boost::unordered::detail::range_key_t<R> >,
+        std::equal_to<boost::unordered::detail::range_key_t<R> >,
+        Allocator>;
+
+    template <boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Allocator,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    concurrent_flat_map(FromRangeT&&, R&&, Allocator)
+      -> concurrent_flat_map<boost::unordered::detail::range_key_t<R>,
+        boost::unordered::detail::range_mapped_t<R>,
+        boost::hash<boost::unordered::detail::range_key_t<R> >,
+        std::equal_to<boost::unordered::detail::range_key_t<R> >,
+        Allocator>;
+
+    template <boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Hash, class Allocator,
+      class = std::enable_if_t<detail::is_hash_v<Hash> >,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    concurrent_flat_map(
+      FromRangeT&&, R&&, std::size_t, Hash, Allocator)
+      -> concurrent_flat_map<boost::unordered::detail::range_key_t<R>,
+        boost::unordered::detail::range_mapped_t<R>, Hash,
+        std::equal_to<boost::unordered::detail::range_key_t<R> >,
+        Allocator>;
+#endif
 
     template <class Key, class T, class Allocator,
       class = std::enable_if_t<detail::is_allocator_v<Allocator> > >

--- a/include/boost/unordered/concurrent_flat_map.hpp
+++ b/include/boost/unordered/concurrent_flat_map.hpp
@@ -551,6 +551,21 @@ namespace boost {
         return count_elements;
       }
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<detail::container_compatible_range<value_type> R, class F>
+      size_type insert_range_or_visit(R&& rg, F f)
+      {
+        BOOST_UNORDERED_STATIC_ASSERT_INVOCABLE(F)
+        size_type count_elements = 0;
+        auto first = std::ranges::begin(rg);
+        auto last = std::ranges::end(rg);
+        for (; first != last; ++first, ++count_elements) {
+          table_.emplace_or_visit(*first, f);
+        }
+        return count_elements;
+      }
+#endif
+
       template <class F>
       size_type insert_or_visit(std::initializer_list<value_type> ilist, F f)
       {
@@ -583,6 +598,21 @@ namespace boost {
         }
         return count_elements;
       }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<detail::container_compatible_range<value_type> R, class F>
+      size_type insert_range_or_cvisit(R&& rg, F f)
+      {
+        BOOST_UNORDERED_STATIC_ASSERT_CONST_INVOCABLE(F)
+        size_type count_elements = 0;
+        auto first = std::ranges::begin(rg);
+        auto last = std::ranges::end(rg);
+        for (; first != last; ++first, ++count_elements) {
+          table_.emplace_or_cvisit(*first, f);
+        }
+        return count_elements;
+      }
+#endif
 
       template <class F>
       size_type insert_or_cvisit(std::initializer_list<value_type> ilist, F f)
@@ -620,6 +650,24 @@ namespace boost {
         }
         return count_elements;
       }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<
+        detail::container_compatible_range<value_type> R, class F1, class F2
+      >
+      size_type insert_range_and_visit(R&& rg, F1 f1, F2 f2)
+      {
+        BOOST_UNORDERED_STATIC_ASSERT_INVOCABLE(F1)
+        BOOST_UNORDERED_STATIC_ASSERT_INVOCABLE(F2)
+        size_type count_elements = 0;
+        auto first = std::ranges::begin(rg);
+        auto last = std::ranges::end(rg);
+        for (; first != last; ++first, ++count_elements) {
+          table_.emplace_and_visit(*first, f1, f2);
+        }
+        return count_elements;
+      }
+#endif
 
       template <class F1, class F2>
       size_type insert_and_visit(
@@ -660,6 +708,24 @@ namespace boost {
         }
         return count_elements;
       }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<
+        detail::container_compatible_range<value_type> R, class F1, class F2
+      >
+      size_type insert_range_and_cvisit(R&& rg, F1 f1, F2 f2)
+      {
+        BOOST_UNORDERED_STATIC_ASSERT_INVOCABLE(F1)
+        BOOST_UNORDERED_STATIC_ASSERT_CONST_INVOCABLE(F2)
+        size_type count_elements = 0;
+        auto first = std::ranges::begin(rg);
+        auto last = std::ranges::end(rg);
+        for (; first != last; ++first, ++count_elements) {
+          table_.emplace_and_cvisit(*first, f1, f2);
+        }
+        return count_elements;
+      }
+#endif
 
       template <class F1, class F2>
       size_type insert_and_cvisit(

--- a/include/boost/unordered/concurrent_flat_set.hpp
+++ b/include/boost/unordered/concurrent_flat_set.hpp
@@ -17,6 +17,7 @@
 #include <boost/unordered/detail/concurrent_static_asserts.hpp>
 #include <boost/unordered/detail/foa/concurrent_table.hpp>
 #include <boost/unordered/detail/foa/flat_set_types.hpp>
+#include <boost/unordered/detail/ranges_support.hpp>
 #include <boost/unordered/detail/type_traits.hpp>
 #include <boost/unordered/unordered_flat_set_fwd.hpp>
 
@@ -99,6 +100,21 @@ namespace boost {
         this->insert(f, l);
       }
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<value_type> R
+      >
+      concurrent_flat_set(FromRangeT&&, R&& rg,
+        size_type n = detail::foa::default_bucket_count,
+        const hasher& hf = hasher(), const key_equal& eql = key_equal(),
+        const allocator_type& a = allocator_type())
+          : table_(n, hf, eql, a)
+      {
+        this->insert_range(std::forward<R>(rg));
+      }
+#endif
+
       concurrent_flat_set(concurrent_flat_set const& rhs)
           : table_(rhs.table_,
               boost::allocator_select_on_container_copy_construction(
@@ -117,6 +133,19 @@ namespace boost {
           : concurrent_flat_set(f, l, 0, hasher(), key_equal(), a)
       {
       }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<value_type> R
+      >
+      concurrent_flat_set(
+        FromRangeT&& fr, R&& rg, allocator_type const& a)
+          : concurrent_flat_set(
+            fr, std::forward<R>(rg), 0, hasher(), key_equal(), a)
+      {
+      }
+#endif
 
       explicit concurrent_flat_set(allocator_type const& a)
           : table_(detail::foa::default_bucket_count, hasher(), key_equal(), a)
@@ -167,6 +196,29 @@ namespace boost {
           : concurrent_flat_set(f, l, n, hf, key_equal(), a)
       {
       }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<value_type> R
+      >
+      concurrent_flat_set(
+        FromRangeT&& fr, R&& rg, size_type n, const allocator_type& a)
+          : concurrent_flat_set(
+            fr, std::forward<R>(rg), n, hasher(), key_equal(), a)
+      {
+      }
+
+      template<
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<value_type> R
+      >
+      concurrent_flat_set(FromRangeT&& fr, R&& rg, size_type n,
+        const hasher& hf, const allocator_type& a)
+          : concurrent_flat_set(fr, std::forward<R>(rg), n, hf, key_equal(), a)
+      {
+      }
+#endif
 
       concurrent_flat_set(
         std::initializer_list<value_type> il, const allocator_type& a)
@@ -435,6 +487,20 @@ namespace boost {
         }
         return count_elements;
       }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<detail::container_compatible_range<value_type> R>
+      size_type insert_range(R&& rg)
+      {
+        size_type count_elements = 0;
+        auto first = std::ranges::begin(rg);
+        auto last = std::ranges::end(rg);
+        while (first != last) {
+          if (table_.emplace(*first++)) ++count_elements;
+        }
+        return count_elements;
+      }
+#endif
 
       size_type insert(std::initializer_list<value_type> ilist)
       {
@@ -853,6 +919,25 @@ namespace boost {
         typename std::iterator_traits<InputIterator>::value_type, Hash, Pred,
         Allocator>;
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+    template <
+      boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Hash =
+        boost::hash<std::ranges::range_value_t<R> >,
+      class Pred =
+        std::equal_to<std::ranges::range_value_t<R> >,
+      class Allocator = std::allocator<std::ranges::range_value_t<R> >,
+      class = std::enable_if_t<detail::is_hash_v<Hash> >,
+      class = std::enable_if_t<detail::is_pred_v<Pred> >,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    concurrent_flat_set(FromRangeT&&, R&&,
+      std::size_t = boost::unordered::detail::foa::default_bucket_count,
+      Hash = Hash(), Pred = Pred(), Allocator = Allocator())
+      -> concurrent_flat_set<std::ranges::range_value_t<R>,
+        Hash, Pred, Allocator>;
+#endif
+
     template <class T, class Hash = boost::hash<T>,
       class Pred = std::equal_to<T>, class Allocator = std::allocator<T>,
       class = std::enable_if_t<detail::is_hash_v<Hash> >,
@@ -893,6 +978,39 @@ namespace boost {
         typename std::iterator_traits<InputIterator>::value_type, Hash,
         std::equal_to<typename std::iterator_traits<InputIterator>::value_type>,
         Allocator>;
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+    template <boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Allocator,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    concurrent_flat_set(FromRangeT&&, R&&, std::size_t, Allocator)
+      -> concurrent_flat_set<std::ranges::range_value_t<R>,
+        boost::hash<std::ranges::range_value_t<R> >,
+        std::equal_to<std::ranges::range_value_t<R> >,
+        Allocator>;
+
+    template <boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Hash, class Allocator,
+      class = std::enable_if_t<detail::is_hash_v<Hash> >,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    concurrent_flat_set(
+      FromRangeT&&, R&&, std::size_t, Hash, Allocator)
+      -> concurrent_flat_set<std::ranges::range_value_t<R>,
+        Hash, std::equal_to<std::ranges::range_value_t<R> >,
+        Allocator>;
+
+    template <boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Allocator,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    concurrent_flat_set(FromRangeT&&, R&&, Allocator)
+      -> concurrent_flat_set<std::ranges::range_value_t<R>,
+        boost::hash<std::ranges::range_value_t<R> >,
+        std::equal_to<std::ranges::range_value_t<R> >,
+        Allocator>;
+#endif
 
     template <class T, class Allocator,
       class = std::enable_if_t<detail::is_allocator_v<Allocator> > >

--- a/include/boost/unordered/concurrent_flat_set.hpp
+++ b/include/boost/unordered/concurrent_flat_set.hpp
@@ -542,6 +542,21 @@ namespace boost {
         return count_elements;
       }
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<detail::container_compatible_range<value_type> R, class F>
+      size_type insert_range_or_visit(R&& rg, F f)
+      {
+        BOOST_UNORDERED_STATIC_ASSERT_CONST_INVOCABLE(F)
+        size_type count_elements = 0;
+        auto first = std::ranges::begin(rg);
+        auto last = std::ranges::end(rg);
+        for (; first != last; ++first, ++count_elements) {
+          table_.emplace_or_visit(*first, f);
+        }
+        return count_elements;
+      }
+#endif
+
       template <class F>
       size_type insert_or_visit(std::initializer_list<value_type> ilist, F f)
       {
@@ -583,6 +598,21 @@ namespace boost {
         }
         return count_elements;
       }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<detail::container_compatible_range<value_type> R, class F>
+      size_type insert_range_or_cvisit(R&& rg, F f)
+      {
+        BOOST_UNORDERED_STATIC_ASSERT_CONST_INVOCABLE(F)
+        size_type count_elements = 0;
+        auto first = std::ranges::begin(rg);
+        auto last = std::ranges::end(rg);
+        for (; first != last; ++first, ++count_elements) {
+          table_.emplace_or_cvisit(*first, f);
+        }
+        return count_elements;
+      }
+#endif
 
       template <class F>
       size_type insert_or_cvisit(std::initializer_list<value_type> ilist, F f)
@@ -631,6 +661,24 @@ namespace boost {
         }
         return count_elements;
       }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<
+        detail::container_compatible_range<value_type> R, class F1, class F2
+      >
+      size_type insert_range_and_visit(R&& rg, F1 f1, F2 f2)
+      {
+        BOOST_UNORDERED_STATIC_ASSERT_CONST_INVOCABLE(F1)
+        BOOST_UNORDERED_STATIC_ASSERT_CONST_INVOCABLE(F2)
+        size_type count_elements = 0;
+        auto first = std::ranges::begin(rg);
+        auto last = std::ranges::end(rg);
+        for (; first != last; ++first, ++count_elements) {
+          table_.emplace_and_visit(*first, f1, f2);
+        }
+        return count_elements;
+      }
+#endif
 
       template <class F1, class F2>
       size_type insert_and_visit(std::initializer_list<value_type> ilist, F1 f1, F2 f2)
@@ -681,6 +729,24 @@ namespace boost {
         }
         return count_elements;
       }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<
+        detail::container_compatible_range<value_type> R, class F1, class F2
+      >
+      size_type insert_range_and_cvisit(R&& rg, F1 f1, F2 f2)
+      {
+        BOOST_UNORDERED_STATIC_ASSERT_CONST_INVOCABLE(F1)
+        BOOST_UNORDERED_STATIC_ASSERT_CONST_INVOCABLE(F2)
+        size_type count_elements = 0;
+        auto first = std::ranges::begin(rg);
+        auto last = std::ranges::end(rg);
+        for (; first != last; ++first, ++count_elements) {
+          table_.emplace_and_cvisit(*first, f1, f2);
+        }
+        return count_elements;
+      }
+#endif
 
       template <class F1, class F2>
       size_type insert_and_cvisit(

--- a/include/boost/unordered/concurrent_node_map.hpp
+++ b/include/boost/unordered/concurrent_node_map.hpp
@@ -578,6 +578,21 @@ namespace boost {
         return count_elements;
       }
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<detail::container_compatible_range<value_type> R, class F>
+      size_type insert_range_or_visit(R&& rg, F f)
+      {
+        BOOST_UNORDERED_STATIC_ASSERT_INVOCABLE(F)
+        size_type count_elements = 0;
+        auto first = std::ranges::begin(rg);
+        auto last = std::ranges::end(rg);
+        for (; first != last; ++first, ++count_elements) {
+          table_.emplace_or_visit(*first, f);
+        }
+        return count_elements;
+      }
+#endif
+
       template <class F>
       size_type insert_or_visit(std::initializer_list<value_type> ilist, F f)
       {
@@ -631,6 +646,21 @@ namespace boost {
         }
         return count_elements;
       }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<detail::container_compatible_range<value_type> R, class F>
+      size_type insert_range_or_cvisit(R&& rg, F f)
+      {
+        BOOST_UNORDERED_STATIC_ASSERT_CONST_INVOCABLE(F)
+        size_type count_elements = 0;
+        auto first = std::ranges::begin(rg);
+        auto last = std::ranges::end(rg);
+        for (; first != last; ++first, ++count_elements) {
+          table_.emplace_or_cvisit(*first, f);
+        }
+        return count_elements;
+      }
+#endif
 
       template <class F>
       size_type insert_or_cvisit(std::initializer_list<value_type> ilist, F f)
@@ -689,6 +719,24 @@ namespace boost {
         }
         return count_elements;
       }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<
+        detail::container_compatible_range<value_type> R, class F1, class F2
+      >
+      size_type insert_range_and_visit(R&& rg, F1 f1, F2 f2)
+      {
+        BOOST_UNORDERED_STATIC_ASSERT_INVOCABLE(F1)
+        BOOST_UNORDERED_STATIC_ASSERT_INVOCABLE(F2)
+        size_type count_elements = 0;
+        auto first = std::ranges::begin(rg);
+        auto last = std::ranges::end(rg);
+        for (; first != last; ++first, ++count_elements) {
+          table_.emplace_and_visit(*first, f1, f2);
+        }
+        return count_elements;
+      }
+#endif
 
       template <class F1, class F2>
       size_type insert_and_visit(
@@ -751,6 +799,24 @@ namespace boost {
         }
         return count_elements;
       }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<
+        detail::container_compatible_range<value_type> R, class F1, class F2
+      >
+      size_type insert_range_and_cvisit(R&& rg, F1 f1, F2 f2)
+      {
+        BOOST_UNORDERED_STATIC_ASSERT_INVOCABLE(F1)
+        BOOST_UNORDERED_STATIC_ASSERT_INVOCABLE(F2)
+        size_type count_elements = 0;
+        auto first = std::ranges::begin(rg);
+        auto last = std::ranges::end(rg);
+        for (; first != last; ++first, ++count_elements) {
+          table_.emplace_and_cvisit(*first, f1, f2);
+        }
+        return count_elements;
+      }
+#endif
 
       template <class F1, class F2>
       size_type insert_and_cvisit(

--- a/include/boost/unordered/concurrent_node_map.hpp
+++ b/include/boost/unordered/concurrent_node_map.hpp
@@ -19,6 +19,7 @@
 #include <boost/unordered/detail/foa/element_type.hpp>
 #include <boost/unordered/detail/foa/node_map_handle.hpp>
 #include <boost/unordered/detail/foa/node_map_types.hpp>
+#include <boost/unordered/detail/ranges_support.hpp>
 #include <boost/unordered/detail/type_traits.hpp>
 #include <boost/unordered/unordered_node_map_fwd.hpp>
 
@@ -110,6 +111,21 @@ namespace boost {
         this->insert(f, l);
       }
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<value_type> R
+      >
+      concurrent_node_map(FromRangeT&&, R&& rg,
+        size_type n = detail::foa::default_bucket_count,
+        const hasher& hf = hasher(), const key_equal& eql = key_equal(),
+        const allocator_type& a = allocator_type())
+          : table_(n, hf, eql, a)
+      {
+        this->insert_range(std::forward<R>(rg));
+      }
+#endif
+
       concurrent_node_map(concurrent_node_map const& rhs)
           : table_(rhs.table_,
               boost::allocator_select_on_container_copy_construction(
@@ -128,6 +144,19 @@ namespace boost {
           : concurrent_node_map(f, l, 0, hasher(), key_equal(), a)
       {
       }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<value_type> R
+      >
+      concurrent_node_map(
+        FromRangeT&& fr, R&& rg, allocator_type const& a)
+          : concurrent_node_map(
+            fr, std::forward<R>(rg), 0, hasher(), key_equal(), a)
+      {
+      }
+#endif
 
       explicit concurrent_node_map(allocator_type const& a)
           : table_(detail::foa::default_bucket_count, hasher(), key_equal(), a)
@@ -178,6 +207,29 @@ namespace boost {
           : concurrent_node_map(f, l, n, hf, key_equal(), a)
       {
       }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<value_type> R
+      >
+      concurrent_node_map(
+        FromRangeT&& fr, R&& rg, size_type n, const allocator_type& a)
+          : concurrent_node_map(
+            fr, std::forward<R>(rg), n, hasher(), key_equal(), a)
+      {
+      }
+
+      template<
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<value_type> R
+      >
+      concurrent_node_map(FromRangeT&& fr, R&& rg, size_type n,
+        const hasher& hf, const allocator_type& a)
+          : concurrent_node_map(fr, std::forward<R>(rg), n, hf, key_equal(), a)
+      {
+      }
+#endif
 
       concurrent_node_map(
         std::initializer_list<value_type> il, const allocator_type& a)
@@ -437,6 +489,20 @@ namespace boost {
         }
         return count_elements;
       }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<detail::container_compatible_range<value_type> R>
+      size_type insert_range(R&& rg)
+      {
+        size_type count_elements = 0;
+        auto first = std::ranges::begin(rg);
+        auto last = std::ranges::end(rg);
+        while (first != last) {
+          if (table_.emplace(*first++)) ++count_elements;
+        }
+        return count_elements;
+      }
+#endif
 
       size_type insert(std::initializer_list<value_type> ilist)
       {
@@ -1128,6 +1194,27 @@ namespace boost {
         boost::unordered::detail::iter_val_t<InputIterator>, Hash, Pred,
         Allocator>;
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+    template <
+      boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Hash =
+        boost::hash<boost::unordered::detail::range_key_t<R> >,
+      class Pred =
+        std::equal_to<boost::unordered::detail::range_key_t<R> >,
+      class Allocator = std::allocator<
+        boost::unordered::detail::range_to_alloc_t<R> >,
+      class = std::enable_if_t<detail::is_hash_v<Hash> >,
+      class = std::enable_if_t<detail::is_pred_v<Pred> >,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    concurrent_node_map(FromRangeT&&, R&&,
+      std::size_t = boost::unordered::detail::foa::default_bucket_count,
+      Hash = Hash(), Pred = Pred(), Allocator = Allocator())
+      -> concurrent_node_map<boost::unordered::detail::range_key_t<R>,
+        boost::unordered::detail::range_mapped_t<R>, Hash, Pred,
+        Allocator>;
+#endif
+
     template <class Key, class T,
       class Hash = boost::hash<std::remove_const_t<Key> >,
       class Pred = std::equal_to<std::remove_const_t<Key> >,
@@ -1174,6 +1261,42 @@ namespace boost {
         boost::unordered::detail::iter_val_t<InputIterator>, Hash,
         std::equal_to<boost::unordered::detail::iter_key_t<InputIterator> >,
         Allocator>;
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+    template <boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Allocator,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    concurrent_node_map(FromRangeT&&, R&&, std::size_t, Allocator)
+      -> concurrent_node_map<boost::unordered::detail::range_key_t<R>,
+        boost::unordered::detail::range_mapped_t<R>,
+        boost::hash<boost::unordered::detail::range_key_t<R> >,
+        std::equal_to<boost::unordered::detail::range_key_t<R> >,
+        Allocator>;
+
+    template <boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Allocator,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    concurrent_node_map(FromRangeT&&, R&&, Allocator)
+      -> concurrent_node_map<boost::unordered::detail::range_key_t<R>,
+        boost::unordered::detail::range_mapped_t<R>,
+        boost::hash<boost::unordered::detail::range_key_t<R> >,
+        std::equal_to<boost::unordered::detail::range_key_t<R> >,
+        Allocator>;
+
+    template <boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Hash, class Allocator,
+      class = std::enable_if_t<detail::is_hash_v<Hash> >,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    concurrent_node_map(
+      FromRangeT&&, R&&, std::size_t, Hash, Allocator)
+      -> concurrent_node_map<boost::unordered::detail::range_key_t<R>,
+        boost::unordered::detail::range_mapped_t<R>, Hash,
+        std::equal_to<boost::unordered::detail::range_key_t<R> >,
+        Allocator>;
+#endif
 
     template <class Key, class T, class Allocator,
       class = std::enable_if_t<detail::is_allocator_v<Allocator> > >

--- a/include/boost/unordered/concurrent_node_set.hpp
+++ b/include/boost/unordered/concurrent_node_set.hpp
@@ -19,6 +19,7 @@
 #include <boost/unordered/detail/foa/element_type.hpp>
 #include <boost/unordered/detail/foa/node_set_handle.hpp>
 #include <boost/unordered/detail/foa/node_set_types.hpp>
+#include <boost/unordered/detail/ranges_support.hpp>
 #include <boost/unordered/detail/type_traits.hpp>
 #include <boost/unordered/unordered_node_set_fwd.hpp>
 
@@ -107,6 +108,21 @@ namespace boost {
         this->insert(f, l);
       }
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<value_type> R
+      >
+      concurrent_node_set(FromRangeT&&, R&& rg,
+        size_type n = detail::foa::default_bucket_count,
+        const hasher& hf = hasher(), const key_equal& eql = key_equal(),
+        const allocator_type& a = allocator_type())
+          : table_(n, hf, eql, a)
+      {
+        this->insert_range(std::forward<R>(rg));
+      }
+#endif
+
       concurrent_node_set(concurrent_node_set const& rhs)
           : table_(rhs.table_,
               boost::allocator_select_on_container_copy_construction(
@@ -125,6 +141,19 @@ namespace boost {
           : concurrent_node_set(f, l, 0, hasher(), key_equal(), a)
       {
       }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<value_type> R
+      >
+      concurrent_node_set(
+        FromRangeT&& fr, R&& rg, allocator_type const& a)
+          : concurrent_node_set(
+            fr, std::forward<R>(rg), 0, hasher(), key_equal(), a)
+      {
+      }
+#endif
 
       explicit concurrent_node_set(allocator_type const& a)
           : table_(detail::foa::default_bucket_count, hasher(), key_equal(), a)
@@ -175,6 +204,29 @@ namespace boost {
           : concurrent_node_set(f, l, n, hf, key_equal(), a)
       {
       }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<value_type> R
+      >
+      concurrent_node_set(
+        FromRangeT&& fr, R&& rg, size_type n, const allocator_type& a)
+          : concurrent_node_set(
+            fr, std::forward<R>(rg), n, hasher(), key_equal(), a)
+      {
+      }
+
+      template<
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<value_type> R
+      >
+      concurrent_node_set(FromRangeT&& fr, R&& rg, size_type n,
+        const hasher& hf, const allocator_type& a)
+          : concurrent_node_set(fr, std::forward<R>(rg), n, hf, key_equal(), a)
+      {
+      }
+#endif
 
       concurrent_node_set(
         std::initializer_list<value_type> il, const allocator_type& a)
@@ -443,6 +495,20 @@ namespace boost {
         }
         return count_elements;
       }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<detail::container_compatible_range<value_type> R>
+      size_type insert_range(R&& rg)
+      {
+        size_type count_elements = 0;
+        auto first = std::ranges::begin(rg);
+        auto last = std::ranges::end(rg);
+        while (first != last) {
+          if (table_.emplace(*first++)) ++count_elements;
+        }
+        return count_elements;
+      }
+#endif
 
       size_type insert(std::initializer_list<value_type> ilist)
       {
@@ -1002,6 +1068,26 @@ namespace boost {
         typename std::iterator_traits<InputIterator>::value_type, Hash, Pred,
         Allocator>;
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+    template <
+      boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Hash =
+        boost::hash<std::ranges::range_value_t<R> >,
+      class Pred =
+        std::equal_to<std::ranges::range_value_t<R> >,
+      class Allocator = std::allocator<std::ranges::range_value_t<R> >,
+      class = std::enable_if_t<detail::is_hash_v<Hash> >,
+      class = std::enable_if_t<detail::is_pred_v<Pred> >,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    concurrent_node_set(FromRangeT&&, R&&,
+      std::size_t = boost::unordered::detail::foa::default_bucket_count,
+      Hash = Hash(), Pred = Pred(), Allocator = Allocator())
+      -> concurrent_node_set<std::ranges::range_value_t<R>,
+        Hash, Pred, Allocator>;
+#endif
+
+
     template <class T, class Hash = boost::hash<T>,
       class Pred = std::equal_to<T>, class Allocator = std::allocator<T>,
       class = std::enable_if_t<detail::is_hash_v<Hash> >,
@@ -1042,6 +1128,39 @@ namespace boost {
         typename std::iterator_traits<InputIterator>::value_type, Hash,
         std::equal_to<typename std::iterator_traits<InputIterator>::value_type>,
         Allocator>;
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+    template <boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Allocator,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    concurrent_node_set(FromRangeT&&, R&&, std::size_t, Allocator)
+      -> concurrent_node_set<std::ranges::range_value_t<R>,
+        boost::hash<std::ranges::range_value_t<R> >,
+        std::equal_to<std::ranges::range_value_t<R> >,
+        Allocator>;
+
+    template <boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Hash, class Allocator,
+      class = std::enable_if_t<detail::is_hash_v<Hash> >,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    concurrent_node_set(
+      FromRangeT&&, R&&, std::size_t, Hash, Allocator)
+      -> concurrent_node_set<std::ranges::range_value_t<R>,
+        Hash, std::equal_to<std::ranges::range_value_t<R> >,
+        Allocator>;
+
+    template <boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Allocator,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    concurrent_node_set(FromRangeT&&, R&&, Allocator)
+      -> concurrent_node_set<std::ranges::range_value_t<R>,
+        boost::hash<std::ranges::range_value_t<R> >,
+        std::equal_to<std::ranges::range_value_t<R> >,
+        Allocator>;
+#endif
 
     template <class T, class Allocator,
       class = std::enable_if_t<detail::is_allocator_v<Allocator> > >

--- a/include/boost/unordered/concurrent_node_set.hpp
+++ b/include/boost/unordered/concurrent_node_set.hpp
@@ -569,6 +569,21 @@ namespace boost {
         return count_elements;
       }
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<detail::container_compatible_range<value_type> R, class F>
+      size_type insert_range_or_visit(R&& rg, F f)
+      {
+        BOOST_UNORDERED_STATIC_ASSERT_CONST_INVOCABLE(F)
+        size_type count_elements = 0;
+        auto first = std::ranges::begin(rg);
+        auto last = std::ranges::end(rg);
+        for (; first != last; ++first, ++count_elements) {
+          table_.emplace_or_visit(*first, f);
+        }
+        return count_elements;
+      }
+#endif
+
       template <class F>
       size_type insert_or_visit(std::initializer_list<value_type> ilist, F f)
       {
@@ -631,6 +646,21 @@ namespace boost {
         }
         return count_elements;
       }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<detail::container_compatible_range<value_type> R, class F>
+      size_type insert_range_or_cvisit(R&& rg, F f)
+      {
+        BOOST_UNORDERED_STATIC_ASSERT_CONST_INVOCABLE(F)
+        size_type count_elements = 0;
+        auto first = std::ranges::begin(rg);
+        auto last = std::ranges::end(rg);
+        for (; first != last; ++first, ++count_elements) {
+          table_.emplace_or_cvisit(*first, f);
+        }
+        return count_elements;
+      }
+#endif
 
       template <class F>
       size_type insert_or_cvisit(std::initializer_list<value_type> ilist, F f)
@@ -700,6 +730,24 @@ namespace boost {
         }
         return count_elements;
       }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<
+        detail::container_compatible_range<value_type> R, class F1, class F2
+      >
+      size_type insert_range_and_visit(R&& rg, F1 f1, F2 f2)
+      {
+        BOOST_UNORDERED_STATIC_ASSERT_CONST_INVOCABLE(F1)
+        BOOST_UNORDERED_STATIC_ASSERT_CONST_INVOCABLE(F2)
+        size_type count_elements = 0;
+        auto first = std::ranges::begin(rg);
+        auto last = std::ranges::end(rg);
+        for (; first != last; ++first, ++count_elements) {
+          table_.emplace_and_visit(*first, f1, f2);
+        }
+        return count_elements;
+      }
+#endif
 
       template <class F1, class F2>
       size_type insert_and_visit(
@@ -773,6 +821,24 @@ namespace boost {
         }
         return count_elements;
       }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<
+        detail::container_compatible_range<value_type> R, class F1, class F2
+      >
+      size_type insert_range_and_cvisit(R&& rg, F1 f1, F2 f2)
+      {
+        BOOST_UNORDERED_STATIC_ASSERT_CONST_INVOCABLE(F1)
+        BOOST_UNORDERED_STATIC_ASSERT_CONST_INVOCABLE(F2)
+        size_type count_elements = 0;
+        auto first = std::ranges::begin(rg);
+        auto last = std::ranges::end(rg);
+        for (; first != last; ++first, ++count_elements) {
+          table_.emplace_and_cvisit(*first, f1, f2);
+        }
+        return count_elements;
+      }
+#endif
 
       template <class F1, class F2>
       size_type insert_and_cvisit(

--- a/include/boost/unordered/detail/implementation.hpp
+++ b/include/boost/unordered/detail/implementation.hpp
@@ -18,6 +18,7 @@
 #include <boost/unordered/detail/allocator_constructed.hpp>
 #include <boost/unordered/detail/fca.hpp>
 #include <boost/unordered/detail/opt_storage.hpp>
+#include <boost/unordered/detail/ranges_support.hpp>
 #include <boost/unordered/detail/serialize_tracked_address.hpp>
 #include <boost/unordered/detail/static_assert.hpp>
 #include <boost/unordered/detail/type_traits.hpp>
@@ -174,6 +175,29 @@ namespace boost {
         return (std::max)(
           boost::unordered::detail::insert_size(i, j), num_buckets);
       }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<std::ranges::input_range R>
+      inline std::size_t insert_size(R&& rg)
+      {
+        if constexpr (std::ranges::sized_range<R>)
+          return std::ranges::size(std::forward<R>(rg));
+        else if constexpr (std::ranges::forward_range<R>)
+          return std::ranges::distance(std::forward<R>(rg));
+        else
+          return 1;
+      }
+
+      template <std::ranges::input_range R>
+      inline std::size_t initial_size(R&& rg,
+        std::size_t num_buckets =
+          boost::unordered::detail::default_bucket_count)
+      {
+        return (std::max)(
+          boost::unordered::detail::insert_size(std::forward<R>(rg)),
+          num_buckets);
+      }
+#endif
 
       //////////////////////////////////////////////////////////////////////////
       // compressed
@@ -2155,8 +2179,8 @@ namespace boost {
         // if hash function throws, or inserting > 1 element, basic exception
         // safety strong otherwise
 
-        template <class InputIt>
-        void insert_range_unique(no_key, InputIt i, InputIt j)
+        template <class InputIt, class Sentinel>
+        void insert_range_unique(no_key, InputIt i, Sentinel j)
         {
           hasher const& hf = this->hash_function();
           node_allocator_type alloc = this->node_alloc();
@@ -2543,14 +2567,20 @@ namespace boost {
 
         // if hash function throws, or inserting > 1 element, basic exception
         // safety. Strong otherwise
-        template <class I>
+        template <class I, class S>
         typename boost::unordered::detail::enable_if_forward<I, void>::type
-        insert_range_equiv(I i, I j)
+        insert_range_equiv(I i, S j)
         {
           if (i == j)
             return;
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+          std::size_t distance = static_cast<std::size_t>(
+            std::ranges::distance(i, j));
+#else
           std::size_t distance = static_cast<std::size_t>(std::distance(i, j));
+#endif
+
           if (distance == 1) {
             emplace_equiv(boost::unordered::detail::func::construct_node(
               this->node_alloc(), *i));
@@ -2566,9 +2596,9 @@ namespace boost {
           }
         }
 
-        template <class I>
+        template <class I, class S>
         typename boost::unordered::detail::disable_if_forward<I, void>::type
-        insert_range_equiv(I i, I j)
+        insert_range_equiv(I i, S j)
         {
           for (; i != j; ++i) {
             emplace_equiv(boost::unordered::detail::func::construct_node(

--- a/include/boost/unordered/detail/ranges_support.hpp
+++ b/include/boost/unordered/detail/ranges_support.hpp
@@ -1,0 +1,101 @@
+/* Copyright 2026 Joaquin M Lopez Munoz.
+ * Distributed under the Boost Software License, Version 1.0.
+ * (See accompanying file LICENSE_1_0.txt or copy at
+ * http://www.boost.org/LICENSE_1_0.txt)
+ *
+ * See https://www.boost.org/libs/unordered for library home page.
+ */
+
+#ifndef BOOST_UNORDERED_DETAIL_RANGES_SUPPORT_HPP
+#define BOOST_UNORDERED_DETAIL_RANGES_SUPPORT_HPP
+
+#include <boost/config.hpp>
+#include <boost/config/workaround.hpp>
+
+#if defined(BOOST_NO_CXX20_HDR_CONCEPTS) || defined(BOOST_NO_CXX20_HDR_RANGES)
+#define BOOST_UNORDERED_NO_RANGES
+#elif BOOST_WORKAROUND(BOOST_CLANG_VERSION, < 170100) && \
+      defined(BOOST_LIBSTDCXX_VERSION)
+/* https://gcc.gnu.org/bugzilla/show_bug.cgi?id=109647
+ * https://github.com/llvm/llvm-project/issues/49620
+ */
+#define BOOST_UNORDERED_NO_RANGES
+#endif
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+#include <concepts>
+#include <functional>
+#include <ranges>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+namespace boost {
+namespace unordered {
+
+struct from_range_t { explicit from_range_t() = default; };
+inline constexpr from_range_t from_range{};
+
+namespace detail {
+
+/* Code below picks std::from_range_t if it exists,
+ * boost::unordered::from_range_t otherwise. Technique explained at
+ https://bannalia.blogspot.com/2016/09/compile-time-checking-existence-of.html
+ */
+
+struct from_range_t_hook{};
+
+} /* namespace detail */
+} /* namespace unordered */
+} /* namespace boost */
+
+namespace std {
+
+template<> struct hash< ::boost::unordered::detail::from_range_t_hook>
+{
+  using from_range_t_type = decltype([] {
+    using namespace ::boost::unordered;
+    return from_range_t{};
+  }());
+
+  /* make standard happy */
+  std::size_t operator()(
+    const ::boost::unordered::detail::from_range_t_hook&) const;
+};
+
+} /* namespace std */
+
+namespace boost {
+namespace unordered {
+namespace detail {
+
+template<typename T>
+concept convertible_to_from_range_t =
+  std::is_convertible_v<T, boost::unordered::from_range_t> ||
+  std::is_convertible_v<T, std::hash<from_range_t_hook>::from_range_t_type>;
+
+template<class R, class T>
+concept container_compatible_range =
+  std::ranges::input_range<R> &&
+  std::convertible_to<std::ranges::range_reference_t<R>, T>;
+
+template<std::ranges::input_range Range>
+using range_key_t =
+  std::remove_cvref_t<
+    std::tuple_element_t<0, std::ranges::range_value_t<Range>>>;
+
+template<std::ranges::input_range Range>
+using range_mapped_t =
+  std::remove_cvref_t<
+    std::tuple_element_t<1, std::ranges::range_value_t<Range>>>;
+
+template<std::ranges::input_range Range>
+using range_to_alloc_t = 
+  std::pair<const range_key_t<Range>, range_mapped_t<Range>>;
+
+} /* namespace detail */
+} /* namespace unordered */
+} /* namespace boost */
+
+#endif /* !defined(BOOST_UNORDERED_NO_RANGES) */
+#endif

--- a/include/boost/unordered/detail/ranges_support.hpp
+++ b/include/boost/unordered/detail/ranges_support.hpp
@@ -38,8 +38,11 @@ inline constexpr from_range_t from_range{};
 
 namespace detail {
 
-/* Code below picks std::from_range_t if it exists,
- * boost::unordered::from_range_t otherwise. Technique explained at
+/* Existence of std::from_range_t is governed by feature macro
+ * __cpp_lib_containers_ranges, but at least one stdlib implementation 
+ * (GCC 14.1) does not honor it, hence the workadound below: code picks 
+ * std::from_range_t if it exists, boost::unordered::from_range_t otherwise.
+ * Technique explained at
  https://bannalia.blogspot.com/2016/09/compile-time-checking-existence-of.html
  */
 

--- a/include/boost/unordered/unordered_flat_map.hpp
+++ b/include/boost/unordered/unordered_flat_map.hpp
@@ -1,5 +1,5 @@
 // Copyright (C) 2022-2023 Christian Mazakas
-// Copyright (C) 2024-2025 Joaquin M Lopez Munoz
+// Copyright (C) 2024-2026 Joaquin M Lopez Munoz
 // Copyright (C) 2026 Braden Ganetsky
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -15,6 +15,7 @@
 #include <boost/unordered/concurrent_flat_map_fwd.hpp>
 #include <boost/unordered/detail/foa/flat_map_types.hpp>
 #include <boost/unordered/detail/foa/table.hpp>
+#include <boost/unordered/detail/ranges_support.hpp>
 #include <boost/unordered/detail/serialize_container.hpp>
 #include <boost/unordered/detail/throw_exception.hpp>
 #include <boost/unordered/detail/type_traits.hpp>
@@ -108,6 +109,19 @@ namespace boost {
       {
       }
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<value_type> R
+      >
+      unordered_flat_map(
+        FromRangeT&& fr, R&& rg, allocator_type const& a)
+          : unordered_flat_map(
+            fr, std::forward<R>(rg), size_type(0), hasher(), key_equal(), a)
+      {
+      }
+#endif
+
       explicit unordered_flat_map(allocator_type const& a)
           : unordered_flat_map(0, a)
       {
@@ -135,6 +149,41 @@ namespace boost {
           : unordered_flat_map(first, last, n, h, key_equal(), a)
       {
       }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<value_type> R
+      >
+      unordered_flat_map(FromRangeT&&, R&& rg, size_type n = 0,
+        hasher const& h = hasher(), key_equal const& pred = key_equal(),
+        allocator_type const& a = allocator_type())
+        :  unordered_flat_map(n, h, pred, a)
+      {
+        this->insert_range(std::forward<R>(rg));
+      }
+
+      template<
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<value_type> R
+      >
+      unordered_flat_map(
+        FromRangeT&& fr, R&& rg, size_type n, allocator_type const& a)
+          : unordered_flat_map(
+            fr, std::forward<R>(rg), n, hasher(), key_equal(), a)
+      {
+      }
+
+      template<
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<value_type> R
+      >
+      unordered_flat_map(FromRangeT&& fr, R&& rg, size_type n,
+        hasher const& h, allocator_type const& a)
+          : unordered_flat_map(fr, std::forward<R>(rg), n, h, key_equal(), a)
+      {
+      }
+#endif
 
       unordered_flat_map(unordered_flat_map const& other) : table_(other.table_)
       {
@@ -277,6 +326,16 @@ namespace boost {
           table_.emplace(*pos);
         }
       }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<detail::container_compatible_range<value_type> R>
+      BOOST_FORCEINLINE void insert_range(R&& rg)
+      {
+        auto first = std::ranges::begin(rg);
+        auto last = std::ranges::end(rg);
+        while (first != last) table_.emplace(*first++);
+      }
+#endif
 
       void insert(std::initializer_list<value_type> ilist)
       {
@@ -756,6 +815,27 @@ namespace boost {
         boost::unordered::detail::iter_val_t<InputIterator>, Hash, Pred,
         Allocator>;
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+    template <
+      boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Hash =
+        boost::hash<boost::unordered::detail::range_key_t<R> >,
+      class Pred =
+        std::equal_to<boost::unordered::detail::range_key_t<R> >,
+      class Allocator = std::allocator<
+        boost::unordered::detail::range_to_alloc_t<R> >,
+      class = std::enable_if_t<detail::is_hash_v<Hash> >,
+      class = std::enable_if_t<detail::is_pred_v<Pred> >,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    unordered_flat_map(FromRangeT&&, R&&,
+      std::size_t = boost::unordered::detail::foa::default_bucket_count,
+      Hash = Hash(), Pred = Pred(), Allocator = Allocator())
+      -> unordered_flat_map<boost::unordered::detail::range_key_t<R>,
+        boost::unordered::detail::range_mapped_t<R>, Hash, Pred,
+        Allocator>;
+#endif
+
     template <class Key, class T,
       class Hash = boost::hash<std::remove_const_t<Key> >,
       class Pred = std::equal_to<std::remove_const_t<Key> >,
@@ -799,6 +879,42 @@ namespace boost {
         boost::unordered::detail::iter_val_t<InputIterator>, Hash,
         std::equal_to<boost::unordered::detail::iter_key_t<InputIterator> >,
         Allocator>;
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+    template <boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Allocator,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    unordered_flat_map(FromRangeT&&, R&&, std::size_t, Allocator)
+      -> unordered_flat_map<boost::unordered::detail::range_key_t<R>,
+        boost::unordered::detail::range_mapped_t<R>,
+        boost::hash<boost::unordered::detail::range_key_t<R> >,
+        std::equal_to<boost::unordered::detail::range_key_t<R> >,
+        Allocator>;
+
+    template <boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Allocator,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    unordered_flat_map(FromRangeT&&, R&&, Allocator)
+      -> unordered_flat_map<boost::unordered::detail::range_key_t<R>,
+        boost::unordered::detail::range_mapped_t<R>,
+        boost::hash<boost::unordered::detail::range_key_t<R> >,
+        std::equal_to<boost::unordered::detail::range_key_t<R> >,
+        Allocator>;
+
+    template <boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Hash, class Allocator,
+      class = std::enable_if_t<detail::is_hash_v<Hash> >,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    unordered_flat_map(
+      FromRangeT&&, R&&, std::size_t, Hash, Allocator)
+      -> unordered_flat_map<boost::unordered::detail::range_key_t<R>,
+        boost::unordered::detail::range_mapped_t<R>, Hash,
+        std::equal_to<boost::unordered::detail::range_key_t<R> >,
+        Allocator>;
+#endif
 
     template <class Key, class T, class Allocator,
       class = std::enable_if_t<detail::is_allocator_v<Allocator> > >

--- a/include/boost/unordered/unordered_flat_set.hpp
+++ b/include/boost/unordered/unordered_flat_set.hpp
@@ -1,5 +1,5 @@
 // Copyright (C) 2022-2023 Christian Mazakas
-// Copyright (C) 2024-2025 Joaquin M Lopez Munoz
+// Copyright (C) 2024-2026 Joaquin M Lopez Munoz
 // Copyright (C) 2026 Braden Ganetsky
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -15,6 +15,7 @@
 #include <boost/unordered/concurrent_flat_set_fwd.hpp>
 #include <boost/unordered/detail/foa/flat_set_types.hpp>
 #include <boost/unordered/detail/foa/table.hpp>
+#include <boost/unordered/detail/ranges_support.hpp>
 #include <boost/unordered/detail/serialize_container.hpp>
 #include <boost/unordered/detail/type_traits.hpp>
 #include <boost/unordered/unordered_flat_set_fwd.hpp>
@@ -104,6 +105,19 @@ namespace boost {
       {
       }
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<value_type> R
+      >
+      unordered_flat_set(
+        FromRangeT&& fr, R&& rg, allocator_type const& a)
+          : unordered_flat_set(
+            fr, std::forward<R>(rg), size_type(0), hasher(), key_equal(), a)
+      {
+      }
+#endif
+
       explicit unordered_flat_set(allocator_type const& a)
           : unordered_flat_set(0, a)
       {
@@ -131,6 +145,41 @@ namespace boost {
           : unordered_flat_set(first, last, n, h, key_equal(), a)
       {
       }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<value_type> R
+      >
+      unordered_flat_set(FromRangeT&&, R&& rg, size_type n = 0,
+        hasher const& h = hasher(), key_equal const& pred = key_equal(),
+        allocator_type const& a = allocator_type())
+        :  unordered_flat_set(n, h, pred, a)
+      {
+        this->insert_range(std::forward<R>(rg));
+      }
+
+      template<
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<value_type> R
+      >
+      unordered_flat_set(
+        FromRangeT&& fr, R&& rg, size_type n, allocator_type const& a)
+          : unordered_flat_set(
+            fr, std::forward<R>(rg), n, hasher(), key_equal(), a)
+      {
+      }
+
+      template<
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<value_type> R
+      >
+      unordered_flat_set(FromRangeT&& fr, R&& rg, size_type n,
+        hasher const& h, allocator_type const& a)
+          : unordered_flat_set(fr, std::forward<R>(rg), n, h, key_equal(), a)
+      {
+      }
+#endif
 
       unordered_flat_set(unordered_flat_set const& other) : table_(other.table_)
       {
@@ -288,6 +337,16 @@ namespace boost {
           table_.emplace(*pos);
         }
       }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<detail::container_compatible_range<value_type> R>
+      void insert_range(R&& rg)
+      {
+        auto first = std::ranges::begin(rg);
+        auto last = std::ranges::end(rg);
+        while (first != last) table_.emplace(*first++);
+      }
+#endif
 
       void insert(std::initializer_list<value_type> ilist)
       {
@@ -574,6 +633,25 @@ namespace boost {
         typename std::iterator_traits<InputIterator>::value_type, Hash, Pred,
         Allocator>;
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+    template <
+      boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Hash =
+        boost::hash<std::ranges::range_value_t<R> >,
+      class Pred =
+        std::equal_to<std::ranges::range_value_t<R> >,
+      class Allocator = std::allocator<std::ranges::range_value_t<R> >,
+      class = std::enable_if_t<detail::is_hash_v<Hash> >,
+      class = std::enable_if_t<detail::is_pred_v<Pred> >,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    unordered_flat_set(FromRangeT&&, R&&,
+      std::size_t = boost::unordered::detail::foa::default_bucket_count,
+      Hash = Hash(), Pred = Pred(), Allocator = Allocator())
+      -> unordered_flat_set<std::ranges::range_value_t<R>,
+        Hash, Pred, Allocator>;
+#endif
+
     template <class T, class Hash = boost::hash<T>,
       class Pred = std::equal_to<T>, class Allocator = std::allocator<T>,
       class = std::enable_if_t<detail::is_hash_v<Hash> >,
@@ -605,6 +683,29 @@ namespace boost {
         std::equal_to<typename std::iterator_traits<InputIterator>::value_type>,
         Allocator>;
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+    template <boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Allocator,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    unordered_flat_set(FromRangeT&&, R&&, std::size_t, Allocator)
+      -> unordered_flat_set<std::ranges::range_value_t<R>,
+        boost::hash<std::ranges::range_value_t<R> >,
+        std::equal_to<std::ranges::range_value_t<R> >,
+        Allocator>;
+
+    template <boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Hash, class Allocator,
+      class = std::enable_if_t<detail::is_hash_v<Hash> >,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    unordered_flat_set(
+      FromRangeT&&, R&&, std::size_t, Hash, Allocator)
+      -> unordered_flat_set<std::ranges::range_value_t<R>,
+        Hash, std::equal_to<std::ranges::range_value_t<R> >,
+        Allocator>;
+#endif
+
     template <class T, class Allocator,
       class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
     unordered_flat_set(std::initializer_list<T>, std::size_t, Allocator)
@@ -625,6 +726,18 @@ namespace boost {
         boost::hash<typename std::iterator_traits<InputIterator>::value_type>,
         std::equal_to<typename std::iterator_traits<InputIterator>::value_type>,
         Allocator>;
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+    template <boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Allocator,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    unordered_flat_set(FromRangeT&&, R&&, Allocator)
+      -> unordered_flat_set<std::ranges::range_value_t<R>,
+        boost::hash<std::ranges::range_value_t<R> >,
+        std::equal_to<std::ranges::range_value_t<R> >,
+        Allocator>;
+#endif
 
     template <class T, class Allocator,
       class = std::enable_if_t<detail::is_allocator_v<Allocator> > >

--- a/include/boost/unordered/unordered_map.hpp
+++ b/include/boost/unordered/unordered_map.hpp
@@ -1,7 +1,7 @@
 // Copyright (C) 2003-2004 Jeremy B. Maitin-Shepard.
 // Copyright (C) 2005-2011 Daniel James.
 // Copyright (C) 2022-2023 Christian Mazakas
-// Copyright (C) 2024 Joaquin M Lopez Munoz.
+// Copyright (C) 2024-2026 Joaquin M Lopez Munoz.
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
@@ -16,6 +16,7 @@
 #endif
 
 #include <boost/unordered/detail/map.hpp>
+#include <boost/unordered/detail/ranges_support.hpp>
 #include <boost/unordered/detail/serialize_fca_container.hpp>
 #include <boost/unordered/detail/throw_exception.hpp>
 #include <boost/unordered/detail/type_traits.hpp>
@@ -92,6 +93,17 @@ namespace boost {
         const hasher& = hasher(), const key_equal& = key_equal(),
         const allocator_type& = allocator_type());
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template <
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<std::pair<const K, T> > R
+      >
+      unordered_map(FromRangeT&&, R&&,
+        size_type = boost::unordered::detail::default_bucket_count,
+        const hasher& = hasher(), const key_equal& = key_equal(),
+        const allocator_type& = allocator_type());
+#endif
+
       unordered_map(unordered_map const&);
 
       unordered_map(unordered_map&& other)
@@ -125,6 +137,27 @@ namespace boost {
       template <class InputIt>
       unordered_map(
         InputIt, InputIt, size_type, const hasher&, const allocator_type&);
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template <
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<std::pair<const K, T> > R
+      >
+      unordered_map(FromRangeT&&, R&&, const allocator_type&);
+
+      template <
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<std::pair<const K, T> > R
+      >
+      unordered_map(FromRangeT&&, R&&, size_type, const allocator_type&);
+
+      template <
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<std::pair<const K, T> > R
+      >
+      unordered_map(
+        FromRangeT&&, R&&, size_type, const hasher&, const allocator_type&);
+#endif
 
       unordered_map(std::initializer_list<value_type>, const allocator_type&);
 
@@ -247,6 +280,11 @@ namespace boost {
       }
 
       template <class InputIt> void insert(InputIt, InputIt);
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template <detail::container_compatible_range<std::pair<const K, T> > R>
+      void insert_range(R&&);
+#endif
 
       void insert(std::initializer_list<value_type>);
 
@@ -622,6 +660,27 @@ namespace boost {
         boost::unordered::detail::iter_val_t<InputIterator>, Hash, Pred,
         Allocator>;
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+    template <
+      boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Hash =
+        boost::hash<boost::unordered::detail::range_key_t<R> >,
+      class Pred =
+        std::equal_to<boost::unordered::detail::range_key_t<R> >,
+      class Allocator = std::allocator<
+        boost::unordered::detail::range_to_alloc_t<R> >,
+      class = std::enable_if_t<detail::is_hash_v<Hash> >,
+      class = std::enable_if_t<detail::is_pred_v<Pred> >,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    unordered_map(FromRangeT&&, R&&,
+      std::size_t = boost::unordered::detail::default_bucket_count,
+      Hash = Hash(), Pred = Pred(), Allocator = Allocator())
+      -> unordered_map<boost::unordered::detail::range_key_t<R>,
+        boost::unordered::detail::range_mapped_t<R>, Hash, Pred,
+        Allocator>;
+#endif
+
     template <class Key, class T,
       class Hash = boost::hash<std::remove_const_t<Key> >,
       class Pred = std::equal_to<std::remove_const_t<Key> >,
@@ -663,6 +722,42 @@ namespace boost {
         boost::unordered::detail::iter_val_t<InputIterator>, Hash,
         std::equal_to<boost::unordered::detail::iter_key_t<InputIterator> >,
         Allocator>;
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+    template <boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Allocator,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    unordered_map(FromRangeT&&, R&&, std::size_t, Allocator)
+      -> unordered_map<boost::unordered::detail::range_key_t<R>,
+        boost::unordered::detail::range_mapped_t<R>,
+        boost::hash<boost::unordered::detail::range_key_t<R> >,
+        std::equal_to<boost::unordered::detail::range_key_t<R> >,
+        Allocator>;
+
+    template <boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Allocator,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    unordered_map(FromRangeT&&, R&&, Allocator)
+      -> unordered_map<boost::unordered::detail::range_key_t<R>,
+        boost::unordered::detail::range_mapped_t<R>,
+        boost::hash<boost::unordered::detail::range_key_t<R> >,
+        std::equal_to<boost::unordered::detail::range_key_t<R> >,
+        Allocator>;
+
+    template <boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Hash, class Allocator,
+      class = std::enable_if_t<detail::is_hash_v<Hash> >,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    unordered_map(
+      FromRangeT&&, R&&, std::size_t, Hash, Allocator)
+      -> unordered_map<boost::unordered::detail::range_key_t<R>,
+        boost::unordered::detail::range_mapped_t<R>, Hash,
+        std::equal_to<boost::unordered::detail::range_key_t<R> >,
+        Allocator>;
+#endif
 
     template <class Key, class T, class Allocator,
       class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
@@ -742,6 +837,17 @@ namespace boost {
         const hasher& = hasher(), const key_equal& = key_equal(),
         const allocator_type& = allocator_type());
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template <
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<std::pair<const K, T> > R
+      >
+      unordered_multimap(FromRangeT&&, R&&,
+        size_type = boost::unordered::detail::default_bucket_count,
+        const hasher& = hasher(), const key_equal& = key_equal(),
+        const allocator_type& = allocator_type());
+#endif
+
       unordered_multimap(unordered_multimap const&);
 
       unordered_multimap(unordered_multimap&& other)
@@ -776,6 +882,27 @@ namespace boost {
       template <class InputIt>
       unordered_multimap(
         InputIt, InputIt, size_type, const hasher&, const allocator_type&);
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template <
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<std::pair<const K, T> > R
+      >
+      unordered_multimap(FromRangeT&&, R&&, const allocator_type&);
+
+      template <
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<std::pair<const K, T> > R
+      >
+      unordered_multimap(FromRangeT&&, R&&, size_type, const allocator_type&);
+
+      template <
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<std::pair<const K, T> > R
+      >
+      unordered_multimap(
+        FromRangeT&&, R&&, size_type, const hasher&, const allocator_type&);
+#endif
 
       unordered_multimap(
         std::initializer_list<value_type>, const allocator_type&);
@@ -893,6 +1020,11 @@ namespace boost {
       }
 
       template <class InputIt> void insert(InputIt, InputIt);
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template <detail::container_compatible_range<std::pair<const K, T> > R>
+      void insert_range(R&&);
+#endif
 
       void insert(std::initializer_list<value_type>);
 
@@ -1141,6 +1273,26 @@ namespace boost {
         boost::unordered::detail::iter_val_t<InputIterator>, Hash, Pred,
         Allocator>;
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+    template <
+      boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Hash =
+        boost::hash<boost::unordered::detail::range_key_t<R> >,
+      class Pred =
+        std::equal_to<boost::unordered::detail::range_key_t<R> >,
+      class Allocator = std::allocator<
+        boost::unordered::detail::range_to_alloc_t<R> >,
+      class = std::enable_if_t<detail::is_hash_v<Hash> >,
+      class = std::enable_if_t<detail::is_pred_v<Pred> >,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    unordered_multimap(FromRangeT&&, R&&,
+      std::size_t = boost::unordered::detail::default_bucket_count,
+      Hash = Hash(), Pred = Pred(), Allocator = Allocator())
+      -> unordered_multimap<boost::unordered::detail::range_key_t<R>,
+        boost::unordered::detail::range_mapped_t<R>, Hash, Pred,
+        Allocator>;
+#endif
     template <class Key, class T,
       class Hash = boost::hash<std::remove_const_t<Key> >,
       class Pred = std::equal_to<std::remove_const_t<Key> >,
@@ -1183,6 +1335,42 @@ namespace boost {
         boost::unordered::detail::iter_val_t<InputIterator>, Hash,
         std::equal_to<boost::unordered::detail::iter_key_t<InputIterator> >,
         Allocator>;
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+    template <boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Allocator,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    unordered_multimap(FromRangeT&&, R&&, std::size_t, Allocator)
+      -> unordered_multimap<boost::unordered::detail::range_key_t<R>,
+        boost::unordered::detail::range_mapped_t<R>,
+        boost::hash<boost::unordered::detail::range_key_t<R> >,
+        std::equal_to<boost::unordered::detail::range_key_t<R> >,
+        Allocator>;
+
+    template <boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Allocator,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    unordered_multimap(FromRangeT&&, R&&, Allocator)
+      -> unordered_multimap<boost::unordered::detail::range_key_t<R>,
+        boost::unordered::detail::range_mapped_t<R>,
+        boost::hash<boost::unordered::detail::range_key_t<R> >,
+        std::equal_to<boost::unordered::detail::range_key_t<R> >,
+        Allocator>;
+
+    template <boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Hash, class Allocator,
+      class = std::enable_if_t<detail::is_hash_v<Hash> >,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    unordered_multimap(
+      FromRangeT&&, R&&, std::size_t, Hash, Allocator)
+      -> unordered_multimap<boost::unordered::detail::range_key_t<R>,
+        boost::unordered::detail::range_mapped_t<R>, Hash,
+        std::equal_to<boost::unordered::detail::range_key_t<R> >,
+        Allocator>;
+#endif
 
     template <class Key, class T, class Allocator,
       class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
@@ -1230,6 +1418,23 @@ namespace boost {
     {
       this->insert(f, l);
     }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+    template <class K, class T, class H, class P, class A>
+    template <
+      detail::convertible_to_from_range_t FromRangeT,
+      detail::container_compatible_range<std::pair<const K, T> > R
+    >
+    unordered_map<K, T, H, P, A>::unordered_map(FromRangeT&&, R&& rg,
+      size_type n, const hasher& hf, const key_equal& eql,
+      const allocator_type& a)
+        : table_(
+          boost::unordered::detail::initial_size(std::forward<R>(rg), n),
+          hf, eql, a)
+    {
+      this->insert_range(std::forward<R>(rg));
+    }
+#endif
 
     template <class K, class T, class H, class P, class A>
     unordered_map<K, T, H, P, A>::unordered_map(unordered_map const& other)
@@ -1303,6 +1508,7 @@ namespace boost {
       this->insert(f, l);
     }
 
+
     template <class K, class T, class H, class P, class A>
     template <class InputIt>
     unordered_map<K, T, H, P, A>::unordered_map(
@@ -1322,6 +1528,51 @@ namespace boost {
     {
       this->insert(f, l);
     }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+    template <class K, class T, class H, class P, class A>
+    template <
+      detail::convertible_to_from_range_t FromRangeT,
+      detail::container_compatible_range<std::pair<const K, T> > R
+    >
+    unordered_map<K, T, H, P, A>::unordered_map(
+      FromRangeT&&, R&& rg, const allocator_type& a)
+        : table_(
+            boost::unordered::detail::initial_size(
+              std::forward<R>(rg), detail::default_bucket_count),
+            hasher(), key_equal(), a)
+    {
+      this->insert_range(std::forward<R>(rg));
+    }
+
+    template <class K, class T, class H, class P, class A>
+    template <
+      detail::convertible_to_from_range_t FromRangeT,
+      detail::container_compatible_range<std::pair<const K, T> > R
+    >
+    unordered_map<K, T, H, P, A>::unordered_map(
+      FromRangeT&&, R&& rg, size_type n, const allocator_type& a)
+        : table_(
+            boost::unordered::detail::initial_size(std::forward<R>(rg), n),
+            hasher(), key_equal(), a)
+    {
+      this->insert_range(std::forward<R>(rg));
+    }
+
+    template <class K, class T, class H, class P, class A>
+    template <
+      detail::convertible_to_from_range_t FromRangeT,
+      detail::container_compatible_range<std::pair<const K, T> > R
+    >
+    unordered_map<K, T, H, P, A>::unordered_map(FromRangeT&&, R&& rg,
+      size_type n, const hasher& hf, const allocator_type& a)
+        : table_(
+            boost::unordered::detail::initial_size(std::forward<R>(rg), n),
+            hf, key_equal(), a)
+    {
+      this->insert_range(std::forward<R>(rg));
+    }
+#endif
 
     template <class K, class T, class H, class P, class A>
     unordered_map<K, T, H, P, A>::unordered_map(
@@ -1394,6 +1645,20 @@ namespace boost {
           table::extractor::extract(*first), first, last);
       }
     }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+    template <class K, class T, class H, class P, class A>
+    template <detail::container_compatible_range<std::pair<const K, T> > R>
+    void unordered_map<K, T, H, P, A>::insert_range(R&& rg)
+    {
+      auto first = std::ranges::begin(rg);
+      auto last = std::ranges::end(rg);
+      if (first != last) {
+        table_.insert_range_unique(
+          table::extractor::extract(*first), first, last);
+      }
+    }
+#endif
 
     template <class K, class T, class H, class P, class A>
     void unordered_map<K, T, H, P, A>::insert(
@@ -1757,6 +2022,23 @@ namespace boost {
       this->insert(f, l);
     }
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+    template <class K, class T, class H, class P, class A>
+    template <
+      detail::convertible_to_from_range_t FromRangeT,
+      detail::container_compatible_range<std::pair<const K, T> > R
+    >
+    unordered_multimap<K, T, H, P, A>::unordered_multimap(FromRangeT&&, R&& rg,
+      size_type n, const hasher& hf, const key_equal& eql,
+      const allocator_type& a)
+        : table_(
+          boost::unordered::detail::initial_size(std::forward<R>(rg), n),
+          hf, eql, a)
+    {
+      this->insert_range(std::forward<R>(rg));
+    }
+#endif
+
     template <class K, class T, class H, class P, class A>
     unordered_multimap<K, T, H, P, A>::unordered_multimap(
       unordered_multimap const& other)
@@ -1851,6 +2133,51 @@ namespace boost {
       this->insert(f, l);
     }
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+    template <class K, class T, class H, class P, class A>
+    template <
+      detail::convertible_to_from_range_t FromRangeT,
+      detail::container_compatible_range<std::pair<const K, T> > R
+    >
+    unordered_multimap<K, T, H, P, A>::unordered_multimap(
+      FromRangeT&&, R&& rg, const allocator_type& a)
+        : table_(
+            boost::unordered::detail::initial_size(
+              std::forward<R>(rg), detail::default_bucket_count),
+            hasher(), key_equal(), a)
+    {
+      this->insert_range(std::forward<R>(rg));
+    }
+
+    template <class K, class T, class H, class P, class A>
+    template <
+      detail::convertible_to_from_range_t FromRangeT,
+      detail::container_compatible_range<std::pair<const K, T> > R
+    >
+    unordered_multimap<K, T, H, P, A>::unordered_multimap(
+      FromRangeT&&, R&& rg, size_type n, const allocator_type& a)
+        : table_(
+            boost::unordered::detail::initial_size(std::forward<R>(rg), n),
+            hasher(), key_equal(), a)
+    {
+      this->insert_range(std::forward<R>(rg));
+    }
+
+    template <class K, class T, class H, class P, class A>
+    template <
+      detail::convertible_to_from_range_t FromRangeT,
+      detail::container_compatible_range<std::pair<const K, T> > R
+    >
+    unordered_multimap<K, T, H, P, A>::unordered_multimap(FromRangeT&&, R&& rg,
+      size_type n, const hasher& hf, const allocator_type& a)
+        : table_(
+            boost::unordered::detail::initial_size(std::forward<R>(rg), n),
+            hf, key_equal(), a)
+    {
+      this->insert_range(std::forward<R>(rg));
+    }
+#endif
+
     template <class K, class T, class H, class P, class A>
     unordered_multimap<K, T, H, P, A>::unordered_multimap(
       std::initializer_list<value_type> list, const allocator_type& a)
@@ -1920,6 +2247,16 @@ namespace boost {
     {
       table_.insert_range_equiv(first, last);
     }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+    template <class K, class T, class H, class P, class A>
+    template <detail::container_compatible_range<std::pair<const K, T> > R>
+    void unordered_multimap<K, T, H, P, A>::insert_range(R&& rg)
+    {
+      table_.insert_range_equiv(std::ranges::begin(rg), std::ranges::end(rg));
+    }
+#endif
+
 
     template <class K, class T, class H, class P, class A>
     void unordered_multimap<K, T, H, P, A>::insert(

--- a/include/boost/unordered/unordered_node_map.hpp
+++ b/include/boost/unordered/unordered_node_map.hpp
@@ -1,5 +1,5 @@
 // Copyright (C) 2022-2023 Christian Mazakas
-// Copyright (C) 2024-2025 Joaquin M Lopez Munoz
+// Copyright (C) 2024-2026 Joaquin M Lopez Munoz
 // Copyright (C) 2026 Braden Ganetsky
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -16,6 +16,7 @@
 #include <boost/unordered/detail/foa/node_map_handle.hpp>
 #include <boost/unordered/detail/foa/node_map_types.hpp>
 #include <boost/unordered/detail/foa/table.hpp>
+#include <boost/unordered/detail/ranges_support.hpp>
 #include <boost/unordered/detail/serialize_container.hpp>
 #include <boost/unordered/detail/throw_exception.hpp>
 #include <boost/unordered/detail/type_traits.hpp>
@@ -115,6 +116,19 @@ namespace boost {
       {
       }
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<value_type> R
+      >
+      unordered_node_map(
+        FromRangeT&& fr, R&& rg, allocator_type const& a)
+          : unordered_node_map(
+            fr, std::forward<R>(rg), size_type(0), hasher(), key_equal(), a)
+      {
+      }
+#endif
+
       explicit unordered_node_map(allocator_type const& a)
           : unordered_node_map(0, a)
       {
@@ -142,6 +156,41 @@ namespace boost {
           : unordered_node_map(first, last, n, h, key_equal(), a)
       {
       }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<value_type> R
+      >
+      unordered_node_map(FromRangeT&&, R&& rg, size_type n = 0,
+        hasher const& h = hasher(), key_equal const& pred = key_equal(),
+        allocator_type const& a = allocator_type())
+        :  unordered_node_map(n, h, pred, a)
+      {
+        this->insert_range(std::forward<R>(rg));
+      }
+
+      template<
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<value_type> R
+      >
+      unordered_node_map(
+        FromRangeT&& fr, R&& rg, size_type n, allocator_type const& a)
+          : unordered_node_map(
+            fr, std::forward<R>(rg), n, hasher(), key_equal(), a)
+      {
+      }
+
+      template<
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<value_type> R
+      >
+      unordered_node_map(FromRangeT&& fr, R&& rg, size_type n,
+        hasher const& h, allocator_type const& a)
+          : unordered_node_map(fr, std::forward<R>(rg), n, h, key_equal(), a)
+      {
+      }
+#endif
 
       unordered_node_map(unordered_node_map const& other) : table_(other.table_)
       {
@@ -284,6 +333,16 @@ namespace boost {
           table_.emplace(*pos);
         }
       }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<detail::container_compatible_range<value_type> R>
+      BOOST_FORCEINLINE void insert_range(R&& rg)
+      {
+        auto first = std::ranges::begin(rg);
+        auto last = std::ranges::end(rg);
+        while (first != last) table_.emplace(*first++);
+      }
+#endif
 
       void insert(std::initializer_list<value_type> ilist)
       {
@@ -830,6 +889,27 @@ namespace boost {
         boost::unordered::detail::iter_val_t<InputIterator>, Hash, Pred,
         Allocator>;
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+    template <
+      boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Hash =
+        boost::hash<boost::unordered::detail::range_key_t<R> >,
+      class Pred =
+        std::equal_to<boost::unordered::detail::range_key_t<R> >,
+      class Allocator = std::allocator<
+        boost::unordered::detail::range_to_alloc_t<R> >,
+      class = std::enable_if_t<detail::is_hash_v<Hash> >,
+      class = std::enable_if_t<detail::is_pred_v<Pred> >,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    unordered_node_map(FromRangeT&&, R&&,
+      std::size_t = boost::unordered::detail::foa::default_bucket_count,
+      Hash = Hash(), Pred = Pred(), Allocator = Allocator())
+      -> unordered_node_map<boost::unordered::detail::range_key_t<R>,
+        boost::unordered::detail::range_mapped_t<R>, Hash, Pred,
+        Allocator>;
+#endif
+
     template <class Key, class T,
       class Hash = boost::hash<std::remove_const_t<Key> >,
       class Pred = std::equal_to<std::remove_const_t<Key> >,
@@ -873,6 +953,42 @@ namespace boost {
         boost::unordered::detail::iter_val_t<InputIterator>, Hash,
         std::equal_to<boost::unordered::detail::iter_key_t<InputIterator> >,
         Allocator>;
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+    template <boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Allocator,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    unordered_node_map(FromRangeT&&, R&&, std::size_t, Allocator)
+      -> unordered_node_map<boost::unordered::detail::range_key_t<R>,
+        boost::unordered::detail::range_mapped_t<R>,
+        boost::hash<boost::unordered::detail::range_key_t<R> >,
+        std::equal_to<boost::unordered::detail::range_key_t<R> >,
+        Allocator>;
+
+    template <boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Allocator,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    unordered_node_map(FromRangeT&&, R&&, Allocator)
+      -> unordered_node_map<boost::unordered::detail::range_key_t<R>,
+        boost::unordered::detail::range_mapped_t<R>,
+        boost::hash<boost::unordered::detail::range_key_t<R> >,
+        std::equal_to<boost::unordered::detail::range_key_t<R> >,
+        Allocator>;
+
+    template <boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Hash, class Allocator,
+      class = std::enable_if_t<detail::is_hash_v<Hash> >,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    unordered_node_map(
+      FromRangeT&&, R&&, std::size_t, Hash, Allocator)
+      -> unordered_node_map<boost::unordered::detail::range_key_t<R>,
+        boost::unordered::detail::range_mapped_t<R>, Hash,
+        std::equal_to<boost::unordered::detail::range_key_t<R> >,
+        Allocator>;
+#endif
 
     template <class Key, class T, class Allocator,
       class = std::enable_if_t<detail::is_allocator_v<Allocator> > >

--- a/include/boost/unordered/unordered_node_set.hpp
+++ b/include/boost/unordered/unordered_node_set.hpp
@@ -1,5 +1,5 @@
 // Copyright (C) 2022-2023 Christian Mazakas
-// Copyright (C) 2024-2025 Joaquin M Lopez Munoz
+// Copyright (C) 2024-2026 Joaquin M Lopez Munoz
 // Copyright (C) 2026 Braden Ganetsky
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -17,6 +17,7 @@
 #include <boost/unordered/detail/foa/node_set_handle.hpp>
 #include <boost/unordered/detail/foa/node_set_types.hpp>
 #include <boost/unordered/detail/foa/table.hpp>
+#include <boost/unordered/detail/ranges_support.hpp>
 #include <boost/unordered/detail/serialize_container.hpp>
 #include <boost/unordered/detail/type_traits.hpp>
 #include <boost/unordered/unordered_node_set_fwd.hpp>
@@ -113,6 +114,19 @@ namespace boost {
       {
       }
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<value_type> R
+      >
+      unordered_node_set(
+        FromRangeT&& fr, R&& rg, allocator_type const& a)
+          : unordered_node_set(
+            fr, std::forward<R>(rg), size_type(0), hasher(), key_equal(), a)
+      {
+      }
+#endif
+
       explicit unordered_node_set(allocator_type const& a)
           : unordered_node_set(0, a)
       {
@@ -140,6 +154,41 @@ namespace boost {
           : unordered_node_set(first, last, n, h, key_equal(), a)
       {
       }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<value_type> R
+      >
+      unordered_node_set(FromRangeT&&, R&& rg, size_type n = 0,
+        hasher const& h = hasher(), key_equal const& pred = key_equal(),
+        allocator_type const& a = allocator_type())
+        :  unordered_node_set(n, h, pred, a)
+      {
+        this->insert_range(std::forward<R>(rg));
+      }
+
+      template<
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<value_type> R
+      >
+      unordered_node_set(
+        FromRangeT&& fr, R&& rg, size_type n, allocator_type const& a)
+          : unordered_node_set(
+            fr, std::forward<R>(rg), n, hasher(), key_equal(), a)
+      {
+      }
+
+      template<
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<value_type> R
+      >
+      unordered_node_set(FromRangeT&& fr, R&& rg, size_type n,
+        hasher const& h, allocator_type const& a)
+          : unordered_node_set(fr, std::forward<R>(rg), n, h, key_equal(), a)
+      {
+      }
+#endif
 
       unordered_node_set(unordered_node_set const& other) : table_(other.table_)
       {
@@ -297,6 +346,16 @@ namespace boost {
           table_.emplace(*pos);
         }
       }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<detail::container_compatible_range<value_type> R>
+      void insert_range(R&& rg)
+      {
+        auto first = std::ranges::begin(rg);
+        auto last = std::ranges::end(rg);
+        while (first != last) table_.emplace(*first++);
+      }
+#endif
 
       void insert(std::initializer_list<value_type> ilist)
       {
@@ -650,6 +709,25 @@ namespace boost {
         typename std::iterator_traits<InputIterator>::value_type, Hash, Pred,
         Allocator>;
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+    template <
+      boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Hash =
+        boost::hash<std::ranges::range_value_t<R> >,
+      class Pred =
+        std::equal_to<std::ranges::range_value_t<R> >,
+      class Allocator = std::allocator<std::ranges::range_value_t<R> >,
+      class = std::enable_if_t<detail::is_hash_v<Hash> >,
+      class = std::enable_if_t<detail::is_pred_v<Pred> >,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    unordered_node_set(FromRangeT&&, R&&,
+      std::size_t = boost::unordered::detail::foa::default_bucket_count,
+      Hash = Hash(), Pred = Pred(), Allocator = Allocator())
+      -> unordered_node_set<std::ranges::range_value_t<R>,
+        Hash, Pred, Allocator>;
+#endif
+
     template <class T, class Hash = boost::hash<T>,
       class Pred = std::equal_to<T>, class Allocator = std::allocator<T>,
       class = std::enable_if_t<detail::is_hash_v<Hash> >,
@@ -681,6 +759,29 @@ namespace boost {
         std::equal_to<typename std::iterator_traits<InputIterator>::value_type>,
         Allocator>;
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+    template <boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Allocator,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    unordered_node_set(FromRangeT&&, R&&, std::size_t, Allocator)
+      -> unordered_node_set<std::ranges::range_value_t<R>,
+        boost::hash<std::ranges::range_value_t<R> >,
+        std::equal_to<std::ranges::range_value_t<R> >,
+        Allocator>;
+
+    template <boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Hash, class Allocator,
+      class = std::enable_if_t<detail::is_hash_v<Hash> >,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    unordered_node_set(
+      FromRangeT&&, R&&, std::size_t, Hash, Allocator)
+      -> unordered_node_set<std::ranges::range_value_t<R>,
+        Hash, std::equal_to<std::ranges::range_value_t<R> >,
+        Allocator>;
+#endif
+
     template <class T, class Allocator,
       class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
     unordered_node_set(std::initializer_list<T>, std::size_t, Allocator)
@@ -701,6 +802,18 @@ namespace boost {
         boost::hash<typename std::iterator_traits<InputIterator>::value_type>,
         std::equal_to<typename std::iterator_traits<InputIterator>::value_type>,
         Allocator>;
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+    template <boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Allocator,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    unordered_node_set(FromRangeT&&, R&&, Allocator)
+      -> unordered_node_set<std::ranges::range_value_t<R>,
+        boost::hash<std::ranges::range_value_t<R> >,
+        std::equal_to<std::ranges::range_value_t<R> >,
+        Allocator>;
+#endif
 
     template <class T, class Allocator,
       class = std::enable_if_t<detail::is_allocator_v<Allocator> > >

--- a/include/boost/unordered/unordered_set.hpp
+++ b/include/boost/unordered/unordered_set.hpp
@@ -1,7 +1,7 @@
 // Copyright (C) 2003-2004 Jeremy B. Maitin-Shepard.
 // Copyright (C) 2005-2011 Daniel James.
 // Copyright (C) 2022-2023 Christian Mazakas
-// Copyright (C) 2024 Joaquin M Lopez Munoz.
+// Copyright (C) 2024-2026 Joaquin M Lopez Munoz.
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
@@ -15,6 +15,7 @@
 #pragma once
 #endif
 
+#include <boost/unordered/detail/ranges_support.hpp>
 #include <boost/unordered/detail/serialize_fca_container.hpp>
 #include <boost/unordered/detail/set.hpp>
 #include <boost/unordered/detail/type_traits.hpp>
@@ -88,6 +89,17 @@ namespace boost {
         const hasher& = hasher(), const key_equal& = key_equal(),
         const allocator_type& = allocator_type());
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<T> R
+      >
+      unordered_set(FromRangeT&&, R&&,
+        size_type = boost::unordered::detail::default_bucket_count,
+        const hasher& = hasher(), const key_equal& = key_equal(),
+        const allocator_type& = allocator_type());
+#endif
+
       unordered_set(unordered_set const&);
 
       unordered_set(unordered_set&& other)
@@ -121,6 +133,27 @@ namespace boost {
       template <class InputIt>
       unordered_set(
         InputIt, InputIt, size_type, const hasher&, const allocator_type&);
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template <
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<T> R
+      >
+      unordered_set(FromRangeT&&, R&&, const allocator_type&);
+
+      template <
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<T> R
+      >
+      unordered_set(FromRangeT&&, R&&, size_type, const allocator_type&);
+
+      template <
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<T> R
+      >
+      unordered_set(
+        FromRangeT&&, R&&, size_type, const hasher&, const allocator_type&);
+#endif
 
       unordered_set(std::initializer_list<value_type>, const allocator_type&);
 
@@ -245,6 +278,11 @@ namespace boost {
       }
 
       template <class InputIt> void insert(InputIt, InputIt);
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template <detail::container_compatible_range<T> R>
+      void insert_range(R&&);
+#endif
 
       void insert(std::initializer_list<value_type>);
 
@@ -478,6 +516,25 @@ namespace boost {
       -> unordered_set<typename std::iterator_traits<InputIterator>::value_type,
         Hash, Pred, Allocator>;
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+    template <
+      boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Hash =
+        boost::hash<std::ranges::range_value_t<R> >,
+      class Pred =
+        std::equal_to<std::ranges::range_value_t<R> >,
+      class Allocator = std::allocator<std::ranges::range_value_t<R> >,
+      class = std::enable_if_t<detail::is_hash_v<Hash> >,
+      class = std::enable_if_t<detail::is_pred_v<Pred> >,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    unordered_set(FromRangeT&&, R&&,
+      std::size_t = boost::unordered::detail::default_bucket_count,
+      Hash = Hash(), Pred = Pred(), Allocator = Allocator())
+      -> unordered_set<std::ranges::range_value_t<R>,
+        Hash, Pred, Allocator>;
+#endif
+
     template <class T, class Hash = boost::hash<T>,
       class Pred = std::equal_to<T>, class Allocator = std::allocator<T>,
       class = std::enable_if_t<detail::is_hash_v<Hash> >,
@@ -507,6 +564,29 @@ namespace boost {
         std::equal_to<typename std::iterator_traits<InputIterator>::value_type>,
         Allocator>;
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+    template <boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Allocator,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    unordered_set(FromRangeT&&, R&&, std::size_t, Allocator)
+      -> unordered_set<std::ranges::range_value_t<R>,
+        boost::hash<std::ranges::range_value_t<R> >,
+        std::equal_to<std::ranges::range_value_t<R> >,
+        Allocator>;
+
+    template <boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Hash, class Allocator,
+      class = std::enable_if_t<detail::is_hash_v<Hash> >,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    unordered_set(
+      FromRangeT&&, R&&, std::size_t, Hash, Allocator)
+      -> unordered_set<std::ranges::range_value_t<R>,
+        Hash, std::equal_to<std::ranges::range_value_t<R> >,
+        Allocator>;
+#endif
+
     template <class T, class Allocator,
       class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
     unordered_set(std::initializer_list<T>, std::size_t, Allocator)
@@ -526,6 +606,18 @@ namespace boost {
         boost::hash<typename std::iterator_traits<InputIterator>::value_type>,
         std::equal_to<typename std::iterator_traits<InputIterator>::value_type>,
         Allocator>;
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+    template <boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Allocator,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    unordered_set(FromRangeT&&, R&&, Allocator)
+      -> unordered_set<std::ranges::range_value_t<R>,
+        boost::hash<std::ranges::range_value_t<R> >,
+        std::equal_to<std::ranges::range_value_t<R> >,
+        Allocator>;
+#endif
 
     template <class T, class Allocator,
       class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
@@ -585,6 +677,18 @@ namespace boost {
         const hasher& = hasher(), const key_equal& = key_equal(),
         const allocator_type& = allocator_type());
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template<
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<T> R
+      >
+      unordered_multiset(FromRangeT&&, R&&,
+        size_type = boost::unordered::detail::default_bucket_count,
+        const hasher& = hasher(), const key_equal& = key_equal(),
+        const allocator_type& = allocator_type());
+#endif
+
+
       unordered_multiset(unordered_multiset const&);
 
       unordered_multiset(unordered_multiset&& other)
@@ -619,6 +723,27 @@ namespace boost {
       template <class InputIt>
       unordered_multiset(
         InputIt, InputIt, size_type, const hasher&, const allocator_type&);
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template <
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<T> R
+      >
+      unordered_multiset(FromRangeT&&, R&&, const allocator_type&);
+
+      template <
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<T> R
+      >
+      unordered_multiset(FromRangeT&&, R&&, size_type, const allocator_type&);
+
+      template <
+        detail::convertible_to_from_range_t FromRangeT,
+        detail::container_compatible_range<T> R
+      >
+      unordered_multiset(
+        FromRangeT&&, R&&, size_type, const hasher&, const allocator_type&);
+#endif
 
       unordered_multiset(
         std::initializer_list<value_type>, const allocator_type&);
@@ -719,6 +844,11 @@ namespace boost {
       }
 
       template <class InputIt> void insert(InputIt, InputIt);
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+      template <detail::container_compatible_range<T> R>
+      void insert_range(R&&);
+#endif
 
       void insert(std::initializer_list<value_type>);
 
@@ -942,6 +1072,25 @@ namespace boost {
         typename std::iterator_traits<InputIterator>::value_type, Hash, Pred,
         Allocator>;
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+    template <
+      boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Hash =
+        boost::hash<std::ranges::range_value_t<R> >,
+      class Pred =
+        std::equal_to<std::ranges::range_value_t<R> >,
+      class Allocator = std::allocator<std::ranges::range_value_t<R> >,
+      class = std::enable_if_t<detail::is_hash_v<Hash> >,
+      class = std::enable_if_t<detail::is_pred_v<Pred> >,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    unordered_multiset(FromRangeT&&, R&&,
+      std::size_t = boost::unordered::detail::default_bucket_count,
+      Hash = Hash(), Pred = Pred(), Allocator = Allocator())
+      -> unordered_multiset<std::ranges::range_value_t<R>,
+        Hash, Pred, Allocator>;
+#endif
+
     template <class T, class Hash = boost::hash<T>,
       class Pred = std::equal_to<T>, class Allocator = std::allocator<T>,
       class = std::enable_if_t<detail::is_hash_v<Hash> >,
@@ -973,6 +1122,29 @@ namespace boost {
         std::equal_to<typename std::iterator_traits<InputIterator>::value_type>,
         Allocator>;
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+    template <boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Allocator,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    unordered_multiset(FromRangeT&&, R&&, std::size_t, Allocator)
+      -> unordered_multiset<std::ranges::range_value_t<R>,
+        boost::hash<std::ranges::range_value_t<R> >,
+        std::equal_to<std::ranges::range_value_t<R> >,
+        Allocator>;
+
+    template <boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Hash, class Allocator,
+      class = std::enable_if_t<detail::is_hash_v<Hash> >,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    unordered_multiset(
+      FromRangeT&&, R&&, std::size_t, Hash, Allocator)
+      -> unordered_multiset<std::ranges::range_value_t<R>,
+        Hash, std::equal_to<std::ranges::range_value_t<R> >,
+        Allocator>;
+#endif
+
     template <class T, class Allocator,
       class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
     unordered_multiset(std::initializer_list<T>, std::size_t, Allocator)
@@ -993,6 +1165,18 @@ namespace boost {
         boost::hash<typename std::iterator_traits<InputIterator>::value_type>,
         std::equal_to<typename std::iterator_traits<InputIterator>::value_type>,
         Allocator>;
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+    template <boost::unordered::detail::convertible_to_from_range_t FromRangeT,
+      std::ranges::input_range R,
+      class Allocator,
+      class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
+    unordered_multiset(FromRangeT&&, R&&, Allocator)
+      -> unordered_multiset<std::ranges::range_value_t<R>,
+        boost::hash<std::ranges::range_value_t<R> >,
+        std::equal_to<std::ranges::range_value_t<R> >,
+        Allocator>;
+#endif
 
     template <class T, class Allocator,
       class = std::enable_if_t<detail::is_allocator_v<Allocator> > >
@@ -1022,6 +1206,23 @@ namespace boost {
     {
       this->insert(f, l);
     }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+    template <class T, class H, class P, class A>
+    template <
+      detail::convertible_to_from_range_t FromRangeT,
+      detail::container_compatible_range<T> R
+    >
+    unordered_set<T, H, P, A>::unordered_set(FromRangeT&&, R&& rg,
+      size_type n, const hasher& hf, const key_equal& eql,
+      const allocator_type& a)
+        : table_(
+          boost::unordered::detail::initial_size(std::forward<R>(rg), n),
+          hf, eql, a)
+    {
+      this->insert_range(std::forward<R>(rg));
+    }
+#endif
 
     template <class T, class H, class P, class A>
     unordered_set<T, H, P, A>::unordered_set(unordered_set const& other)
@@ -1115,6 +1316,51 @@ namespace boost {
       this->insert(f, l);
     }
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+    template <class T, class H, class P, class A>
+    template <
+      detail::convertible_to_from_range_t FromRangeT,
+      detail::container_compatible_range<T> R
+    >
+    unordered_set<T, H, P, A>::unordered_set(
+      FromRangeT&&, R&& rg, const allocator_type& a)
+        : table_(
+            boost::unordered::detail::initial_size(
+              std::forward<R>(rg), detail::default_bucket_count),
+            hasher(), key_equal(), a)
+    {
+      this->insert_range(std::forward<R>(rg));
+    }
+
+    template <class T, class H, class P, class A>
+    template <
+      detail::convertible_to_from_range_t FromRangeT,
+      detail::container_compatible_range<T> R
+    >
+    unordered_set<T, H, P, A>::unordered_set(
+      FromRangeT&&, R&& rg, size_type n, const allocator_type& a)
+        : table_(
+            boost::unordered::detail::initial_size(std::forward<R>(rg), n),
+            hasher(), key_equal(), a)
+    {
+      this->insert_range(std::forward<R>(rg));
+    }
+
+    template <class T, class H, class P, class A>
+    template <
+      detail::convertible_to_from_range_t FromRangeT,
+      detail::container_compatible_range<T> R
+    >
+    unordered_set<T, H, P, A>::unordered_set(FromRangeT&&, R&& rg,
+      size_type n, const hasher& hf, const allocator_type& a)
+        : table_(
+            boost::unordered::detail::initial_size(std::forward<R>(rg), n),
+            hf, key_equal(), a)
+    {
+      this->insert_range(std::forward<R>(rg));
+    }
+#endif
+
     template <class T, class H, class P, class A>
     unordered_set<T, H, P, A>::unordered_set(
       std::initializer_list<value_type> list, const allocator_type& a)
@@ -1186,6 +1432,20 @@ namespace boost {
           table::extractor::extract(*first), first, last);
       }
     }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+    template <class T, class H, class P, class A>
+    template <detail::container_compatible_range<T> R>
+    void unordered_set<T, H, P, A>::insert_range(R&& rg)
+    {
+      auto first = std::ranges::begin(rg);
+      auto last = std::ranges::end(rg);
+      if (first != last) {
+        table_.insert_range_unique(
+          table::extractor::extract(*first), first, last);
+      }
+    }
+#endif
 
     template <class T, class H, class P, class A>
     void unordered_set<T, H, P, A>::insert(
@@ -1420,6 +1680,23 @@ namespace boost {
       this->insert(f, l);
     }
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+    template <class T, class H, class P, class A>
+    template <
+      detail::convertible_to_from_range_t FromRangeT,
+      detail::container_compatible_range<T> R
+    >
+    unordered_multiset<T, H, P, A>::unordered_multiset(FromRangeT&&, R&& rg,
+      size_type n, const hasher& hf, const key_equal& eql,
+      const allocator_type& a)
+        : table_(
+          boost::unordered::detail::initial_size(std::forward<R>(rg), n),
+          hf, eql, a)
+    {
+      this->insert_range(std::forward<R>(rg));
+    }
+#endif
+
     template <class T, class H, class P, class A>
     unordered_multiset<T, H, P, A>::unordered_multiset(
       unordered_multiset const& other)
@@ -1513,6 +1790,51 @@ namespace boost {
       this->insert(f, l);
     }
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+    template <class T, class H, class P, class A>
+    template <
+      detail::convertible_to_from_range_t FromRangeT,
+      detail::container_compatible_range<T> R
+    >
+    unordered_multiset<T, H, P, A>::unordered_multiset(
+      FromRangeT&&, R&& rg, const allocator_type& a)
+        : table_(
+            boost::unordered::detail::initial_size(
+              std::forward<R>(rg), detail::default_bucket_count),
+            hasher(), key_equal(), a)
+    {
+      this->insert_range(std::forward<R>(rg));
+    }
+
+    template <class T, class H, class P, class A>
+    template <
+      detail::convertible_to_from_range_t FromRangeT,
+      detail::container_compatible_range<T> R
+    >
+    unordered_multiset<T, H, P, A>::unordered_multiset(
+      FromRangeT&&, R&& rg, size_type n, const allocator_type& a)
+        : table_(
+            boost::unordered::detail::initial_size(std::forward<R>(rg), n),
+            hasher(), key_equal(), a)
+    {
+      this->insert_range(std::forward<R>(rg));
+    }
+
+    template <class T, class H, class P, class A>
+    template <
+      detail::convertible_to_from_range_t FromRangeT,
+      detail::container_compatible_range<T> R
+    >
+    unordered_multiset<T, H, P, A>::unordered_multiset(FromRangeT&&, R&& rg,
+      size_type n, const hasher& hf, const allocator_type& a)
+        : table_(
+            boost::unordered::detail::initial_size(std::forward<R>(rg), n),
+            hf, key_equal(), a)
+    {
+      this->insert_range(std::forward<R>(rg));
+    }
+#endif
+
     template <class T, class H, class P, class A>
     unordered_multiset<T, H, P, A>::unordered_multiset(
       std::initializer_list<value_type> list, const allocator_type& a)
@@ -1581,6 +1903,16 @@ namespace boost {
     {
       table_.insert_range_equiv(first, last);
     }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+    template <class T, class H, class P, class A>
+    template <detail::container_compatible_range<T> R>
+    void unordered_multiset<T, H, P, A>::insert_range(R&& rg)
+    {
+      table_.insert_range_equiv(
+        std::ranges::begin(rg), std::ranges::end(rg));
+    }
+#endif
 
     template <class T, class H, class P, class A>
     void unordered_multiset<T, H, P, A>::insert(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -139,7 +139,11 @@ foa_tests(SOURCES exception/merge_exception_tests.cpp)
 set(cfoa_insert_test_options $<$<CXX_COMPILER_ID:MSVC>:/bigobj>)
 
 if(MINGW AND CMAKE_SIZEOF_VOID_P EQUAL 4)
-  list(APPEND cfoa_insert_test_options -O0 -g0) # GCC MinGW32 OOMs otherwise
+  list(APPEND cfoa_insert_test_options
+    -O0 -g0
+    --param ggc-min-expand=10
+    --param ggc-min-heapsize=16384
+  ) # GCC MinGW32 OOMs otherwise
 endif()
 
 cfoa_tests(SOURCES cfoa/insert_tests.cpp COMPILE_OPTIONS ${cfoa_insert_test_options})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -141,8 +141,8 @@ set(cfoa_insert_test_options $<$<CXX_COMPILER_ID:MSVC>:/bigobj>)
 if(MINGW AND CMAKE_SIZEOF_VOID_P EQUAL 4)
   list(APPEND cfoa_insert_test_options
     -O0 -g0
-    --param ggc-min-expand=10
-    --param ggc-min-heapsize=16384
+    -fparam=ggc-min-expand=10
+    -fparam=ggc-min-heapsize=16384
   ) # GCC MinGW32 OOMs otherwise
 endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -141,8 +141,8 @@ set(cfoa_insert_test_options $<$<CXX_COMPILER_ID:MSVC>:/bigobj>)
 if(MINGW AND CMAKE_SIZEOF_VOID_P EQUAL 4)
   list(APPEND cfoa_insert_test_options
     -O0 -g0
-    -fparam=ggc-min-expand=10
-    -fparam=ggc-min-heapsize=16384
+    --param=ggc-min-expand=10
+    --param=ggc-min-heapsize=16384
   ) # GCC MinGW32 OOMs otherwise
 endif()
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -380,7 +380,7 @@ run cfoa/insert_tests.cpp
       <toolset>msvc:<cxxflags>/bigobj
       <toolset>gcc:<inlining>on
       <toolset>gcc:<optimization>off
-      <toolset>gcc:<debug-symbols>off
+      <toolset>gcc:<cxxflags>-g0
       <toolset>clang:<inlining>on
       <toolset>clang:<optimization>space
     : cfoa_insert_tests ;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -379,7 +379,8 @@ run cfoa/insert_tests.cpp
     : $(CPP11) <threading>multi
       <toolset>msvc:<cxxflags>/bigobj
       <toolset>gcc:<inlining>on
-      <toolset>gcc:<optimization>space
+      <toolset>gcc:<optimization>off
+      <toolset>gcc:<debug-symbols>off
       <toolset>clang:<inlining>on
       <toolset>clang:<optimization>space
     : cfoa_insert_tests ;

--- a/test/cfoa/constructor_tests.cpp
+++ b/test/cfoa/constructor_tests.cpp
@@ -714,8 +714,8 @@ namespace {
     using allocator_type = typename X::allocator_type;
 
     auto init_list = p.second;
-    auto sentineled_rg = 
-      std::list<value_type>{init_list} | std::views::take(init_list.size());
+    auto init_std_list = std::list<value_type>{init_list};
+    auto sentineled_rg = init_std_list | std::views::take(init_list.size());
 
     {
       raii::reset_counts();

--- a/test/cfoa/constructor_tests.cpp
+++ b/test/cfoa/constructor_tests.cpp
@@ -1,5 +1,5 @@
 // Copyright (C) 2023 Christian Mazakas
-// Copyright (C) 2023-2024 Joaquin M Lopez Munoz
+// Copyright (C) 2023-2026 Joaquin M Lopez Munoz
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
@@ -9,6 +9,8 @@
 #include <boost/unordered/concurrent_flat_set.hpp>
 #include <boost/unordered/concurrent_node_map.hpp>
 #include <boost/unordered/concurrent_node_set.hpp>
+
+#include <list>
 
 test::seed_t initialize_seed(4122023);
 
@@ -702,6 +704,97 @@ namespace {
     }
   }
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+  template <class X, class IL>
+  void range_with_all_params(std::pair<X*, IL> p)
+  {
+    using value_type = typename X::value_type;
+    static constexpr auto value_type_cardinality = 
+      value_cardinality<value_type>::value;
+    using allocator_type = typename X::allocator_type;
+
+    auto init_list = p.second;
+    auto sentineled_rg = 
+      std::list<value_type>{init_list} | std::views::take(init_list.size());
+
+    {
+      raii::reset_counts();
+
+      X x(
+        boost::unordered::from_range,
+        init_list, 0, hasher(1), key_equal(2), allocator_type(3));
+
+      BOOST_TEST_EQ(x.size(), 11u);
+      BOOST_TEST_EQ(x.hash_function(), hasher(1));
+      BOOST_TEST_EQ(x.key_eq(), key_equal(2));
+      BOOST_TEST(x.get_allocator() == allocator_type(3));
+
+      BOOST_TEST_EQ(raii::default_constructor, 0u);
+      BOOST_TEST_EQ(
+        raii::copy_constructor, value_type_cardinality * init_list.size() / 2u);
+      BOOST_TEST_EQ(
+        raii::move_constructor, 0u);
+    }
+    check_raii_counts();
+
+    {
+      raii::reset_counts();
+
+      X x(boost::unordered::from_range, sentineled_rg, allocator_type(3));
+
+      BOOST_TEST_EQ(x.size(), 11u);
+      BOOST_TEST_EQ(x.hash_function(), hasher());
+      BOOST_TEST_EQ(x.key_eq(), key_equal());
+      BOOST_TEST(x.get_allocator() == allocator_type(3));
+
+      BOOST_TEST_EQ(raii::default_constructor, 0u);
+      BOOST_TEST_EQ(
+        raii::copy_constructor, value_type_cardinality * init_list.size() / 2u);
+      BOOST_TEST_EQ(
+        raii::move_constructor, 0u);
+    }
+    check_raii_counts();
+
+    {
+      raii::reset_counts();
+
+      X x(boost::unordered::from_range, init_list, 0, allocator_type(3));
+
+      BOOST_TEST_EQ(x.size(), 11u);
+      BOOST_TEST_EQ(x.hash_function(), hasher());
+      BOOST_TEST_EQ(x.key_eq(), key_equal());
+      BOOST_TEST(x.get_allocator() == allocator_type(3));
+
+      BOOST_TEST_EQ(raii::default_constructor, 0u);
+      BOOST_TEST_EQ(
+        raii::copy_constructor, value_type_cardinality * init_list.size() / 2u);
+      BOOST_TEST_EQ(
+        raii::move_constructor, 0u);
+    }
+    check_raii_counts();
+
+    {
+      raii::reset_counts();
+
+      X x(
+        boost::unordered::from_range, 
+        sentineled_rg, 0, hasher(1), allocator_type(3));
+
+      BOOST_TEST_EQ(x.size(), 11u);
+      BOOST_TEST_EQ(x.hash_function(), hasher(1));
+      BOOST_TEST_EQ(x.key_eq(), key_equal());
+      BOOST_TEST(x.get_allocator() == allocator_type(3));
+
+      BOOST_TEST_EQ(raii::default_constructor, 0u);
+      BOOST_TEST_EQ(
+        raii::copy_constructor, value_type_cardinality * init_list.size() / 2u);
+      BOOST_TEST_EQ(
+        raii::move_constructor, 0u);
+    }
+    check_raii_counts();
+  }
+#endif
+
   template <class X, class IL>
   void initializer_list_with_all_params(std::pair<X*, IL> p)
   {
@@ -1039,6 +1132,13 @@ UNORDERED_TEST(
 UNORDERED_TEST(
   explicit_allocator,
   ((test_map)(test_node_map)(test_set)(test_node_set)))
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+UNORDERED_TEST(
+  range_with_all_params,
+  ((test_map_and_init_list)(test_node_map_and_init_list)
+   (test_set_and_init_list)(test_node_set_and_init_list)))
+#endif
 
 UNORDERED_TEST(
   initializer_list_with_all_params,

--- a/test/cfoa/insert_tests.cpp
+++ b/test/cfoa/insert_tests.cpp
@@ -175,6 +175,39 @@ namespace {
     }
   } iterator_range_inserter;
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+  struct range_inserter_type
+  {
+    template <class T, class X> void operator()(std::vector<T>& values, X& x)
+    {
+      static constexpr auto value_type_cardinality = 
+        value_cardinality<typename X::value_type>::value;
+
+      std::vector<raii_convertible> values2;
+      values2.reserve(values.size());
+      for (auto const& v : values) { 
+        values2.push_back(raii_convertible(v));
+      }
+
+      auto sz = x.size();
+      std::atomic<std::uint64_t> num_inserts{0};
+      std::atomic<std::uint64_t> num_attempted_inserts{0};
+      thread_runner(values2, [&x, &num_inserts, &num_attempted_inserts](boost::span<raii_convertible> s) {
+        num_inserts += x.insert_range(s | std::views::take(s.size() / 2));
+        num_inserts += x.insert_range(s);
+        num_attempted_inserts += s.size() + s.size() / 2;
+      });
+      BOOST_TEST_EQ(x.size(), sz + num_inserts);
+
+      BOOST_TEST_EQ(
+        raii::default_constructor, value_type_cardinality * num_attempted_inserts);
+      BOOST_TEST_EQ(raii::copy_constructor, 0u);
+      BOOST_TEST_EQ(raii::copy_assignment, 0u);
+      BOOST_TEST_EQ(raii::move_assignment, 0u);
+    }
+  } range_inserter;
+#endif
+
   struct lvalue_insert_or_assign_copy_assign_type
   {
     template <class T, class X> void operator()(std::vector<T>& values, X& x)
@@ -1265,13 +1298,19 @@ UNORDERED_TEST(
   ((map_and_init_list)(node_map_and_init_list)
    (set_and_init_list)(node_set_and_init_list)))
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+#define RANGE_INSERTER (range_inserter)
+#else
+#define RANGE_INSERTER
+#endif
+
 UNORDERED_TEST(
   insert,
   ((map)(fancy_map)(node_map)(fancy_node_map)
    (set)(fancy_set)(node_set)(fancy_node_set))
   ((value_type_generator_factory)(init_type_generator_factory))
   ((lvalue_inserter)(rvalue_inserter)(iterator_range_inserter)
-   (norehash_lvalue_inserter)(norehash_rvalue_inserter)
+   RANGE_INSERTER (norehash_lvalue_inserter)(norehash_rvalue_inserter)
    (lvalue_insert_or_cvisit)(lvalue_insert_or_visit)
    (rvalue_insert_or_cvisit)(rvalue_insert_or_visit)
    (iterator_range_insert_or_cvisit)(iterator_range_insert_or_visit))

--- a/test/cfoa/insert_tests.cpp
+++ b/test/cfoa/insert_tests.cpp
@@ -831,6 +831,41 @@ namespace {
     }
   } iterator_range_insert_or_cvisit;
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+  struct insert_range_or_cvisit_type
+  {
+    template <class T, class X> void operator()(std::vector<T>& values, X& x)
+    {
+      static constexpr auto value_type_cardinality = 
+        value_cardinality<typename X::value_type>::value;
+
+      std::vector<raii_convertible> values2;
+      values2.reserve(values.size());
+      for (auto const& v : values) {
+        values2.push_back(raii_convertible(v));
+      }
+
+      std::atomic<std::uint64_t> num_invokes{0};
+      thread_runner(
+        values2, [&x, &num_invokes](boost::span<raii_convertible> s) {
+          BOOST_TEST_EQ(x.insert_range_or_cvisit(s,
+                          [&num_invokes](typename X::value_type const& v) {
+                            (void)v;
+                            ++num_invokes;
+                          }),
+            s.size());
+        });
+
+      BOOST_TEST_EQ(num_invokes, values.size() - x.size());
+
+      BOOST_TEST_EQ(
+        raii::default_constructor, value_type_cardinality * values2.size());
+      BOOST_TEST_EQ(raii::copy_constructor, 0u);
+      BOOST_TEST_GT(raii::move_constructor, 0u);
+    }
+  } insert_range_or_cvisit;
+#endif
+
   struct iterator_range_insert_and_cvisit_type
   {
     template <class T, class X> void operator()(std::vector<T>& values, X& x)
@@ -885,6 +920,55 @@ namespace {
     }
   } iterator_range_insert_and_cvisit;
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+  struct insert_range_and_cvisit_type
+  {
+    template <class T, class X> void operator()(std::vector<T>& values, X& x)
+    {
+      static constexpr auto value_type_cardinality = 
+        value_cardinality<typename X::value_type>::value;
+
+      // concurrent_flat_set visit is always const access
+      using arg_type = typename std::conditional<
+        std::is_same<typename X::key_type, typename X::value_type>::value,
+        typename X::value_type const,
+        typename X::value_type
+      >::type;
+
+      std::vector<raii_convertible> values2;
+      values2.reserve(values.size());
+      for (auto const& v : values) {
+        values2.push_back(raii_convertible(v));
+      }
+
+      std::atomic<std::uint64_t> num_inserts{0};
+      std::atomic<std::uint64_t> num_invokes{0};
+      thread_runner(values2,
+        [&x, &num_inserts, &num_invokes](boost::span<raii_convertible> s) {
+          BOOST_TEST_EQ(x.insert_range_and_cvisit(
+                          s,
+                          [&num_inserts](arg_type& v) {
+                            (void)v;
+                            ++num_inserts;
+                          },
+                          [&num_invokes](typename X::value_type const& v) {
+                            (void)v;
+                            ++num_invokes;
+                          }),
+            s.size());
+        });
+
+      BOOST_TEST_EQ(num_inserts, x.size());
+      BOOST_TEST_EQ(num_invokes, values.size() - x.size());
+
+      BOOST_TEST_EQ(
+        raii::default_constructor, value_type_cardinality * values2.size());
+      BOOST_TEST_EQ(raii::copy_constructor, 0u);
+      BOOST_TEST_GT(raii::move_constructor, 0u);
+    }
+  } insert_range_and_cvisit;
+#endif
+
   struct iterator_range_insert_or_visit_type
   {
     template <class T, class X> void operator()(std::vector<T>& values, X& x)
@@ -931,6 +1015,48 @@ namespace {
       BOOST_TEST_GT(raii::move_constructor, 0u);
     }
   } iterator_range_insert_or_visit;
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+  struct insert_range_or_visit_type
+  {
+    template <class T, class X> void operator()(std::vector<T>& values, X& x)
+    {
+      static constexpr auto value_type_cardinality = 
+        value_cardinality<typename X::value_type>::value;
+
+      // concurrent_flat_set visit is always const access
+      using arg_type = typename std::conditional<
+        std::is_same<typename X::key_type, typename X::value_type>::value,
+        typename X::value_type const,
+        typename X::value_type
+      >::type;
+
+      std::vector<raii_convertible> values2;
+      values2.reserve(values.size());
+      for (auto const& v : values) {
+        values2.push_back(raii_convertible(v));
+      }
+
+      std::atomic<std::uint64_t> num_invokes{0};
+      thread_runner(
+        values2, [&x, &num_invokes](boost::span<raii_convertible> s) {
+          BOOST_TEST_EQ(x.insert_range_or_visit(s,
+                          [&num_invokes](arg_type& v) {
+                            (void)v;
+                            ++num_invokes;
+                          }),
+            s.size());
+        });
+
+      BOOST_TEST_EQ(num_invokes, values.size() - x.size());
+
+      BOOST_TEST_EQ(
+        raii::default_constructor, value_type_cardinality * values2.size());
+      BOOST_TEST_EQ(raii::copy_constructor, 0u);
+      BOOST_TEST_GT(raii::move_constructor, 0u);
+    }
+  } insert_range_or_visit;
+#endif
 
   struct iterator_range_insert_and_visit_type
   {
@@ -985,6 +1111,55 @@ namespace {
       BOOST_TEST_GT(raii::move_constructor, 0u);
     }
   } iterator_range_insert_and_visit;
+
+#if !defined(BOOT_UNORDERED_NO_RANGES)
+  struct insert_range_and_visit_type
+  {
+    template <class T, class X> void operator()(std::vector<T>& values, X& x)
+    {
+      static constexpr auto value_type_cardinality = 
+        value_cardinality<typename X::value_type>::value;
+
+      // concurrent_flat_set visit is always const access
+      using arg_type = typename std::conditional<
+        std::is_same<typename X::key_type, typename X::value_type>::value,
+        typename X::value_type const,
+        typename X::value_type
+      >::type;
+
+      std::vector<raii_convertible> values2;
+      values2.reserve(values.size());
+      for (auto const& v : values) {
+        values2.push_back(raii_convertible(v));
+      }
+
+      std::atomic<std::uint64_t> num_inserts{0};
+      std::atomic<std::uint64_t> num_invokes{0};
+      thread_runner(values2,
+        [&x, &num_inserts, &num_invokes](boost::span<raii_convertible> s) {
+          BOOST_TEST_EQ(x.insert_range_and_visit(
+                          s,
+                          [&num_inserts](arg_type& v) {
+                            (void)v;
+                            ++num_inserts;
+                          },
+                          [&num_invokes](typename X::value_type const& v) {
+                            (void)v;
+                            ++num_invokes;
+                          }),
+            s.size());
+        });
+
+      BOOST_TEST_EQ(num_inserts, x.size());
+      BOOST_TEST_EQ(num_invokes, values.size() - x.size());
+
+      BOOST_TEST_EQ(
+        raii::default_constructor, value_type_cardinality * values2.size());
+      BOOST_TEST_EQ(raii::copy_constructor, 0u);
+      BOOST_TEST_GT(raii::move_constructor, 0u);
+    }
+  } insert_range_and_visit;
+#endif
 
   struct non_copyable_function
   {
@@ -1300,8 +1475,16 @@ UNORDERED_TEST(
 
 #if !defined(BOOST_UNORDERED_NO_RANGES)
 #define RANGE_INSERTER (range_inserter)
+#define INSERT_RANGE_OR_CVISIT (insert_range_or_cvisit)
+#define INSERT_RANGE_OR_VISIT (insert_range_or_visit)
+#define INSERT_RANGE_AND_CVISIT (insert_range_and_cvisit)
+#define INSERT_RANGE_AND_VISIT (insert_range_and_visit)
 #else
 #define RANGE_INSERTER
+#define INSERT_RANGE_OR_CVISIT
+#define INSERT_RANGE_OR_VISIT
+#define INSERT_RANGE_AND_CVISIT
+#define INSERT_RANGE_AND_VISIT
 #endif
 
 UNORDERED_TEST(
@@ -1313,7 +1496,8 @@ UNORDERED_TEST(
    RANGE_INSERTER (norehash_lvalue_inserter)(norehash_rvalue_inserter)
    (lvalue_insert_or_cvisit)(lvalue_insert_or_visit)
    (rvalue_insert_or_cvisit)(rvalue_insert_or_visit)
-   (iterator_range_insert_or_cvisit)(iterator_range_insert_or_visit))
+   (iterator_range_insert_or_cvisit)(iterator_range_insert_or_visit)
+   INSERT_RANGE_OR_CVISIT INSERT_RANGE_OR_VISIT )
   ((default_generator)(sequential)(limited_range)))
 
 UNORDERED_TEST(
@@ -1323,7 +1507,8 @@ UNORDERED_TEST(
   ((value_type_generator_factory)(init_type_generator_factory))
   ((lvalue_insert_and_cvisit)(lvalue_insert_and_visit)
    (rvalue_insert_and_cvisit)(rvalue_insert_and_visit)
-   (iterator_range_insert_and_cvisit)(iterator_range_insert_and_visit))
+   (iterator_range_insert_and_cvisit)(iterator_range_insert_and_visit)
+   INSERT_RANGE_AND_CVISIT INSERT_RANGE_AND_VISIT )
   ((default_generator)(sequential)(limited_range)))
 
  UNORDERED_TEST(

--- a/test/cfoa/insert_tests.cpp
+++ b/test/cfoa/insert_tests.cpp
@@ -1112,7 +1112,7 @@ namespace {
     }
   } iterator_range_insert_and_visit;
 
-#if !defined(BOOT_UNORDERED_NO_RANGES)
+#if !defined(BOOST_UNORDERED_NO_RANGES)
   struct insert_range_and_visit_type
   {
     template <class T, class X> void operator()(std::vector<T>& values, X& x)

--- a/test/unordered/constructor_tests.cpp
+++ b/test/unordered/constructor_tests.cpp
@@ -1,6 +1,7 @@
 
 // Copyright 2006-2010 Daniel James.
 // Copyright (C) 2022-2023 Christian Mazakas
+// Copyright (C) 2026 Joaquin M Lopez Munoz
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
@@ -14,6 +15,7 @@
 #include "../helpers/tracker.hpp"
 #include "../objects/test.hpp"
 
+#include <list>
 #include <vector>
 
 namespace constructor_tests {
@@ -336,6 +338,211 @@ namespace constructor_tests {
     // deleted for some of the test types
     //
     std::vector<value_type> expected(vec.begin(), vec.begin() + 3);
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+    UNORDERED_SUB_TEST("Range construct 1")
+    {
+      test::check_instances check_;
+
+      {
+        T x(boost::unordered::from_range, list);
+        BOOST_TEST(x.empty());
+        BOOST_TEST(test::equivalent(x.hash_function(), hf));
+        BOOST_TEST(test::equivalent(x.key_eq(), eq));
+        BOOST_TEST(test::equivalent(x.get_allocator(), al));
+      }
+
+      {
+        T x(boost::unordered::from_range, std::vector{vec[0], vec[1], vec[2]});
+        BOOST_TEST_NOT(x.empty());
+        BOOST_TEST_GT(x.bucket_count(), 0u);
+        BOOST_TEST(test::equivalent(x.hash_function(), hf));
+        BOOST_TEST(test::equivalent(x.key_eq(), eq));
+        BOOST_TEST(test::equivalent(x.get_allocator(), al));
+        test::check_container(x, expected);
+      }
+    }
+
+    UNORDERED_SUB_TEST("Range construct 2")
+    {
+      test::check_instances check_;
+
+      {
+        T x(boost::unordered::from_range, list, 1000);
+        BOOST_TEST(x.empty());
+        BOOST_TEST(x.bucket_count() >= 1000);
+        BOOST_TEST(test::equivalent(x.hash_function(), hf));
+        BOOST_TEST(test::equivalent(x.key_eq(), eq));
+        BOOST_TEST(test::equivalent(x.get_allocator(), al));
+      }
+
+      {
+        T x(
+          boost::unordered::from_range, 
+          std::list{vec[0], vec[1], vec[2]} | std::views::take(3), 1000);
+        BOOST_TEST_NOT(x.empty());
+        BOOST_TEST(x.bucket_count() >= 1000);
+        BOOST_TEST(test::equivalent(x.hash_function(), hf));
+        BOOST_TEST(test::equivalent(x.key_eq(), eq));
+        BOOST_TEST(test::equivalent(x.get_allocator(), al));
+        test::check_container(x, expected);
+      }
+    }
+
+    UNORDERED_SUB_TEST("Range construct 3")
+    {
+      {
+        test::check_instances check_;
+
+        T x(boost::unordered::from_range, list, 10, hf1);
+        BOOST_TEST(x.empty());
+        BOOST_TEST(x.bucket_count() >= 10);
+        BOOST_TEST(test::equivalent(x.hash_function(), hf1));
+        BOOST_TEST(test::equivalent(x.key_eq(), eq));
+        BOOST_TEST(test::equivalent(x.get_allocator(), al));
+      }
+
+      {
+        test::check_instances check_;
+
+        T x(
+          boost::unordered::from_range, std::vector{vec[0], vec[1], vec[2]},
+          10, hf1);
+        BOOST_TEST_NOT(x.empty());
+        BOOST_TEST(x.bucket_count() >= 10);
+        BOOST_TEST(test::equivalent(x.hash_function(), hf1));
+        BOOST_TEST(test::equivalent(x.key_eq(), eq));
+        BOOST_TEST(test::equivalent(x.get_allocator(), al));
+        test::check_container(x, expected);
+      }
+    }
+
+    UNORDERED_SUB_TEST("Range construct 4")
+    {
+      {
+        test::check_instances check_;
+
+        T x(boost::unordered::from_range, list, 10, hf1, eq1);
+        BOOST_TEST(x.empty());
+        BOOST_TEST(x.bucket_count() >= 10);
+        BOOST_TEST(test::equivalent(x.hash_function(), hf1));
+        BOOST_TEST(test::equivalent(x.key_eq(), eq1));
+        BOOST_TEST(test::equivalent(x.get_allocator(), al));
+      }
+
+      {
+        test::check_instances check_;
+
+        T x(
+          boost::unordered::from_range, 
+          std::list{vec[0], vec[1], vec[2]} | std::views::take(3),
+          10, hf1, eq1);
+        BOOST_TEST_NOT(x.empty());
+        BOOST_TEST(x.bucket_count() >= 10);
+        BOOST_TEST(test::equivalent(x.hash_function(), hf1));
+        BOOST_TEST(test::equivalent(x.key_eq(), eq1));
+        BOOST_TEST(test::equivalent(x.get_allocator(), al));
+        test::check_container(x, expected);
+      }
+    }
+
+    UNORDERED_SUB_TEST("Range construct 5")
+    {
+      {
+        test::check_instances check_;
+
+        T x(boost::unordered::from_range, list, 10, hf1, eq1, al1);
+        BOOST_TEST(x.empty());
+        BOOST_TEST(x.bucket_count() >= 10);
+        BOOST_TEST(test::equivalent(x.hash_function(), hf1));
+        BOOST_TEST(test::equivalent(x.key_eq(), eq1));
+        BOOST_TEST(test::equivalent(x.get_allocator(), al1));
+      }
+
+      {
+        test::check_instances check_;
+
+        T x(
+          boost::unordered::from_range, 
+          std::vector{vec[0], vec[1], vec[2]}, 10, hf1, eq1, al1);
+        BOOST_TEST_NOT(x.empty());
+        BOOST_TEST(x.bucket_count() >= 10);
+        BOOST_TEST(test::equivalent(x.hash_function(), hf1));
+        BOOST_TEST(test::equivalent(x.key_eq(), eq1));
+        BOOST_TEST(test::equivalent(x.get_allocator(), al1));
+        test::check_container(x, expected);
+      }
+    }
+
+    UNORDERED_SUB_TEST("Range construct 6")
+    {
+      {
+        test::check_instances check_;
+
+        T x(boost::unordered::from_range, list, 10, al1);
+        BOOST_TEST(x.empty());
+        BOOST_TEST(x.bucket_count() >= 10);
+        BOOST_TEST(test::equivalent(x.get_allocator(), al1));
+      }
+
+      {
+        test::check_instances check_;
+
+        T x(
+          boost::unordered::from_range,
+          std::list{vec[0], vec[1], vec[2]} | std::views::take(3), 10, al1);
+        BOOST_TEST_NOT(x.empty());
+        BOOST_TEST(x.bucket_count() >= 10);
+        BOOST_TEST(test::equivalent(x.get_allocator(), al1));
+        test::check_container(x, expected);
+      }
+    }
+
+    UNORDERED_SUB_TEST("Range construct 7")
+    {
+      {
+        test::check_instances check_;
+
+        T x(boost::unordered::from_range, list, 10, hf1, al1);
+        BOOST_TEST(x.empty());
+        BOOST_TEST(x.bucket_count() >= 10);
+        BOOST_TEST(test::equivalent(x.hash_function(), hf1));
+        BOOST_TEST(test::equivalent(x.get_allocator(), al1));
+      }
+
+      {
+        test::check_instances check_;
+
+        T x(
+          boost::unordered::from_range, 
+          std::vector{vec[0], vec[1], vec[2]}, 10, hf1, al1);
+        BOOST_TEST_NOT(x.empty());
+        BOOST_TEST(x.bucket_count() >= 10);
+        BOOST_TEST(test::equivalent(x.hash_function(), hf1));
+        BOOST_TEST(test::equivalent(x.get_allocator(), al1));
+        test::check_container(x, expected);
+      }
+    }
+
+    UNORDERED_SUB_TEST("Range construct 8")
+    {
+      test::check_instances check_;
+
+      {
+        T x(boost::unordered::from_range, list, al1);
+        BOOST_TEST(x.empty());
+        BOOST_TEST(test::equivalent(x.get_allocator(), al1));
+      }
+
+      {
+        T x(
+          boost::unordered::from_range, 
+          std::list{vec[0], vec[1], vec[2]} | std::views::take(3), al1);
+        BOOST_TEST(test::equivalent(x.get_allocator(), al1));
+        test::check_container(x, expected);
+      }
+    }
+#endif
 
     UNORDERED_SUB_TEST("Initializer list construct 1")
     {

--- a/test/unordered/constructor_tests.cpp
+++ b/test/unordered/constructor_tests.cpp
@@ -340,6 +340,9 @@ namespace constructor_tests {
     std::vector<value_type> expected(vec.begin(), vec.begin() + 3);
 
 #if !defined(BOOST_UNORDERED_NO_RANGES)
+    auto std_list = std::list{vec[0], vec[1], vec[2]};
+    auto sentineled_rg = std_list | std::views::take(3);
+
     UNORDERED_SUB_TEST("Range construct 1")
     {
       test::check_instances check_;
@@ -377,9 +380,7 @@ namespace constructor_tests {
       }
 
       {
-        T x(
-          boost::unordered::from_range, 
-          std::list{vec[0], vec[1], vec[2]} | std::views::take(3), 1000);
+        T x(boost::unordered::from_range, sentineled_rg, 1000);
         BOOST_TEST_NOT(x.empty());
         BOOST_TEST(x.bucket_count() >= 1000);
         BOOST_TEST(test::equivalent(x.hash_function(), hf));
@@ -433,10 +434,7 @@ namespace constructor_tests {
       {
         test::check_instances check_;
 
-        T x(
-          boost::unordered::from_range, 
-          std::list{vec[0], vec[1], vec[2]} | std::views::take(3),
-          10, hf1, eq1);
+        T x(boost::unordered::from_range, sentineled_rg, 10, hf1, eq1);
         BOOST_TEST_NOT(x.empty());
         BOOST_TEST(x.bucket_count() >= 10);
         BOOST_TEST(test::equivalent(x.hash_function(), hf1));
@@ -488,9 +486,7 @@ namespace constructor_tests {
       {
         test::check_instances check_;
 
-        T x(
-          boost::unordered::from_range,
-          std::list{vec[0], vec[1], vec[2]} | std::views::take(3), 10, al1);
+        T x(boost::unordered::from_range, sentineled_rg, 10, al1);
         BOOST_TEST_NOT(x.empty());
         BOOST_TEST(x.bucket_count() >= 10);
         BOOST_TEST(test::equivalent(x.get_allocator(), al1));
@@ -535,9 +531,7 @@ namespace constructor_tests {
       }
 
       {
-        T x(
-          boost::unordered::from_range, 
-          std::list{vec[0], vec[1], vec[2]} | std::views::take(3), al1);
+        T x(boost::unordered::from_range, sentineled_rg, al1);
         BOOST_TEST(test::equivalent(x.get_allocator(), al1));
         test::check_container(x, expected);
       }

--- a/test/unordered/deduction_tests.cpp
+++ b/test/unordered/deduction_tests.cpp
@@ -494,7 +494,7 @@ template <template <class...> class UnorderedSet> void set_tests()
                      test_allocator<int> >);
   }
 
-#if !defined(BOOT_UNORDERED_NO_RANGES)
+#if !defined(BOOST_UNORDERED_NO_RANGES)
   /* 
    template<ranges::input_range R, class Allocator>
       unordered_set(from_range_t, R&&, 

--- a/test/unordered/deduction_tests.cpp
+++ b/test/unordered/deduction_tests.cpp
@@ -1,19 +1,26 @@
 
 // Copyright 2017-2018 Daniel James.
+// Copyright 2026 Joaquin M Lopez Munoz.
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/unordered_map.hpp>
+#include <iostream>
+
+#if BOOST_UNORDERED_TEMPLATE_DEDUCTION_GUIDES
 
 #include <boost/core/lightweight_test_trait.hpp>
 #include <boost/unordered_map.hpp>
 #include <boost/unordered_set.hpp>
-#include <iostream>
-#include <vector>
-
-#if BOOST_UNORDERED_TEMPLATE_DEDUCTION_GUIDES
-
 #include <boost/unordered/unordered_flat_map.hpp>
 #include <boost/unordered/unordered_flat_set.hpp>
+#include <boost/unordered/unordered_node_map.hpp>
+#include <boost/unordered/unordered_node_set.hpp>
 #include <boost/unordered/concurrent_flat_map.hpp>
+#include <boost/unordered/concurrent_flat_set.hpp>
+#include <boost/unordered/concurrent_node_map.hpp>
+#include <boost/unordered/concurrent_node_set.hpp>
+#include <vector>
 
 struct hash_equals
 {
@@ -86,6 +93,44 @@ template <template <class...> class UnorderedMap> void map_tests()
       decltype(m), UnorderedMap<int, int, std::hash<int>, std::equal_to<int>,
                      test_allocator<std::pair<const int, int> > >);
   }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+  /*
+   template<ranges::input_range R, class Hash = hash<range-key-type<R>>,
+            class Pred = equal_to<range-key-type<R>>,
+            class Allocator = allocator<range-to-alloc-type<R>>>
+     unordered_map(from_range_t, R&&, 
+                   typename see below::size_type = see below,
+                   Hash = Hash(), Pred = Pred(), Allocator = Allocator())
+       -> unordered_map<
+            range-key-type<R>, range-mapped-type<R>, Hash, Pred, Allocator>;
+   */
+
+  {
+    UnorderedMap m(boost::unordered::from_range, x);
+    BOOST_TEST_TRAIT_SAME(decltype(m), UnorderedMap<int, int>);
+  }
+
+  {
+    UnorderedMap m(boost::unordered::from_range, x, 0, std::hash<int>());
+    BOOST_TEST_TRAIT_SAME(decltype(m), UnorderedMap<int, int, std::hash<int> >);
+  }
+
+  {
+    UnorderedMap m(
+      boost::unordered::from_range, x, 0, std::hash<int>(), std::equal_to<int>());
+    BOOST_TEST_TRAIT_SAME(
+      decltype(m), UnorderedMap<int, int, std::hash<int>, std::equal_to<int> >);
+  }
+
+  {
+    UnorderedMap m(boost::unordered::from_range, x, 0, std::hash<int>(),
+      std::equal_to<int>(), pair_allocator);
+    BOOST_TEST_TRAIT_SAME(
+      decltype(m), UnorderedMap<int, int, std::hash<int>, std::equal_to<int>,
+                     test_allocator<std::pair<const int, int> > >);
+  }
+#endif
 
   /*
   template<class Key, class T, class Hash = hash<Key>,
@@ -162,6 +207,24 @@ template <template <class...> class UnorderedMap> void map_tests()
                      test_allocator<std::pair<const int, int> > >);
   }
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+  /*
+   template<ranges::input_range R, class Allocator>
+      unordered_map(
+        from_range_t, R&&, typename see below::size_type, Allocator)
+        -> unordered_map<
+             range-key-type<R>, range-mapped-type<R>, hash<range-key-type<R>>,
+             equal_to<range-key-type<R>>, Allocator>;
+   */
+
+  {
+    UnorderedMap m(boost::unordered::from_range, x, 0u, pair_allocator);
+    BOOST_TEST_TRAIT_SAME(
+      decltype(m), UnorderedMap<int, int, boost::hash<int>, std::equal_to<int>,
+                     test_allocator<std::pair<const int, int> > >);
+  }
+#endif
+
   /*
     template<class InputIterator, class Allocator>
     unordered_map(InputIterator, InputIterator, Allocator)
@@ -178,6 +241,23 @@ template <template <class...> class UnorderedMap> void map_tests()
                      test_allocator<std::pair<const int, int> > >);
   }
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+  /*
+   template<ranges::input_range R, class Allocator>
+     unordered_map(from_range_t, R&&, Allocator)
+       -> unordered_map<
+            range-key-type<R>, range-mapped-type<R>, hash<range-key-type<R>>,
+            equal_to<range-key-type<R>>, Allocator>;
+  */
+
+  {
+    UnorderedMap m(boost::unordered::from_range, x, pair_allocator);
+    BOOST_TEST_TRAIT_SAME(
+      decltype(m), UnorderedMap<int, int, boost::hash<int>, std::equal_to<int>,
+                     test_allocator<std::pair<const int, int> > >);
+  }
+#endif
+
   /*
   template<class InputIterator, class Hash, class Allocator>
     unordered_map(InputIterator, InputIterator, typename see below::size_type,
@@ -193,6 +273,23 @@ template <template <class...> class UnorderedMap> void map_tests()
       decltype(m), UnorderedMap<int, int, hash_equals, std::equal_to<int>,
                      test_allocator<std::pair<const int, int> > >);
   }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+  /*
+   template<ranges::input_range R, class Hash, class Allocator>
+     unordered_map(
+       from_range_t, R&&, typename see below::size_type, Hash, Allocator)
+       -> unordered_map<range-key-type<R>, range-mapped-type<R>, Hash,
+                        equal_to<range-key-type<R>>, Allocator>;
+  */
+
+  {
+    UnorderedMap m(boost::unordered::from_range, x, 0u, f, pair_allocator);
+    BOOST_TEST_TRAIT_SAME(
+      decltype(m), UnorderedMap<int, int, hash_equals, std::equal_to<int>,
+                     test_allocator<std::pair<const int, int> > >);
+  }
+#endif
 
   /*
     template<class Key, class T, typename Allocator>
@@ -305,6 +402,45 @@ template <template <class...> class UnorderedSet> void set_tests()
                      test_allocator<int> >);
   }
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+  /*   
+   template<ranges::input_range R,
+            class Hash = hash<ranges::range_value_t<R>>,
+            class Pred = equal_to<ranges::range_value_t<R>>,
+            class Allocator = allocator<ranges::range_value_t<R>>>
+     unordered_set(from_range_t, R&&, 
+                   typename see below::size_type = see below,
+                   Hash = Hash(), Pred = Pred(), Allocator = Allocator())
+       -> unordered_set<ranges::range_value_t<R>, Hash, Pred, Allocator>;   
+   */
+
+  {
+    UnorderedSet s(boost::unordered::from_range, y);
+    BOOST_TEST_TRAIT_SAME(decltype(s), UnorderedSet<int>);
+  }
+
+  {
+    UnorderedSet s(boost::unordered::from_range, y, 0, std::hash<int>());
+    BOOST_TEST_TRAIT_SAME(decltype(s), UnorderedSet<int, std::hash<int> >);
+  }
+
+  {
+    UnorderedSet s(
+      boost::unordered::from_range, y, 0, std::hash<int>(),
+      std::equal_to<int>());
+    BOOST_TEST_TRAIT_SAME(
+      decltype(s), UnorderedSet<int, std::hash<int>, std::equal_to<int> >);
+  }
+
+  {
+    UnorderedSet s(boost::unordered::from_range, y, 0, std::hash<int>(),
+      std::equal_to<int>(), int_allocator);
+    BOOST_TEST_TRAIT_SAME(
+      decltype(s), UnorderedSet<int, std::hash<int>, std::equal_to<int>,
+                     test_allocator<int> >);
+  }
+#endif
+
   /* template<class T,
            class Hash = std::hash<T>,
            class Pred = std::equal_to<T>,
@@ -358,6 +494,24 @@ template <template <class...> class UnorderedSet> void set_tests()
                      test_allocator<int> >);
   }
 
+#if !defined(BOOT_UNORDERED_NO_RANGES)
+  /* 
+   template<ranges::input_range R, class Allocator>
+      unordered_set(from_range_t, R&&, 
+                    typename see below::size_type, Allocator)
+        -> unordered_set<ranges::range_value_t<R>, 
+                         hash<ranges::range_value_t<R>>,
+                         equal_to<ranges::range_value_t<R>>, Allocator>;
+   */
+
+  {
+    UnorderedSet s(boost::unordered::from_range, y, 0u, int_allocator);
+    BOOST_TEST_TRAIT_SAME(
+      decltype(s), UnorderedSet<int, boost::hash<int>, std::equal_to<int>,
+                     test_allocator<int> >);
+  }
+#endif
+
   /* template<class InputIt, class Hash, class Alloc>
   unordered_set(InputIt, InputIt, typename see below::size_type, Hash, Alloc)
     -> unordered_set<typename std::iterator_traits<InputIt>::value_type, Hash,
@@ -369,6 +523,22 @@ template <template <class...> class UnorderedSet> void set_tests()
     BOOST_TEST_TRAIT_SAME(decltype(s),
       UnorderedSet<int, hash_equals, std::equal_to<int>, test_allocator<int> >);
   }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+  /* 
+   template<ranges::input_range R, class Hash, class Allocator>
+     unordered_set(from_range_t, R&&, typename see below::size_type,
+                   Hash, Allocator)
+       -> unordered_set<ranges::range_value_t<R>, Hash,
+                        equal_to<ranges::range_value_t<R>>, Allocator>;  
+   */
+
+  {
+    UnorderedSet s(boost::unordered::from_range, y, 0u, f, int_allocator);
+    BOOST_TEST_TRAIT_SAME(decltype(s),
+      UnorderedSet<int, hash_equals, std::equal_to<int>, test_allocator<int> >);
+  }
+#endif
 
   /*   template<class T, class Allocator>
   unordered_set(std::initializer_list<T>, typename see below::size_type,
@@ -408,6 +578,23 @@ template <template <class...> class UnorderedSet> void set_tests()
                      test_allocator<int> >);
   }
 
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+  /*
+   template<ranges::input_range R, class Allocator>
+     unordered_set(from_range_t, R&&, Allocator)
+       -> unordered_set<ranges::range_value_t<R>, 
+                        hash<ranges::range_value_t<R>>,
+                        equal_to<ranges::range_value_t<R>>, Allocator>;
+   */
+
+  {
+    UnorderedSet s(boost::unordered::from_range, y, int_allocator);
+    BOOST_TEST_TRAIT_SAME(
+      decltype(s), UnorderedSet<int, boost::hash<int>, std::equal_to<int>,
+                     test_allocator<int> >);
+  }
+#endif
+
   /*
   template<class T, class Allocator>
     unordered_set(initializer_list<T>, Allocator)
@@ -433,10 +620,15 @@ int main()
   map_tests<boost::unordered_map>();
   map_tests<boost::unordered_multimap>();
   map_tests<boost::unordered_flat_map>();
+  map_tests<boost::unordered_node_map>();
   map_tests<boost::concurrent_flat_map>();
+  map_tests<boost::concurrent_node_map>();
   set_tests<boost::unordered_set>();
   set_tests<boost::unordered_multiset>();
   set_tests<boost::unordered_flat_set>();
+  set_tests<boost::unordered_node_set>();
+  set_tests<boost::concurrent_flat_set>();
+  set_tests<boost::concurrent_node_set>();
 
   return boost::report_errors();
 #endif

--- a/test/unordered/insert_tests.cpp
+++ b/test/unordered/insert_tests.cpp
@@ -1,6 +1,7 @@
 
 // Copyright 2006-2010 Daniel James.
 // Copyright (C) 2022-2023 Christian Mazakas
+// Copyright (C) 2026 Joaquin M Lopez Munoz
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
@@ -405,6 +406,27 @@ namespace insert_tests {
         test::check_equivalent_keys(x);
       }
     }
+
+#if !defined(BOOST_UNORDERED_NO_RANGES)
+    UNORDERED_SUB_TEST("insert_range tests")
+    {
+      test::check_instances check_;
+
+      X x;
+
+      test::random_values<X> v(1000, generator);
+      x.insert_range(v);
+
+      test::check_container(x, v);
+      test::check_equivalent_keys(x);
+
+      x.clear();
+      x.insert_range(v | std::views::take(v.size()));
+
+      test::check_container(x, v);
+      test::check_equivalent_keys(x);
+    }
+#endif
   }
 
   template <class X>


### PR DESCRIPTION
Added interoperability with C++20 ranges to all the containers in the library: `insert_range` (plus `insert_range_(or|and)_[c]visit` for concurrent containers), `std::from_range` construction and associated CTAD deduction guides. The `boost::unordered::from_range` construction tag is provided as an alternative to C++23 `std::from_range` or when this is not available.

Closes #347.